### PR TITLE
fix(collab): tear down the bridge's own client on bridge removal (CHOO-1489)

### DIFF
--- a/core/switch_core/bridges/collaboration/lifecycle_service.py
+++ b/core/switch_core/bridges/collaboration/lifecycle_service.py
@@ -247,6 +247,7 @@ class CollaborationBridgeLifecycleService:
     async def remove(self, bridge_id: str) -> None:
         await self.stop(bridge_id)
         async with self._session_factory() as session:
+            bridge = await self._bridge_store.get(session, bridge_id)
             dependent_rooms = await self._room_store.get_by_bridge(session, bridge_id)
             if dependent_rooms:
                 logger.warning(
@@ -260,6 +261,11 @@ class CollaborationBridgeLifecycleService:
                     await self._room_store.clear_bridge(session, room.id)
             await self._external_user_store.delete_by_bridge(session, bridge_id)
             await self._bridge_store.delete(session, bridge_id)
+            if bridge is not None:
+                await self._room_store.remove_client_from_all_rooms(
+                    session, bridge.client_id
+                )
+                await self._client_store.delete(session, bridge.client_id)
             await session.commit()
         logger.info("Removed collaboration bridge %s", bridge_id)
 

--- a/core/switch_core/db/stores/room_store.py
+++ b/core/switch_core/db/stores/room_store.py
@@ -266,6 +266,14 @@ class RoomStore:
         )
         await session.flush()
 
+    async def remove_client_from_all_rooms(
+        self, session: AsyncSession, client_id: str
+    ) -> None:
+        await session.execute(
+            delete(ClientRoom).where(ClientRoom.client_id == client_id)
+        )
+        await session.flush()
+
     async def get_client_ids(self, session: AsyncSession, room_id: str) -> list[str]:
         result = await session.execute(
             select(ClientRoom.client_id).where(ClientRoom.room_id == room_id)

--- a/core/tests/switch_core/bridges/collaboration/test_lifecycle_remove.py
+++ b/core/tests/switch_core/bridges/collaboration/test_lifecycle_remove.py
@@ -10,6 +10,7 @@ from switch_core.bridges.collaboration.lifecycle_service import (
     CollaborationBridgeLifecycleService,
 )
 from switch_core.db.models import Client, CollaborationBridge, ExternalUser, Room
+from switch_core.db.stores.client_store import ClientStore
 from switch_core.db.stores.collaboration_bridge_store import CollaborationBridgeStore
 from switch_core.db.stores.external_user_store import ExternalUserStore
 from switch_core.db.stores.room_store import RoomStore
@@ -25,7 +26,7 @@ def _service(
         bridge_message_map_store=MagicMock(),
         room_store=RoomStore(),
         agent_store=MagicMock(),
-        client_store=MagicMock(),
+        client_store=ClientStore(),
         client_lifecycle=MagicMock(),
         room_service=MagicMock(),
         matrix_admin=MagicMock(),
@@ -46,7 +47,8 @@ async def _make_client(session: AsyncSession, *, client_type: str) -> str:
     return client.id
 
 
-async def _make_bridge(session: AsyncSession) -> str:
+async def _make_bridge(session: AsyncSession) -> tuple[str, str]:
+    """Returns (bridge_id, bridge_client_id)."""
     client_id = await _make_client(session, client_type="bridge")
     bridge = CollaborationBridge(
         type="mattermost",
@@ -56,7 +58,7 @@ async def _make_bridge(session: AsyncSession) -> str:
     )
     session.add(bridge)
     await session.flush()
-    return bridge.id
+    return bridge.id, client_id
 
 
 async def _make_bridged_room(session: AsyncSession, *, bridge_id: str) -> str:
@@ -92,14 +94,14 @@ async def test_remove_detaches_dependent_rooms(
 ) -> None:
     """Removing a bridge that still has dependent rooms must not FK-violate.
 
-    Regression for the DELETE /collab/bridges 500: rooms.bridge_id references
-    collaboration_bridges.id with no ON DELETE rule, so deleting the bridge
-    while rooms point at it raised a raw FK error. remove() now detaches the
-    rooms (non-destructive) before deleting the bridge.
+    Regression for the DELETE /collab/bridges 500 (CHOO-1484): rooms.bridge_id
+    references collaboration_bridges.id with no ON DELETE rule, so deleting the
+    bridge while rooms point at it raised a raw FK error. remove() now detaches
+    the rooms (non-destructive) before deleting the bridge.
     """
     service = _service(session_factory)
     async with session_factory() as session:
-        bridge_id = await _make_bridge(session)
+        bridge_id, _ = await _make_bridge(session)
         room_id = await _make_bridged_room(session, bridge_id=bridge_id)
         external_user_id = await _make_external_user(session, bridge_id=bridge_id)
         await session.commit()
@@ -121,15 +123,47 @@ async def test_remove_detaches_dependent_rooms(
 
 
 @pytest.mark.asyncio
-async def test_remove_without_dependent_rooms_still_deletes(
+async def test_remove_deletes_bridge_own_client(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
+    """The bridge's own Client (and its room memberships) is torn down on remove.
+
+    Regression for CHOO-1489: register() mints a dedicated bridge Client, but
+    remove() left it (and its client_rooms rows) orphaned in the DB after every
+    onboard->remove cycle. remove() now clears the bridge client's memberships
+    and deletes the Client row alongside the bridge.
+    """
     service = _service(session_factory)
     async with session_factory() as session:
-        bridge_id = await _make_bridge(session)
+        bridge_id, bridge_client_id = await _make_bridge(session)
+        room_id = await _make_bridged_room(session, bridge_id=bridge_id)
+        # The bridge client is a member of the room it bridges.
+        await RoomStore().add_client(session, bridge_client_id, room_id)
         await session.commit()
 
     await service.remove(bridge_id)
 
     async with session_factory() as session:
         assert await CollaborationBridgeStore().get(session, bridge_id) is None
+        # The bridge's own Client row is gone (no orphan).
+        assert await ClientStore().get(session, bridge_client_id) is None
+        # Its room membership is gone; the room itself survives (detached).
+        member_ids = await RoomStore().get_client_ids(session, room_id)
+        assert bridge_client_id not in member_ids
+        assert await RoomStore().get(session, room_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_remove_without_dependent_rooms_still_deletes(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = _service(session_factory)
+    async with session_factory() as session:
+        bridge_id, bridge_client_id = await _make_bridge(session)
+        await session.commit()
+
+    await service.remove(bridge_id)
+
+    async with session_factory() as session:
+        assert await CollaborationBridgeStore().get(session, bridge_id) is None
+        assert await ClientStore().get(session, bridge_client_id) is None


### PR DESCRIPTION
## Problem

`CollaborationBridgeLifecycleService.register()` mints a dedicated Matrix bridge `Client` (`collaboration_bridges.client_id → clients.id`), but `remove()` deleted the bridge row, `external_users`, and detached dependent rooms **without ever deleting that Client**. Every onboard→remove cycle left an orphaned `clients` row plus its `client_rooms` memberships (`client_rooms.client_id → clients.id`, no cascade) behind — accumulating over time. Surfaced as the follow-up to CHOO-1484 (had to be purged manually during CHOO-1365 teardown).

## Fix

After deleting the bridge row, `remove()` now:
1. clears the bridge client's room memberships — new `RoomStore.remove_client_from_all_rooms(client_id)`, mirroring the existing `agent_store` teardown pattern; then
2. deletes the `Client` row — in the **same transaction**.

Order matters: the bridge row (which references `client_id`) is deleted first, so removing the client no longer FK-violates. Deleting the memberships first prevents the same `client_rooms` FK violation the CHOO-1484 fix addressed for rooms.

## Scope / notes

- `matrix_admin` exposes **no user-deactivation endpoint** (Tuwunel), so the Matrix account itself isn't deregistered — this fix removes the **Switch-side DB orphans**, which is what actually accumulated.
- **External-user puppet clients** (`external_users.client_id`) are a separate, related leak — `delete_by_bridge` drops the `external_users` rows but not their puppet `clients`. Left out of scope here; worth its own ticket if we want fully leak-free teardown.

## Tests

Extended `test_lifecycle_remove.py`:
- **new** `test_remove_deletes_bridge_own_client` — bridge client (with a `client_rooms` membership in the bridged room) is gone after `remove()`, its membership is cleared, and the room survives detached;
- no-dependent-rooms case now also asserts the client is deleted;
- existing detach-rooms regression retained.

Collaboration suite: **230 passed**. `ruff check` / `ruff format` / `mypy` clean.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-1489 (Backend epic CHOO-465). Branches off `main` which already has CHOO-1484 — no dependency/rebase needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)