### PR TITLE
fix(pty): make tmux set-option target parse so remote terminal mouse scroll works (CHOO-1403)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/pty/tmux-session-name.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/pty/tmux-session-name.test.ts
@@ -16,9 +16,12 @@ describe('buildTmuxShellLine', () => {
     expect(result).toContain(
       'tmux -u new-session -d -s \\"agent-session\\" \\"exec /bin/zsh -il\\"'
     );
-    expect(result).toContain('tmux set-option -t \\"=agent-session\\" mouse on');
-    expect(result).toContain('tmux set-option -t \\"=agent-session\\" history-limit 100000');
-    expect(result).toContain('tmux set-option -t \\"=agent-session\\" window-size latest');
+    // set-option needs the trailing colon: it rejects a bare `=name` target
+    // ("no such session"), silently disabling mouse scroll on tmux terminals
+    // (CHOO-1403). `=name:` keeps the exact match and is accepted.
+    expect(result).toContain('tmux set-option -t \\"=agent-session:\\" mouse on');
+    expect(result).toContain('tmux set-option -t \\"=agent-session:\\" history-limit 100000');
+    expect(result).toContain('tmux set-option -t \\"=agent-session:\\" window-size latest');
     expect(result).toContain('tmux -u attach-session -t \\"=agent-session\\"');
     expect(result.indexOf('mouse on')).toBeLessThan(result.indexOf('attach-session'));
     expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));

--- a/dash/apps/switchdash-desktop/src/main/core/pty/tmux-session-name.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/pty/tmux-session-name.ts
@@ -22,6 +22,10 @@ export function buildTmuxShellLine(
 ): string {
   const quotedName = JSON.stringify(sessionName);
   const quotedTarget = JSON.stringify(exactTmuxTarget(sessionName));
+  // set-option/show-options reject a bare `=name` target ("no such session"),
+  // unlike has-session/attach-session. A trailing colon makes them parse it as
+  // a session target while keeping the `=` exact-match guarantee.
+  const quotedOptionTarget = JSON.stringify(`${exactTmuxTarget(sessionName)}:`);
   const quotedCmd = JSON.stringify(commandLine);
   // Set the agent's env on the tmux session itself with `-e`. A new pane inherits
   // the tmux SERVER's environment, NOT that of the shell invoking `new-session`,
@@ -40,14 +44,14 @@ export function buildTmuxShellLine(
   // non-UTF-8 locale and mangles multibyte glyphs like Nerd-font/box-drawing characters.
   const checkExists = `tmux has-session -t ${quotedTarget} 2>/dev/null`;
   const newSession = `tmux -u new-session ${newSessionFlags} -s ${quotedName} ${quotedCmd}`;
-  const enableMouse = `tmux set-option -t ${quotedTarget} mouse on 2>/dev/null || true`;
-  const setHistoryLimit = `tmux set-option -t ${quotedTarget} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
+  const enableMouse = `tmux set-option -t ${quotedOptionTarget} mouse on 2>/dev/null || true`;
+  const setHistoryLimit = `tmux set-option -t ${quotedOptionTarget} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
   // With multiple clients (different laptops) attached to the same session, tmux
   // otherwise clamps the shared window to the SMALLEST client, cramping the active
   // user whenever an idle viewer with a smaller terminal is attached. `latest`
   // sizes the window to the most-recently-active client instead, so a passive
   // viewer no longer constrains whoever is actually driving the session.
-  const setWindowSize = `tmux set-option -t ${quotedTarget} window-size latest 2>/dev/null || true`;
+  const setWindowSize = `tmux set-option -t ${quotedOptionTarget} window-size latest 2>/dev/null || true`;
   const configure = `(${enableMouse}) && (${setHistoryLimit}) && (${setWindowSize})`;
   const attach = `tmux -u attach-session -t ${quotedTarget}`;
   const script = `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;


### PR DESCRIPTION
## Summary

In a switchdash terminal attached to a remote host, mouse wheel scroll-up was delivered to the shell as an arrow-up keypress (walking command history) instead of scrolling the terminal UI. Local terminals scrolled fine.

Jira: [CHOO-1403](https://sandboxquantum.atlassian.net/browse/CHOO-1403)

## Root cause

Two layers:

1. Remote terminals always run under `tmux attach` (`workspace-factory.ts` hard-codes tmux for SSH sessions), which puts xterm.js on the alternate-screen buffer. xterm.js 6.0's built-in "alternate scroll" converts wheel ticks into arrow-key sequences whenever the alt buffer is active and no mouse-reporting protocol is enabled. Local terminals run a bare shell on the normal buffer, so xterm's own scrollback handles the wheel.
2. Mouse reporting was supposed to be on: `buildTmuxShellLine` runs `tmux set-option -t "=<session>" mouse on` before attaching. But `set-option` (unlike `has-session`/`attach-session`/`kill-session`) rejects the bare `=name` exact-match target with `no such session` — reproduced on tmux 3.6a — and the `2>/dev/null || true` swallowed the failure. So tmux mouse mode never turned on, tmux never enabled mouse reporting toward xterm, and xterm fell back to wheel→arrow keys. All three `set-option` calls in that script (`mouse on`, `history-limit 100000`, `window-size latest`) were silently failing.

## Fix

Target the three `set-option` calls at `=<session>:` — with a trailing colon, `set-option` parses the target as a session while keeping the `=` exact-match guarantee (it still refuses to prefix-match a `<session>-sidecar` sibling, verified). On attach tmux now emits the mouse-enable sequences (DECSET 1000/1002/1006), so xterm forwards wheel events to tmux and tmux scrolls its scrollback (copy-mode) instead of feeding arrows to the shell.

Verified empirically with tmux 3.6a under a local PTY harness: before the fix, attach emits only mouse-mode *resets*; after, it emits enables, and the option lands on the exact session only.

## Notes

- This also un-breaks `window-size latest` (multi-client sizing) and `history-limit` for the same reason.
- Known limitation: tmux applies `history-limit` only to panes created after the option is set, so the session's initial pane keeps tmux's default 2000-line history (copy-mode scroll depth). Fixing that would require setting the option globally before session creation, which side-effects the user's shared tmux server on the remote host — left as a possible follow-up.

## Testing

- Updated `tmux-session-name.test.ts` assertions to pin the `=name:` set-option target.
- `pnpm run format:check`, `lint`, `typecheck`, and the full `pnpm run test` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1403]: https://sandboxquantum.atlassian.net/browse/CHOO-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ