### PR TITLE
fix(collab): delete external-user puppet clients on bridge removal (CHOO-1492)

### DIFF
--- a/core/switch_core/bridges/collaboration/lifecycle_service.py
+++ b/core/switch_core/bridges/collaboration/lifecycle_service.py
@@ -259,6 +259,15 @@ class CollaborationBridgeLifecycleService:
                 )
                 for room in dependent_rooms:
                     await self._room_store.clear_bridge(session, room.id)
+            # Each external-user puppet has its own Client; capture those ids
+            # before deleting the external_users rows that reference them, so
+            # the puppet Clients can be torn down too rather than orphaned.
+            puppet_client_ids = [
+                user.client_id
+                for user in await self._external_user_store.get_by_bridge(
+                    session, bridge_id
+                )
+            ]
             await self._external_user_store.delete_by_bridge(session, bridge_id)
             await self._bridge_store.delete(session, bridge_id)
             if bridge is not None:
@@ -266,6 +275,15 @@ class CollaborationBridgeLifecycleService:
                     session, bridge.client_id
                 )
                 await self._client_store.delete(session, bridge.client_id)
+            for client_id in puppet_client_ids:
+                await self._room_store.remove_client_from_all_rooms(session, client_id)
+                await self._client_store.delete(session, client_id)
+            if puppet_client_ids:
+                logger.info(
+                    "Removed %d external-user puppet client(s) for bridge %s",
+                    len(puppet_client_ids),
+                    bridge_id,
+                )
             await session.commit()
         logger.info("Removed collaboration bridge %s", bridge_id)
 

--- a/core/tests/switch_core/bridges/collaboration/test_lifecycle_remove.py
+++ b/core/tests/switch_core/bridges/collaboration/test_lifecycle_remove.py
@@ -167,3 +167,38 @@ async def test_remove_without_dependent_rooms_still_deletes(
     async with session_factory() as session:
         assert await CollaborationBridgeStore().get(session, bridge_id) is None
         assert await ClientStore().get(session, bridge_client_id) is None
+
+
+@pytest.mark.asyncio
+async def test_remove_deletes_external_user_puppet_clients(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """External-user puppet Clients are torn down on remove (CHOO-1492).
+
+    Regression: remove() deleted the external_users rows but left each puppet's
+    own Client (external_users.client_id -> clients.id) — and its client_rooms
+    memberships — orphaned in the DB after every onboard->remove cycle. remove()
+    now clears each puppet client's memberships and deletes the Client row too.
+    """
+    service = _service(session_factory)
+    async with session_factory() as session:
+        bridge_id, _ = await _make_bridge(session)
+        room_id = await _make_bridged_room(session, bridge_id=bridge_id)
+        external_user_id = await _make_external_user(session, bridge_id=bridge_id)
+        puppet = await ExternalUserStore().get(session, external_user_id)
+        assert puppet is not None
+        puppet_client_id = puppet.client_id
+        # The puppet client is a member of the room it speaks in.
+        await RoomStore().add_client(session, puppet_client_id, room_id)
+        await session.commit()
+
+    await service.remove(bridge_id)
+
+    async with session_factory() as session:
+        assert await CollaborationBridgeStore().get(session, bridge_id) is None
+        # The puppet's own Client row is gone (no orphan).
+        assert await ClientStore().get(session, puppet_client_id) is None
+        # Its room membership is gone; the room itself survives (detached).
+        member_ids = await RoomStore().get_client_ids(session, room_id)
+        assert puppet_client_id not in member_ids
+        assert await RoomStore().get(session, room_id) is not None


### PR DESCRIPTION
## Problem

`remove()` deleted the `external_users` rows on bridge removal but left each external-user **puppet's own Client** (`external_users.client_id` → `clients.id`) — and its `client_rooms` memberships — orphaned in the DB after every onboard→remove cycle. This is a sibling leak to the bridge's own Client (CHOO-1489), on the same `remove()` path. Surfaced during CHOO-1365 Discord teardown.

## Fix

`remove()` now captures each puppet's `client_id` **before** deleting the `external_users` rows (which hold the FK to `clients`), then — mirroring the bridge-client teardown from CHOO-1489 — clears each puppet client's room memberships (`remove_client_from_all_rooms`) and deletes the Client row, logging the count.

**Detach-then-delete**, same shape as the bridge client: ordering matters because `external_users.client_id` → `clients.id` (RESTRICT), so external_users must go first.

## Tests

Extends `test_lifecycle_remove.py`: a puppet with its own Client + a room membership → after `remove()`, asserts the puppet's Client row and its membership are gone while the room survives (detached). Collaboration suite: **231 passed**; ruff + mypy clean.

## Stacking / merge order

Stacked on **#37 (CHOO-1489)** — it adds the `remove_client_from_all_rooms` helper this fix reuses and edits the same `remove()` method. PR base is `fix/remove-bridge-orphan-client` so the diff shows only this change; GitHub auto-retargets it to `main` when #37 merges. **Merge #37 first.**

Jira: CHOO-1492 — https://sandboxquantum.atlassian.net/browse/CHOO-1492 (Backend epic CHOO-465, sibling to CHOO-1489).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
