### PR TITLE
fix(switch-setup): re-point stale marketplace source and surface failed refresh (CHOO-1405)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/switch-setup/remote-switch-setup.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-setup/remote-switch-setup.ts
@@ -5,7 +5,12 @@ import { ensureSshConnected } from '@main/core/ssh/connect/connect-agent-ssh';
 import { agentSshConnectionId } from '@main/core/workspaces/resolve-agent-workspace';
 import { log } from '@main/lib/logger';
 import { getPlugin, listPlugins } from '../providers/plugin-registry';
-import type { SwitchSetupResult, SwitchSetupStatus } from './switch-setup-service';
+import type {
+  MarketplaceListEntry,
+  SwitchSetupResult,
+  SwitchSetupStatus,
+} from './switch-setup-service';
+import { marketplaceMatchesSource } from './switch-setup-service';
 
 const EXEC_TIMEOUT_MS = 120_000;
 
@@ -19,6 +24,7 @@ function unsupported(agentId: string): SwitchSetupStatus {
     installedVersion: null,
     latestVersion: null,
     updateAvailable: false,
+    refreshError: null,
   };
 }
 
@@ -126,6 +132,12 @@ export class RemoteSwitchSetupService {
     return market?.plugins?.find((p) => p.name === pluginName)?.version ?? null;
   }
 
+  /**
+   * Ensure the marketplace is registered AND points at the expected source.
+   * A same-named marketplace registered against a different source (e.g. a
+   * pre-migration repo) is removed and re-added so update checks read the
+   * current source rather than a stale one.
+   */
   private async ensureMarketplace(
     bin: string,
     marketplaceName: string,
@@ -133,11 +145,22 @@ export class RemoteSwitchSetupService {
   ): Promise<void> {
     const { stdout } = await this.run(bin, ['plugin', 'marketplace', 'list', '--json']);
     const parsed = parseJsonLoose(stdout);
-    if (
-      Array.isArray(parsed) &&
-      (parsed as Array<{ name?: string }>).some((m) => m.name === marketplaceName)
-    ) {
-      return;
+    const existing = Array.isArray(parsed)
+      ? (parsed as MarketplaceListEntry[]).find((m) => m.name === marketplaceName)
+      : undefined;
+    if (existing) {
+      if (marketplaceMatchesSource(existing, marketplaceSource)) return;
+      log.warn('remote-switch-setup: re-pointing marketplace to current source', {
+        marketplaceName,
+        from: existing.repo ?? existing.path ?? null,
+        to: marketplaceSource,
+      });
+      const removed = await this.run(bin, ['plugin', 'marketplace', 'remove', marketplaceName]);
+      if (removed.code !== 0) {
+        throw new Error(
+          removed.stderr.trim() || `Failed to remove stale marketplace ${marketplaceName}`
+        );
+      }
     }
     const res = await this.run(bin, ['plugin', 'marketplace', 'add', marketplaceSource]);
     if (res.code !== 0 && !/already|exists/i.test(res.stderr)) {
@@ -170,20 +193,38 @@ export class RemoteSwitchSetupService {
       installedVersion,
       latestVersion,
       updateAvailable,
+      refreshError: null,
     };
   }
 
+  /**
+   * Refresh the marketplace catalog, then recompute status (the network step).
+   * A failed refresh does not throw — the returned status carries the cached
+   * versions with `refreshError` set so the UI can disclose the staleness.
+   */
   async checkForUpdates(agentId: string): Promise<SwitchSetupStatus> {
     const resolved = await this.resolve(agentId);
     if (!resolved) return unsupported(agentId);
     const { descriptor, bin } = resolved;
+    let refreshError: string | null = null;
     try {
       await this.ensureMarketplace(bin, descriptor.marketplaceName, descriptor.marketplaceSource);
-      await this.run(bin, ['plugin', 'marketplace', 'update', descriptor.marketplaceName]);
+      const res = await this.run(bin, [
+        'plugin',
+        'marketplace',
+        'update',
+        descriptor.marketplaceName,
+      ]);
+      if (res.code !== 0) {
+        throw new Error(
+          res.stderr.trim() || `Failed to update marketplace ${descriptor.marketplaceName}`
+        );
+      }
     } catch (err) {
       log.warn('remote-switch-setup: marketplace refresh failed', { agentId, err });
+      refreshError = err instanceof Error ? err.message : String(err);
     }
-    return this.getStatus(agentId);
+    return { ...(await this.getStatus(agentId)), refreshError };
   }
 
   async install(agentId: string): Promise<SwitchSetupResult> {

--- a/dash/apps/switchdash-desktop/src/main/core/switch-setup/switch-setup-service.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-setup/switch-setup-service.test.ts
@@ -79,7 +79,12 @@ function execImpl(installedVersion: string | null) {
     if (a === 'plugin marketplace list --json') {
       return Promise.resolve({
         stdout: JSON.stringify([
-          { name: 'switch-plugins', source: 'github', installLocation: MARKET_LOCATION },
+          {
+            name: 'switch-plugins',
+            source: 'github',
+            repo: 'sandbox-quantum/switch',
+            installLocation: MARKET_LOCATION,
+          },
         ]),
         stderr: '',
       });
@@ -182,6 +187,90 @@ describe('switchSetupService.listOnboardable', () => {
   });
 });
 
+describe('switchSetupService.checkForUpdates', () => {
+  function calls(): string[] {
+    return mocks.exec.mock.calls.map((c) => (c[1] as string[]).join(' '));
+  }
+
+  it('leaves a marketplace already pointing at the expected source alone', async () => {
+    mocks.exec.mockImplementation(execImpl('0.1.0'));
+    mocks.readFile.mockImplementation(readFileImpl('0.1.0', '0.1.0'));
+
+    const status = await switchSetupService.checkForUpdates('claude');
+
+    expect(status.refreshError).toBeNull();
+    expect(calls()).not.toContain('plugin marketplace remove switch-plugins');
+    expect(calls()).toContain('plugin marketplace update switch-plugins');
+  });
+
+  it('re-points a same-named marketplace registered against a different source', async () => {
+    const base = execImpl('0.1.0');
+    mocks.exec.mockImplementation((bin: string, args: string[] = []) => {
+      if (args.join(' ') === 'plugin marketplace list --json') {
+        return Promise.resolve({
+          stdout: JSON.stringify([
+            {
+              name: 'switch-plugins',
+              source: 'github',
+              repo: 'sandbox-quantum/napoleon',
+              installLocation: MARKET_LOCATION,
+            },
+          ]),
+          stderr: '',
+        });
+      }
+      return base(bin, args);
+    });
+    mocks.readFile.mockImplementation(readFileImpl('0.1.0', '0.1.9'));
+
+    const status = await switchSetupService.checkForUpdates('claude');
+
+    expect(calls()).toContain('plugin marketplace remove switch-plugins');
+    expect(calls()).toContain('plugin marketplace add sandbox-quantum/switch');
+    expect(status.refreshError).toBeNull();
+    expect(status.updateAvailable).toBe(true);
+  });
+
+  it('surfaces refreshError with cached status when the marketplace update fails', async () => {
+    const base = execImpl('0.1.0');
+    mocks.exec.mockImplementation((bin: string, args: string[] = []) => {
+      if (args.join(' ') === 'plugin marketplace update switch-plugins') {
+        return Promise.reject(
+          Object.assign(new Error('boom'), { code: 1, stderr: 'repository not found' })
+        );
+      }
+      return base(bin, args);
+    });
+    mocks.readFile.mockImplementation(readFileImpl('0.1.0', '0.1.0'));
+
+    const status = await switchSetupService.checkForUpdates('claude');
+
+    expect(status.refreshError).toBe('repository not found');
+    expect(status.installedVersion).toBe('0.1.0');
+    expect(status.updateAvailable).toBe(false);
+  });
+
+  it('surfaces refreshError when re-adding the marketplace fails', async () => {
+    mocks.exec.mockImplementation((_bin: string, args: string[] = []) => {
+      const a = args.join(' ');
+      if (a === 'plugin list --json') {
+        return Promise.resolve({ stdout: JSON.stringify([]), stderr: '' });
+      }
+      if (a === 'plugin marketplace list --json') {
+        return Promise.resolve({ stdout: JSON.stringify([]), stderr: '' });
+      }
+      return Promise.reject(
+        Object.assign(new Error('boom'), { code: 1, stderr: 'could not resolve source' })
+      );
+    });
+    mocks.readFile.mockImplementation(() => Promise.reject(new Error('ENOENT')));
+
+    const status = await switchSetupService.checkForUpdates('claude');
+
+    expect(status.refreshError).toBe('could not resolve source');
+  });
+});
+
 describe('switchSetupService mutations', () => {
   it('install issues the scoped install command (marketplace already present)', async () => {
     mocks.exec.mockImplementation(execImpl(null));
@@ -213,7 +302,14 @@ describe('switchSetupService mutations', () => {
     mocks.exec.mockImplementation((_bin: string, args: string[] = []) => {
       if (args.join(' ') === 'plugin marketplace list --json') {
         return Promise.resolve({
-          stdout: JSON.stringify([{ name: 'switch-plugins', installLocation: MARKET_LOCATION }]),
+          stdout: JSON.stringify([
+            {
+              name: 'switch-plugins',
+              source: 'github',
+              repo: 'sandbox-quantum/switch',
+              installLocation: MARKET_LOCATION,
+            },
+          ]),
           stderr: '',
         });
       }

--- a/dash/apps/switchdash-desktop/src/main/core/switch-setup/switch-setup-service.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-setup/switch-setup-service.ts
@@ -15,7 +15,27 @@ export type SwitchSetupStatus = {
   installedVersion: string | null;
   latestVersion: string | null;
   updateAvailable: boolean;
+  /**
+   * Set when a checkForUpdates marketplace refresh failed: the returned
+   * versions come from the stale local cache, not the source. Always null on
+   * plain getStatus reads.
+   */
+  refreshError: string | null;
 };
+
+/** Marketplace entry shape from `plugin marketplace list --json`. */
+export type MarketplaceListEntry = {
+  name?: string;
+  source?: string;
+  repo?: string;
+  path?: string;
+  installLocation?: string;
+};
+
+/** Whether a registered marketplace entry points at the expected source (repo or path). */
+export function marketplaceMatchesSource(entry: MarketplaceListEntry, source: string): boolean {
+  return entry.repo === source || entry.path === source;
+}
 
 /** Outcome of a mutating operation, mirroring the providers controller shape. */
 export type SwitchSetupResult = { success: boolean; message?: string };
@@ -32,6 +52,7 @@ function unsupported(agentId: string): SwitchSetupStatus {
     installedVersion: null,
     latestVersion: null,
     updateAvailable: false,
+    refreshError: null,
   };
 }
 
@@ -139,7 +160,12 @@ class SwitchSetupService {
     return pluginManifest?.version ?? null;
   }
 
-  /** Ensure the marketplace is registered; treat an already-added marketplace as success. */
+  /**
+   * Ensure the marketplace is registered AND points at the expected source.
+   * A same-named marketplace registered against a different source (e.g. a
+   * pre-migration repo) is removed and re-added so update checks read the
+   * current source rather than a stale one.
+   */
   private async ensureMarketplace(
     bin: string,
     marketplaceName: string,
@@ -147,10 +173,28 @@ class SwitchSetupService {
   ): Promise<void> {
     const { stdout } = await this.run(bin, ['plugin', 'marketplace', 'list', '--json']);
     try {
-      const markets: Array<{ name?: string }> = JSON.parse(stdout);
-      if (markets.some((m) => m.name === marketplaceName)) return;
-    } catch {
-      // fall through and attempt to add
+      const markets: MarketplaceListEntry[] = JSON.parse(stdout);
+      const existing = markets.find((m) => m.name === marketplaceName);
+      if (existing) {
+        if (marketplaceMatchesSource(existing, marketplaceSource)) return;
+        log.warn('switch-setup: re-pointing marketplace to current source', {
+          marketplaceName,
+          from: existing.repo ?? existing.path ?? null,
+          to: marketplaceSource,
+        });
+        const removed = await this.run(bin, ['plugin', 'marketplace', 'remove', marketplaceName]);
+        if (removed.code !== 0) {
+          throw new Error(
+            removed.stderr.trim() || `Failed to remove stale marketplace ${marketplaceName}`
+          );
+        }
+      }
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        // Unparseable list output — fall through and attempt to add.
+      } else {
+        throw err;
+      }
     }
     const res = await this.run(bin, ['plugin', 'marketplace', 'add', marketplaceSource]);
     if (res.code !== 0 && !/already|exists/i.test(res.stderr)) {
@@ -184,6 +228,7 @@ class SwitchSetupService {
       installedVersion,
       latestVersion,
       updateAvailable,
+      refreshError: null,
     };
   }
 
@@ -202,18 +247,34 @@ class SwitchSetupService {
     return onboardable;
   }
 
-  /** Refresh the marketplace catalog, then recompute status (the network step). */
+  /**
+   * Refresh the marketplace catalog, then recompute status (the network step).
+   * A failed refresh does not throw — the returned status carries the cached
+   * versions with `refreshError` set so the UI can disclose the staleness.
+   */
   async checkForUpdates(agentId: string): Promise<SwitchSetupStatus> {
     const resolved = await this.resolve(agentId);
     if (!resolved) return unsupported(agentId);
     const { descriptor, bin } = resolved;
+    let refreshError: string | null = null;
     try {
       await this.ensureMarketplace(bin, descriptor.marketplaceName, descriptor.marketplaceSource);
-      await this.run(bin, ['plugin', 'marketplace', 'update', descriptor.marketplaceName]);
+      const res = await this.run(bin, [
+        'plugin',
+        'marketplace',
+        'update',
+        descriptor.marketplaceName,
+      ]);
+      if (res.code !== 0) {
+        throw new Error(
+          res.stderr.trim() || `Failed to update marketplace ${descriptor.marketplaceName}`
+        );
+      }
     } catch (err) {
       log.warn('switch-setup: marketplace refresh failed', { agentId, err });
+      refreshError = err instanceof Error ? err.message : String(err);
     }
-    return this.getStatus(agentId);
+    return { ...(await this.getStatus(agentId)), refreshError };
   }
 
   async install(agentId: string): Promise<SwitchSetupResult> {

--- a/dash/apps/switchdash-desktop/src/renderer/features/remote-hosts/remote-host-detail.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/remote-hosts/remote-host-detail.tsx
@@ -464,8 +464,30 @@ function AgentTypeRow({
     onSettled: invalidateAll,
   });
 
+  const checkUpdates = useMutation({
+    mutationFn: () => rpc.remoteHosts.checkAgentPluginUpdates({ sshHost, agentId: dep.id }),
+    onSuccess: (status) => {
+      setActionError(
+        status.refreshError
+          ? `Could not refresh the plugin marketplace — showing cached status. ${status.refreshError}`
+          : null
+      );
+      queryClient.setQueryData(pluginsQueryKey(sshHost), (prev: AgentPluginStatus[] | undefined) =>
+        prev?.map((p) => (p.agentId === status.agentId ? status : p))
+      );
+    },
+    onError: (error) => {
+      log.error('Remote plugin update check failed', { sshHost, id: dep.id, error });
+      setActionError(error instanceof Error ? error.message : 'Update check failed.');
+    },
+  });
+
   const cliInstalled = dep.status === 'available';
-  const pending = installCli.isPending || installPlugin.isPending || updatePlugin.isPending;
+  const pending =
+    installCli.isPending ||
+    installPlugin.isPending ||
+    updatePlugin.isPending ||
+    checkUpdates.isPending;
 
   // Green only when the agent type is fully usable: CLI present AND (the Switch
   // plugin is installed, or this agent type has no plugin). CLI-without-plugin is
@@ -528,6 +550,16 @@ function AgentTypeRow({
         {cliInstalled && plugin?.supported && !plugin.installed && (
           <Button size="sm" disabled={pending} onClick={() => installPlugin.mutate()}>
             {installPlugin.isPending ? 'Installing…' : 'Install plugin'}
+          </Button>
+        )}
+        {cliInstalled && plugin?.installed && !plugin.updateAvailable && (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pending}
+            onClick={() => checkUpdates.mutate()}
+          >
+            {checkUpdates.isPending ? 'Checking…' : 'Check for updates'}
           </Button>
         )}
         {cliInstalled && plugin?.installed && plugin.updateAvailable && (

--- a/dash/apps/switchdash-desktop/src/renderer/features/settings/agents-page/SwitchSetupCard.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/settings/agents-page/SwitchSetupCard.tsx
@@ -96,6 +96,11 @@ export function SwitchSetupCard({ agentId }: { agentId: string }) {
             )}
           </div>
         </div>
+        {status.refreshError && (
+          <p className="text-destructive text-xs">
+            Couldn't refresh the plugin marketplace — showing cached status. {status.refreshError}
+          </p>
+        )}
         <p className="text-xs text-foreground-muted">
           Connects this agent to a Switch instance. Credentials are managed when you add the agent
           to a Switch server.

--- a/dash/apps/switchdash-desktop/src/renderer/lib/stores/use-switch-setup.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/stores/use-switch-setup.ts
@@ -43,7 +43,13 @@ export function useSwitchSetup(agentId: string) {
     mutationFn: () => rpc.switchSetup.checkForUpdates(agentId),
     onSuccess: (status) => {
       qc.setQueryData(queryKey, status);
-      if (status.supported && status.installed && !status.updateAvailable) {
+      if (status.refreshError) {
+        toast({
+          title: 'Could not refresh the plugin marketplace — showing cached status',
+          description: status.refreshError,
+          variant: 'destructive',
+        });
+      } else if (status.supported && status.installed && !status.updateAvailable) {
         toast({ title: 'Switch connector is up to date' });
       }
     },


### PR DESCRIPTION
Fixes [CHOO-1405](https://sandboxquantum.atlassian.net/browse/CHOO-1405): switchdash's switch-connector "Check for updates" falsely reported up-to-date (installed 0.1.13 shown current while the marketplace source ships 0.1.14).

Two compounding faults, fixed in both `switch-setup-service.ts` and its remote twin `remote-switch-setup.ts`:

1. **Stale marketplace source never re-pointed.** `ensureMarketplace` treated any already-registered `switch-plugins` marketplace as success. It now compares the registered entry's source (`repo` / `path` from `plugin marketplace list --json`) against the expected `marketplaceSource` and, on mismatch, runs `plugin marketplace remove` + `add` to re-point it. This applies to both `checkForUpdates` and `install` (local and remote/SSH hosts alike).

2. **Silent refresh failure degraded to "up to date".** `checkForUpdates` swallowed marketplace add/update failures with a `log.warn` and returned status off the stale cache; a non-zero exit from `marketplace update` wasn't even checked. `SwitchSetupStatus` now carries `refreshError: string | null`; on a failed refresh the cached status is returned with it set, and the UI shows a destructive toast ("Could not refresh the plugin marketplace — showing cached status") plus a warning line on the SwitchSetupCard instead of a false "up to date".

Out of scope (as agreed): the underlying repo-reachability blocker (CHOO-1251/1253, CHOO-1400).

**Testing:** new unit tests cover re-point-on-mismatch, no-op on matching source, and refreshError on failed update/add; full desktop suite (1216 tests), lint, and typecheck pass. The pre-existing `packages/plugins` hook-config test failure is unrelated (fails on the clean branch too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1405]: https://sandboxquantum.atlassian.net/browse/CHOO-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Addendum (review feedback):** the remote-host card had no way to trigger an update check at all — `remoteHosts.checkAgentPluginUpdates` existed but was never called from the UI, and the card's Refresh only re-reads cached status. Each agent-type row now gets a **Check for updates** button (when the plugin is installed and no update is flagged) that refreshes the marketplace on the host, updates the row in place, and surfaces `refreshError` on the row.