### PR TITLE
feat(switchdash): make it obvious when a server needs re-auth (CHOO-1406)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
@@ -47,6 +47,7 @@ import {
   deleteSessionCookie,
   getActiveServerId,
   getServer,
+  getSessionCookie,
   listServers,
   removeServer,
   setActiveServerId,
@@ -175,10 +176,13 @@ export const switchServersController = createRPCController({
     const server = await requireServer(serverId);
     try {
       const user = await fetchMe(server);
-      return { serverId, connected: true, user };
+      return { serverId, connected: true, user, reason: null };
     } catch (cause) {
       if (cause instanceof GatewayError && cause.kind === 'unauthorized') {
-        return { serverId, connected: false, user: null };
+        // A stored-but-rejected session means the user was signed in and needs
+        // to re-auth (`expired`); no stored session is a plain `signed-out`.
+        const reason = (await getSessionCookie(serverId)) ? 'expired' : 'signed-out';
+        return { serverId, connected: false, user: null, reason };
       }
       throw cause;
     }

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/gateway-client.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/gateway-client.test.ts
@@ -3,11 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const getSessionCookie = vi.hoisted(() => vi.fn());
 const refreshSession = vi.hoisted(() => vi.fn());
 const reauthenticateManagedServer = vi.hoisted(() => vi.fn());
+const emit = vi.hoisted(() => vi.fn());
 
 vi.mock('./servers-store', () => ({ getSessionCookie }));
 vi.mock('./auth', () => ({ refreshSession, reauthenticateManagedServer }));
+vi.mock('@main/lib/events', () => ({ events: { emit, on: vi.fn() } }));
 
 const { fetchMe } = await import('./gateway-client');
+const { switchServerConnectionStatusChannel } =
+  await import('@shared/events/switchServerConnectionEvents');
 
 const SERVER = {
   id: 'srv-1',
@@ -194,5 +198,50 @@ describe('gatewayFetch managed-server silent re-auth', () => {
     await expect(fetchMe(SERVER)).rejects.toMatchObject({ kind: 'unauthorized' });
     expect(reauthenticateManagedServer).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('gatewayFetch pushes expired status on a rejected session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockImplementation(async () => okMeResponse());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('emits an expired connection status when an authenticated call 401s', async () => {
+    const stored = makeJwt(24 * 60 * 60);
+    getSessionCookie.mockResolvedValue(stored);
+    fetchMock.mockResolvedValue(unauthorizedResponse());
+
+    await expect(fetchMe(SERVER)).rejects.toMatchObject({ kind: 'unauthorized' });
+    expect(emit).toHaveBeenCalledExactlyOnceWith(switchServerConnectionStatusChannel, {
+      serverId: 'srv-1',
+      connected: false,
+      user: null,
+      reason: 'expired',
+    });
+  });
+
+  it('does not emit when there is no stored session to reject', async () => {
+    getSessionCookie.mockResolvedValue(null);
+
+    await expect(fetchMe(SERVER)).rejects.toMatchObject({ kind: 'unauthorized' });
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('does not emit when the managed server silently re-auths past a 401', async () => {
+    const stored = makeJwt(24 * 60 * 60);
+    const reissued = makeJwt(24 * 60 * 60);
+    getSessionCookie.mockResolvedValue(stored);
+    reauthenticateManagedServer.mockResolvedValue(reissued);
+    fetchMock.mockResolvedValueOnce(unauthorizedResponse());
+
+    await fetchMe(MANAGED);
+
+    expect(emit).not.toHaveBeenCalled();
   });
 });

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/gateway-client.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/gateway-client.ts
@@ -1,3 +1,4 @@
+import { events } from '@main/lib/events';
 import type {
   RemoteAgentRoom,
   RemoteAgentSummary,
@@ -7,6 +8,7 @@ import type {
   SwitchServer,
   SwitchUser,
 } from '@shared/core/switch-servers/switch-servers';
+import { switchServerConnectionStatusChannel } from '@shared/events/switchServerConnectionEvents';
 import { reauthenticateManagedServer, refreshSession } from './auth';
 import { getSessionCookie } from './servers-store';
 
@@ -150,6 +152,15 @@ async function gatewayFetch(
   }
 
   if (response.status === 401) {
+    // A rejected session means the user must sign in again. Push it so the UI
+    // flips to "needs re-auth" immediately, no matter which call hit the 401 or
+    // which view is open — not only on the next focus/manual refresh.
+    events.emit(switchServerConnectionStatusChannel, {
+      serverId: server.id,
+      connected: false,
+      user: null,
+      reason: 'expired',
+    });
     throw new GatewayError('unauthorized', 'Switch session expired — please sign in again.', 401);
   }
   if (!response.ok) {

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -155,7 +155,8 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
   const server = store.servers.find((s) => s.id === serverId);
   if (!server) return null;
 
-  const connected = store.isConnected(serverId);
+  const status = store.statusFor(serverId);
+  const connected = status?.connected ?? false;
   const isViewing = isCurrentView(currentView, 'server') && params.serverId === serverId;
   // The active server scopes the whole sidebar (agents/rooms/sessions). Selecting
   // a server makes it active and opens its page.
@@ -170,6 +171,9 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
       : localServerStore.isRunning;
   const dormant = server.managed && !managedRunning;
   const needsSignIn = !dormant && !connected;
+  // Distinguish "was signed in, session expired" from "never signed in" so the
+  // pill nudges a re-auth rather than a first sign-in (CHOO-1406).
+  const expired = needsSignIn && status?.reason === 'expired';
 
   return (
     <SidebarMenuButton
@@ -208,7 +212,7 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
           }}
           className="shrink-0 rounded border border-red-500/40 px-1.5 py-0.5 text-xs font-medium text-red-500 hover:bg-red-500/10"
         >
-          Sign in
+          {expired ? 'Sign in again' : 'Sign in'}
         </span>
       )}
     </SidebarMenuButton>

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -1,11 +1,14 @@
 import { makeAutoObservable, runInAction } from 'mobx';
-import { rpc } from '@renderer/lib/ipc';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import { events, rpc } from '@renderer/lib/ipc';
+import { appState } from '@renderer/lib/stores/app-state';
 import type {
   ServerConnectionStatus,
   SwitchAuthConfig,
   SwitchServer,
   UpdateServerResult,
 } from '@shared/core/switch-servers/switch-servers';
+import { switchServerConnectionStatusChannel } from '@shared/events/switchServerConnectionEvents';
 
 /**
  * Renderer store for the Switch-server integration. Holds the registered
@@ -32,6 +35,9 @@ export class SwitchServersStore {
   /** Whether the sidebar "Servers" section is expanded. */
   serversExpanded = true;
 
+  /** Unsubscribe from the live connection-status push, set up once in `init`. */
+  private offConnectionStatus: (() => void) | null = null;
+
   constructor() {
     makeAutoObservable(this);
   }
@@ -57,6 +63,14 @@ export class SwitchServersStore {
   }
 
   async init(): Promise<void> {
+    // Subscribe once: the main process pushes a status whenever an authenticated
+    // gateway call is rejected, so an expired session surfaces live rather than
+    // waiting for the next focus/manual refresh (CHOO-1406).
+    if (!this.offConnectionStatus) {
+      this.offConnectionStatus = events.on(switchServerConnectionStatusChannel, (status) => {
+        this.applyPushedStatus(status);
+      });
+    }
     runInAction(() => {
       this.loadingServers = true;
       this.error = null;
@@ -105,13 +119,52 @@ export class SwitchServersStore {
       // global, so one unreachable server would paint an error over every
       // server's view.
       runInAction(() => {
-        this.statuses.set(serverId, { serverId, connected: false, user: null });
+        this.statuses.set(serverId, {
+          serverId,
+          connected: false,
+          user: null,
+          reason: 'signed-out',
+        });
       });
     } finally {
       runInAction(() => {
         this.refreshing.delete(serverId);
       });
     }
+  }
+
+  /**
+   * Apply a status pushed from the main process (a live 401 during use). Record
+   * it, and when a server *transitions* into the expired state — from connected,
+   * or from any other state we hadn't already flagged expired — raise an
+   * app-level toast so it's obvious no matter which view is open. Guarding on the
+   * transition keeps a burst of 401s from stacking duplicate toasts.
+   */
+  private applyPushedStatus(status: ServerConnectionStatus): void {
+    const previous = this.statuses.get(status.serverId);
+    const alreadyExpired = previous?.connected === false && previous.reason === 'expired';
+    runInAction(() => {
+      this.statuses.set(status.serverId, status);
+    });
+    if (!status.connected && status.reason === 'expired' && !alreadyExpired) {
+      this.notifyExpired(status.serverId);
+    }
+  }
+
+  private notifyExpired(serverId: string): void {
+    const name = this.servers.find((s) => s.id === serverId)?.name ?? 'a Switch server';
+    toast({
+      title: 'Sign in again',
+      description: `Your session for ${name} expired.`,
+      variant: 'destructive',
+      action: {
+        label: 'Sign in',
+        onClick: () => {
+          void this.setActive(serverId);
+          appState.navigation.navigate('server', { serverId });
+        },
+      },
+    });
   }
 
   async ensureAuthConfig(serverId: string): Promise<void> {

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
@@ -82,6 +82,7 @@ const ServerMainPanel = observer(function ServerMainPanel() {
 
   const status = store.statusFor(serverId);
   const connected = status?.connected ?? false;
+  const expired = !connected && status?.reason === 'expired';
   const refreshing = store.refreshing.has(serverId);
 
   return (
@@ -147,6 +148,8 @@ const ServerMainPanel = observer(function ServerMainPanel() {
                   <span className="text-foreground">
                     Connected{status?.user ? ` as ${status.user.name || status.user.email}` : ''}
                   </span>
+                ) : expired ? (
+                  <span className="text-foreground">Session expired — sign in again</span>
                 ) : (
                   <span className="text-foreground-muted">Not signed in</span>
                 )}
@@ -171,7 +174,7 @@ const ServerMainPanel = observer(function ServerMainPanel() {
               </div>
             </div>
 
-            {!connected && <LoginPanel serverId={serverId} />}
+            {!connected && <LoginPanel serverId={serverId} expired={expired} />}
 
             <div className={`${card} space-y-3`}>
               <p className="text-sm text-foreground-muted">
@@ -207,7 +210,13 @@ function StatusDot({ connected }: { connected: boolean }) {
   );
 }
 
-const LoginPanel = observer(function LoginPanel({ serverId }: { serverId: string }) {
+const LoginPanel = observer(function LoginPanel({
+  serverId,
+  expired,
+}: {
+  serverId: string;
+  expired: boolean;
+}) {
   const store = switchServersStore;
   const config = store.authConfigFor(serverId);
   const [email, setEmail] = useState('');
@@ -238,7 +247,11 @@ const LoginPanel = observer(function LoginPanel({ serverId }: { serverId: string
 
   return (
     <div className={`${card} space-y-4`}>
-      <p className="text-sm text-foreground-muted">Sign in to connect to this server.</p>
+      <p className="text-sm text-foreground-muted">
+        {expired
+          ? 'Your session expired. Sign in again to reconnect to this server.'
+          : 'Sign in to connect to this server.'}
+      </p>
 
       {config.passwordLoginEnabled && (
         <div className="space-y-3">

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
@@ -102,12 +102,24 @@ export type SwitchUser = {
   role: string;
 };
 
+/**
+ * Why switchdash is not holding a valid session for a server, when
+ * `ServerConnectionStatus.connected` is false:
+ * - `expired` — a session was stored but the gateway rejected it (401). The
+ *   user was signed in and now needs to sign in *again* (CHOO-1406).
+ * - `signed-out` — no session is stored (never signed in, or signed out). Also
+ *   the fallback when the gateway is unreachable, matching the "Sign in" state.
+ */
+export type ServerDisconnectedReason = 'expired' | 'signed-out';
+
 /** Connection status for a server: whether switchdash holds a valid session. */
 export type ServerConnectionStatus = {
   serverId: string;
   connected: boolean;
   /** The signed-in user when connected; null otherwise. */
   user: SwitchUser | null;
+  /** Why we're disconnected, when `connected` is false; null when connected. */
+  reason: ServerDisconnectedReason | null;
 };
 
 export type PasswordLoginParams = {

--- a/dash/apps/switchdash-desktop/src/shared/events/switchServerConnectionEvents.ts
+++ b/dash/apps/switchdash-desktop/src/shared/events/switchServerConnectionEvents.ts
@@ -1,0 +1,12 @@
+import type { ServerConnectionStatus } from '@shared/core/switch-servers/switch-servers';
+import { defineEvent } from '@shared/lib/ipc/events';
+
+/**
+ * Pushed by the main process when it observes a server's connection status
+ * change outside an explicit refresh — chiefly when an authenticated gateway
+ * call is rejected (401), so the UI can flip to "needs re-auth" live rather than
+ * waiting for the next window focus or manual refresh (CHOO-1406).
+ */
+export const switchServerConnectionStatusChannel = defineEvent<ServerConnectionStatus>(
+  'switch-server:connection-status'
+);


### PR DESCRIPTION
## What & why

CHOO-1406 — switchdash: make it obvious when a Switch server needs to be signed in *again*.

Before this, an expired session looked identical to "never signed in", connection status was **pull-only** (refreshed on app init / window focus / server-page mount / manual Refresh), and real 401s during use were swallowed by the rooms/agents stores — so a token that expired while you were on any other view went unnoticed until the next refresh.

## Changes

- **Model the reason.** `ServerConnectionStatus` now carries `reason: 'expired' | 'signed-out' | null`. `getConnectionStatus` decides expired vs signed-out by whether a session cookie is stored (present-but-rejected → expired).
- **Push status live.** New `switch-server:connection-status` event, emitted from the single gateway 401 chokepoint (`gatewayFetch`). Any authenticated call that 401s (rooms, agents, verify, status) now flips that server to "expired" in the UI immediately — no wait for focus/refresh, and it closes the swallowed-401 gap in one place. `switchServersStore` subscribes and updates its status map.
- **Surface it clearly.**
  - Sidebar: expired servers show a **"Sign in again"** pill (vs "Sign in" for never-signed-in), keeping the amber dot.
  - Server page: **"Session expired — sign in again"** and a login panel that reflects the re-auth case.
  - **App-level toast** on transition into expired (guarded so a burst of 401s doesn't stack duplicates), with a **"Sign in"** action that opens that server's page — obvious from any view.

## Tests

Added `gateway-client` coverage for the emit: fires on a real 401, does **not** fire when there's no stored session, and does **not** fire when the managed local server silently re-auths past a 401.

Merge gate green locally: `format`, `lint`, `typecheck`, and `test` (1241 passing across node/main-db/migrations/browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)