### PR TITLE
chore(security): trim vestigial Python setup from Socket workflow

### DIFF
--- a/.github/workflows/socket_cve_fix.yml
+++ b/.github/workflows/socket_cve_fix.yml
@@ -21,14 +21,6 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.12'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -39,9 +31,6 @@ jobs:
 
       - name: Install pnpm
         run: npm i -g pnpm
-
-      - name: Install Socket CLI
-        run: pip install socketsecurity --upgrade
 
       - name: Generate github App Token #Generate short-lived Installation Access Token
         id: generate-token


### PR DESCRIPTION
Removes `setup-python`, `uv`, and `pip install socketsecurity` from the Socket autofix workflow. `socket fix` runs off the npm CLI and parses pip/pyproject statically, so these steps are unused (verified via `socket fix --no-apply-fixes`). No change to CVE coverage or `cdxgen` targets; ~15s faster per scheduled run.

Efficiency-only cleanup, no functional change.