### PR TITLE
feat(switchdash): label sidebar agents by registered Switch name (CHOO-1082)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
@@ -28,6 +28,7 @@ import { createRPCController } from '@shared/lib/ipc/rpc';
 import { type LoginError, oidcLogin, passwordLogin } from './auth';
 import {
   agentExistsOnServer,
+  fetchAgentDetail,
   fetchAgentRooms,
   fetchAgents,
   fetchAuthConfig,
@@ -152,6 +153,12 @@ export const switchServersController = createRPCController({
 
   listRemoteAgents: async (serverId: string): Promise<RemoteAgentSummary[]> =>
     fetchAgents(await requireServer(serverId)),
+
+  getRemoteAgent: async (params: {
+    serverId: string;
+    agentId: string;
+  }): Promise<RemoteAgentSummary> =>
+    fetchAgentDetail(await requireServer(params.serverId), params.agentId),
 
   listRemoteRooms: async (serverId: string): Promise<RemoteRoomSummary[]> =>
     fetchRooms(await requireServer(serverId)),

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/gateway-client.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/gateway-client.ts
@@ -178,6 +178,39 @@ export async function fetchAgents(server: SwitchServer): Promise<RemoteAgentSumm
 }
 
 /**
+ * Fetch one agent's registered detail by id (`GET /agents/{id}`, which returns
+ * the gateway `AgentDetail` — a superset of `AgentSummary`). Used to resolve an
+ * agent's registered Switch name for display. A 404 surfaces as a `GatewayError`
+ * so callers can distinguish "not on this server" from other failures.
+ */
+export async function fetchAgentDetail(
+  server: SwitchServer,
+  agentId: string
+): Promise<RemoteAgentSummary> {
+  const res = await gatewayFetch(server, `/agents/${encodeURIComponent(agentId)}`, {
+    authenticated: true,
+  });
+  const json = (await res.json()) as {
+    id: string;
+    name: string;
+    description: string;
+    connector_type: string;
+    owner_name: string | null;
+    known_agent_type: string | null;
+    created_at: string;
+  };
+  return {
+    id: json.id,
+    name: json.name,
+    description: json.description,
+    connectorType: json.connector_type,
+    ownerName: json.owner_name,
+    knownAgentType: json.known_agent_type,
+    createdAt: json.created_at,
+  };
+}
+
+/**
  * Whether `agentId` is a registered agent on `server`. Used to verify the user's
  * chosen server actually owns the agent before linking it. A 404 from the
  * gateway means "not this server" (returned as false); an unauthorized error

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/location-item.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/location-item.tsx
@@ -75,6 +75,20 @@ export const SidebarLocationItem = observer(function SidebarLocationItem({
     enabled: !!locationId,
   });
 
+  // The row is labelled by the agent's registered Switch name (its identity on
+  // the server), not the local directory-derived location name. Resolve it by
+  // id from the gateway, keyed on (server, switch agent id) so it caches and is
+  // shared across rows for the same agent.
+  const remoteAgentQuery = useQuery({
+    queryKey: ['remoteAgentName', agentQuery.data?.serverId, agentQuery.data?.switchAgentId],
+    queryFn: async () =>
+      rpc.switchServers.getRemoteAgent({
+        serverId: agentQuery.data!.serverId!,
+        agentId: agentQuery.data!.switchAgentId!,
+      }),
+    enabled: !!agentQuery.data?.serverId && !!agentQuery.data?.switchAgentId,
+  });
+
   const location = getLocationStore(locationId);
 
   const currentLocationId =
@@ -97,7 +111,13 @@ export const SidebarLocationItem = observer(function SidebarLocationItem({
 
   const iconClass =
     'absolute h-4 w-4 opacity-100 transition-opacity duration-150 group-hover/row:opacity-0';
-  const locationLabel = location.name ?? 'agent';
+  // Registered Switch name wins. While the lookup is still in flight, keep the
+  // local name so the row does not flash; once it settles without a name
+  // (server unlinked, agent unregistered, or offline) show a stable placeholder.
+  const switchName = remoteAgentQuery.data?.name?.trim() || null;
+  const locationLabel =
+    switchName ??
+    (remoteAgentQuery.isLoading ? (location.name ?? 'Unnamed agent') : 'Unnamed agent');
   const toggleExpanded = () => sidebarStore.toggleLocationExpanded(locationId);
 
   // Clicking the row opens the agent's page (Sessions / Subagents / Settings),
@@ -185,7 +205,7 @@ export const SidebarLocationItem = observer(function SidebarLocationItem({
               )}
             >
               <span className="flex min-w-0 items-center gap-1.5">
-                <span className="truncate">{location.name}</span>
+                <span className="truncate">{locationLabel}</span>
                 {location.data?.sshHost != null && (
                   <Tooltip>
                     <TooltipTrigger>
@@ -262,7 +282,7 @@ export const SidebarLocationItem = observer(function SidebarLocationItem({
           onClick={() => {
             void confirmDeleteAgent({
               locationId,
-              locationLabel: location.name ?? 'this agent',
+              locationLabel: switchName ?? location.name ?? 'this agent',
               onDeleted: () => {
                 if (isLocationActive) navigate('home');
               },


### PR DESCRIPTION
## What & why

CHOO-1082: switchdash's left sidebar labelled each agent row with the local, **directory-derived** location name (`claude-code.<repo>.<user>`, set once at onboarding and never re-synced). That can drift from the agent's **registered Switch identity**, making agents ambiguous.

This changes the row to display the agent's **registered Switch name**, resolved by id from the gateway.

## How

- **gateway-client** (`fetchAgentDetail`): GET `/agents/{id}` — the gateway already returns `AgentDetail` (a superset of `AgentSummary`, includes `name`); `agentExistsOnServer` / `fetchAgentChildren` already hit this endpoint, so **no gateway change was needed**.
- **switch-servers controller** (`getRemoteAgent` RPC): thin wrapper over `fetchAgentDetail`.
- **`location-item.tsx`**: each row already fetches its local agent (giving `switchAgentId` + `serverId`); added a react-query keyed on `(serverId, switchAgentId)` — cached/shared across rows — that resolves the registered name and renders it (row label, aria-labels, and the delete-confirm label).

### Fallback
When the registered name can't be resolved — server unlinked, `switchAgentId` null (unregistered), offline, or empty — the row shows **"Unnamed agent"**. The local name is kept only during the brief initial lookup so the row doesn't flash.

## Model note
Built on the post-CHOO-1424 / CHOO-1426 model where each sidebar row is a `Location` = one agent (`getAgents(locationId)[0]`), consistent with how the row already derives its icon and gateway URL.

## Testing
- `pnpm format`, app `lint`, app `typecheck` clean.
- Full desktop-app suite green (1186 tests).
- Pre-existing, unrelated: `packages/plugins` letta `newSessionFlag` typecheck error fails the repo-wide `typecheck` — present on main, not introduced here.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)