### PR TITLE
fix(collab): route bridge deletion through non-atomic-safe remove() (CHOO-1487)

### DIFF
--- a/core/switch_core/gateway/collaborations.py
+++ b/core/switch_core/gateway/collaborations.py
@@ -19,7 +19,6 @@ from switch_core.gateway.dependencies import (
     get_bridge_store,
     get_collab_lifecycle,
     get_external_user_store,
-    get_room_service,
     get_room_store,
     get_session,
 )
@@ -30,7 +29,6 @@ from switch_core.gateway.schemas import (
     BridgeUpdateRequest,
     ExternalUserSummary,
 )
-from switch_core.room_service import RoomService
 
 logger = logging.getLogger(__name__)
 
@@ -171,8 +169,6 @@ async def delete_bridge(
     bridge_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     bridge_store: Annotated[CollaborationBridgeStore, Depends(get_bridge_store)],
-    room_store: Annotated[RoomStore, Depends(get_room_store)],
-    room_service: Annotated[RoomService, Depends(get_room_service)],
     collab_lifecycle: Annotated[
         CollaborationBridgeLifecycleService, Depends(get_collab_lifecycle)
     ],
@@ -181,10 +177,6 @@ async def delete_bridge(
     bridge = await bridge_store.get(session, bridge_id)
     if bridge is None:
         raise HTTPException(status_code=404, detail="Bridge not found")
-
-    rooms = await room_store.get_by_bridge(session, bridge_id)
-    for room in rooms:
-        await room_service.delete_room(room.id)
 
     await collab_lifecycle.remove(bridge_id)
     return {"ok": True}

--- a/core/tests/switch_core/gateway/test_collaborations_delete.py
+++ b/core/tests/switch_core/gateway/test_collaborations_delete.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.bridges.collaboration.lifecycle_service import (
+    CollaborationBridgeLifecycleService,
+)
+from switch_core.db.models import Client, CollaborationBridge, ExternalUser, Room
+from switch_core.db.stores.collaboration_bridge_store import CollaborationBridgeStore
+from switch_core.db.stores.external_user_store import ExternalUserStore
+from switch_core.db.stores.room_store import RoomStore
+from switch_core.gateway.collaborations import delete_bridge
+
+
+def _lifecycle(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> CollaborationBridgeLifecycleService:
+    """Real service with real stores; mock the deps remove() never touches."""
+    return CollaborationBridgeLifecycleService(
+        bridge_store=CollaborationBridgeStore(),
+        external_user_store=ExternalUserStore(),
+        bridge_message_map_store=MagicMock(),
+        room_store=RoomStore(),
+        agent_store=MagicMock(),
+        client_store=MagicMock(),
+        client_lifecycle=MagicMock(),
+        room_service=MagicMock(),
+        matrix_admin=MagicMock(),
+        session_factory=session_factory,
+        config=MagicMock(),
+    )
+
+
+async def _make_client(session: AsyncSession, *, client_type: str) -> str:
+    client = Client(
+        matrix_user_id=f"@{client_type}-{uuid.uuid4().hex[:8]}:test",
+        display_name=f"{client_type} client",
+        type=client_type,
+        password="x",
+    )
+    session.add(client)
+    await session.flush()
+    return client.id
+
+
+async def _make_bridge(session: AsyncSession) -> str:
+    client_id = await _make_client(session, client_type="bridge")
+    bridge = CollaborationBridge(
+        type="mattermost",
+        display_name="MM",
+        client_id=client_id,
+        status="active",
+    )
+    session.add(bridge)
+    await session.flush()
+    return bridge.id
+
+
+async def _make_bridged_room(session: AsyncSession, *, bridge_id: str) -> str:
+    room = Room(
+        matrix_room_id=f"!{uuid.uuid4().hex[:8]}:test",
+        name="bridged room",
+        description="mirror of an external channel",
+        bridge_id=bridge_id,
+        channel_type="channel_public",
+        external_channel_id="C123",
+    )
+    session.add(room)
+    await session.flush()
+    return room.id
+
+
+async def _make_external_user(session: AsyncSession, *, bridge_id: str) -> str:
+    client_id = await _make_client(session, client_type="external_user")
+    user = ExternalUser(
+        bridge_id=bridge_id,
+        external_user_id=f"U{uuid.uuid4().hex[:8]}",
+        external_username="alice",
+        client_id=client_id,
+    )
+    session.add(user)
+    await session.flush()
+    return user.id
+
+
+@pytest.mark.asyncio
+async def test_delete_bridge_detaches_dependent_rooms(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The DELETE /collab/bridges endpoint must be non-destructive and atomic.
+
+    Regression for CHOO-1487: the endpoint used to destructively delete every
+    dependent room one-by-one (each in its own committed transaction, also
+    destroying the Matrix room) before removing the bridge. A failure partway
+    left a partial delete + 500. It now routes removal entirely through
+    remove(), which detaches dependent rooms atomically — so bridged rooms
+    survive as internal-only rooms.
+    """
+    async with session_factory() as session:
+        bridge_id = await _make_bridge(session)
+        room_id = await _make_bridged_room(session, bridge_id=bridge_id)
+        external_user_id = await _make_external_user(session, bridge_id=bridge_id)
+        await session.commit()
+
+    async with session_factory() as session:
+        result = await delete_bridge(
+            bridge_id=bridge_id,
+            session=session,
+            bridge_store=CollaborationBridgeStore(),
+            collab_lifecycle=_lifecycle(session_factory),
+            _user=MagicMock(),
+        )
+
+    assert result == {"ok": True}
+
+    async with session_factory() as session:
+        assert await CollaborationBridgeStore().get(session, bridge_id) is None
+
+        # Room survives, just detached from the (now-gone) bridge.
+        room = await RoomStore().get(session, room_id)
+        assert room is not None
+        assert room.bridge_id is None
+        assert room.channel_type is None
+        assert room.external_channel_id is None
+
+        # External users for the bridge are cleaned up.
+        assert await ExternalUserStore().get(session, external_user_id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_bridge_missing_is_not_found(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        with pytest.raises(HTTPException) as exc:
+            await delete_bridge(
+                bridge_id="does-not-exist",
+                session=session,
+                bridge_store=CollaborationBridgeStore(),
+                collab_lifecycle=_lifecycle(session_factory),
+                _user=MagicMock(),
+            )
+
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary

`DELETE /collab/bridges/{id}` still 500'd with a partial room-count drop (reporter saw 8 → 4) even after CHOO-1484 fixed `remove()` to detach dependent rooms. This fixes the **actual** cause, which lives in the gateway endpoint, not `remove()`.

## Root cause

The gateway `delete_bridge` endpoint never benefited from CHOO-1484. Before calling `remove()`, it looped over dependent rooms:

```python
rooms = await room_store.get_by_bridge(session, bridge_id)
for room in rooms:
    await room_service.delete_room(room.id)   # destructive; own session + own commit; deletes Matrix room too
await collab_lifecycle.remove(bridge_id)
```

Two problems:
- **Non-atomic** — `room_service.delete_room` opens its *own* session and commits *per room* (and irreversibly deletes the Matrix room). A failure partway leaves the already-processed rooms permanently deleted + committed, the loop aborts, and the exception surfaces as a **500** — the observed **8 → 4 partial drop**.
- **Contradicts CHOO-1484's design** — CHOO-1484 deliberately made removal *non-destructive* (rooms preserved as internal-only). This loop deleted them instead, so CHOO-1484's detach code was effectively **dead for the gateway path** (`get_by_bridge` inside `remove()` returned nothing).

Deploy gap ruled out: the endpoint is byte-identical at `switch-v0.6.0` and on `main` — unchanged since the initial import — so a redeploy would not have fixed it.

## Fix

`delete_bridge` now routes removal entirely through `collab_lifecycle.remove()`, which detaches dependent rooms atomically in a single transaction. Result: non-destructive (bridged rooms survive as internal-only rooms), atomic, idempotent. 404-on-missing preserved. Drops the now-unused `room_service` / `RoomService` / `get_room_service` import and parameter.

## Test

New `gateway/test_collaborations_delete.py` exercises the endpoint through the **real** lifecycle service: deleting a bridge with a dependent room + external user returns 200, the room survives *detached* (`bridge_id` / `channel_type` / `external_channel_id` → NULL), and the bridge + external users are gone. Plus a 404 case.

`just check` ✅ · `just typecheck` ✅ · new + existing lifecycle tests pass (4/4).

Jira: [CHOO-1487](https://sandboxquantum.atlassian.net/browse/CHOO-1487) (Backend epic CHOO-465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1487]: https://sandboxquantum.atlassian.net/browse/CHOO-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ