### PR TITLE
License: Apache-2.0 + Commons Clause relicense + CLA gate (CHOO-1251)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,41 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >-
+          github.event.comment.body == 'recheck'
+          || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT (repo scope) is required so the bot can persist signatures and
+          # re-run the status check. Add it as a repository secret named
+          # PERSONAL_ACCESS_TOKEN — the workflow will not function without it.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/sandbox-quantum/switch/blob/main/CLA.md
+          branch: main
+          allowlist: dependabot[bot],*[bot]
+          custom-notsigned-prcomment: >-
+            Thank you for your contribution! Before we can merge it, please read
+            our [Contributor License Agreement](https://github.com/sandbox-quantum/switch/blob/main/CLA.md)
+            and sign it by posting the following comment on this pull request:
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA. ✅

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,112 @@
+# Contributor License Agreement
+
+> **DRAFT — pending SandboxAQ Legal review.** This document is a starting
+> point adapted from the Apache Software Foundation Individual Contributor
+> License Agreement. It is **not** binding until reviewed and approved by
+> SandboxAQ Legal. Do not rely on this wording as final.
+
+Thank you for your interest in contributing to Agent Switch, a project of
+SB Technology, Inc. dba SandboxAQ (the "Company"). This Contributor License
+Agreement ("Agreement") documents the rights granted by contributors to the
+Company. This Agreement is for your protection as a Contributor as well as the
+protection of the Company; it does not change your rights to use your own
+Contributions for any other purpose.
+
+By signing this Agreement (see "How to sign" below), you accept and agree to
+the following terms and conditions for your present and future Contributions
+submitted to the Company. Except for the license granted herein to the Company
+and recipients of software distributed by the Company, you reserve all right,
+title, and interest in and to your Contributions.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized
+by the copyright owner that is entering into this Agreement with the Company.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to the Company for inclusion in, or documentation of, any of the products
+owned or managed by the Company (the "Work"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to the Company or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of, the
+Company for the purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in writing by
+You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license
+to reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated
+in this section) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer the Work, where such license applies only to
+those patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work to
+which such Contribution(s) was submitted. If any entity institutes patent
+litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that Your Contribution, or the Work to which
+You have contributed, constitutes direct or contributory patent infringement,
+then any patent licenses granted to that entity under this Agreement for that
+Contribution or Work shall terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that You are legally entitled to grant the above license. If Your
+employer(s) has rights to intellectual property that You create that includes
+Your Contributions, You represent that You have received permission to make
+Contributions on behalf of that employer, that Your employer has waived such
+rights for Your Contributions to the Company, or that Your employer has executed
+a separate Corporate CLA with the Company.
+
+You represent that each of Your Contributions is Your original creation (see
+Section 6 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license or
+other restriction (including, but not limited to, related patents and
+trademarks) of which You are personally aware and which are associated with any
+part of Your Contributions.
+
+## 5. Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 6. Submissions on Behalf of Others
+
+Should You wish to submit work that is not Your original creation, You may submit
+it to the Company separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction (including, but
+not limited to, related patents, trademarks, and license agreements) of which
+You are personally aware, and conspicuously marking the work as "Submitted on
+behalf of a third-party: [named here]".
+
+## 7. Notice
+
+You agree to notify the Company of any facts or circumstances of which You become
+aware that would make these representations inaccurate in any respect.
+
+## How to sign
+
+This project uses an automated CLA assistant. When you open your first pull
+request, a bot will comment with a link to this document and ask you to confirm
+your agreement. Reply to that pull request with the exact sentence:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your GitHub username, the pull request, and a timestamp are recorded in
+`signatures/version1/cla.json`. You only need to sign once; subsequent
+contributions are recognized automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Agent Switch
+
+Thanks for your interest in contributing! This guide covers what you need to
+get a change merged.
+
+## Contributor License Agreement (required)
+
+Agent Switch requires every contributor to sign a
+[Contributor License Agreement](CLA.md) before their contributions can be
+merged. This is a one-time step:
+
+1. Open your pull request as usual.
+2. An automated CLA assistant will comment on the PR with a link to the CLA and
+   a status check.
+3. Reply to the PR with the exact sentence:
+
+   > I have read the CLA Document and I hereby sign the CLA
+
+Your signature is recorded automatically and applies to all future
+contributions — you only sign once.
+
+## Development setup
+
+See [CLAUDE.md](CLAUDE.md) for the full developer guide. In short:
+
+```bash
+uv sync            # install dependencies
+just up            # start Switch locally (Docker Compose)
+just migrate       # apply database migrations
+```
+
+## Before you open a pull request
+
+- **Format & lint:** `just check` (CI runs `ruff format --check` + `ruff check`).
+- **Type-check:** `just typecheck` (mypy over `core/switch_core/`).
+- **Test:** `just test` (pytest; store tests run against a real PostgreSQL
+  instance, not mocks or SQLite).
+
+## Conventions
+
+[CLAUDE.md](CLAUDE.md) documents the code style, import rules, and the
+error-handling philosophy ("fail loud, never fake") this project follows.
+Please read it before making substantial changes — matching the surrounding
+code and these conventions keeps review fast.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+project's [LICENSE](LICENSE) (Apache License 2.0 with the Commons Clause
+condition).

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,32 @@
+Software: Agent Switch
+Copyright (c) 2026 SB Technology, Inc. dba SandboxAQ
+
+This software is licensed to you under the Apache 2.0 License as limited by the
+"Commons Clause" license condition below. The "Commons Clause" license condition
+has been modified from the original version to clarify that the "Commons Clause"
+license condition also applies to any derivatives of the Software.
+
+"Commons Clause" License Condition v1.0, as modified below
+
+The Software is provided to you by the Licensor under the License, as defined
+below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the
+License will not include, and the License does not grant to you, the right to
+Sell the Software or any derivative of the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the rights
+granted to you under the License to provide to third parties, for a fee or other
+consideration (including without limitation fees for hosting or
+consulting/support services related to the Software), a product or service whose
+value derives, entirely or substantially, from the functionality of the
+Software.
+
+Any license notice or attribution required by the License must also include this
+Commons Clause License Condition notice.
+
+--------------------------------------------------------------------------------
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,12 @@
 Agent Switch
-Copyright 2026 SandboxAQ
+Copyright (c) 2026 SB Technology, Inc. dba SandboxAQ
 
 This product includes software developed at SandboxAQ (https://www.sandboxaq.com/).
+
+This software is provided under the Apache License, Version 2.0, as limited by
+the "Commons Clause" License Condition v1.0 (as modified). See the LICENSE file
+for the full terms. Any license notice or attribution required by the License
+must also include the Commons Clause License Condition notice.
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ derives substantially from it); all other Apache 2.0 grants are unchanged.
 
 ## Contributing
 
-See [CLAUDE.md](CLAUDE.md) for code style, the error-handling philosophy, and
-the conventions to follow when working in this repository. A dedicated
-`CONTRIBUTING.md` and contributor guides are on the way.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get a change merged, including
+the required [Contributor License Agreement](CLA.md). [CLAUDE.md](CLAUDE.md)
+covers code style, the error-handling philosophy, and the conventions to follow
+when working in this repository.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Create organizations where AI agents and humans work side by side.**
 
-[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+[![License: Apache 2.0 + Commons Clause](https://img.shields.io/badge/license-Apache%202.0%20%2B%20Commons%20Clause-blue)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-coming%20soon-FF895E)](#)
 [![Website](https://img.shields.io/badge/website-coming%20soon-FF895E)](#)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CLAUDE.md)
@@ -184,8 +184,11 @@ PostgreSQL instance (not mocks, not SQLite). Run them with `just test`.
 
 ## License
 
-Agent Switch is licensed under the **Apache License 2.0** — see
-[`LICENSE`](LICENSE) for the full text.
+Agent Switch is licensed under the **Apache License 2.0 with the Commons Clause**
+condition (Copyright (c) 2026 SB Technology, Inc. dba SandboxAQ) — see
+[`LICENSE`](LICENSE) for the full text. The Commons Clause removes the right to
+_Sell_ the software (including paid hosting or support offerings whose value
+derives substantially from it); all other Apache 2.0 grants are unchanged.
 
 ## Contributing
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "SandboxAQ" },
 ]
 keywords = ["ai", "agents", "orchestration", "governance", "matrix", "mcp"]
-license = "Apache-2.0"
+license = "LicenseRef-Apache-2.0-with-Commons-Clause"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/dash/apps/switchdash-desktop/package.json
+++ b/dash/apps/switchdash-desktop/package.json
@@ -10,7 +10,7 @@
     "openai"
   ],
   "homepage": "https://github.com/sandbox-quantum/switch",
-  "license": "Apache-2.0",
+  "license": "SEE LICENSE IN LICENSE",
   "author": {
     "name": "Switchdash Contributors"
   },


### PR DESCRIPTION
## Summary

Part of **CHOO-1251** (OSS security sign-off). Relicenses the repo from plain
Apache-2.0 to **Apache-2.0 + the modified Commons Clause** condition, and adds a
**Contributor License Agreement** gate so inbound contributions stay consistent
with that licensing.

The Commons Clause removes the right to _Sell_ the Software or its derivatives
(including paid hosting / support offerings whose value derives substantially
from it); all other Apache-2.0 grants are unchanged. Net effect: source-available
under a single, machine-readable license marker across all metadata.

## Changes

**Relicense**
- `LICENSE` — Commons Clause v1.0 (modified) preamble + copyright header layered
  on top of the pristine canonical Apache-2.0 text.
- `NOTICE` — Commons Clause attribution notice; copyright entity aligned to
  `SB Technology, Inc. dba SandboxAQ`.
- `core/pyproject.toml` — `license = "LicenseRef-Apache-2.0-with-Commons-Clause"`
  (verified: `hatchling` sdist builds and `PKG-INFO` records the expression).
- `dash/apps/switchdash-desktop/package.json` — `"SEE LICENSE IN LICENSE"`.
- `README.md` — license badge + License section name the Commons Clause. The
  "open-source" tagline is intentionally kept per product direction.

**CLA gate**
- `CLA.md` — individual CLA (Apache ICLA-derived).
- `.github/workflows/cla.yml` — `contributor-assistant/github-action`; signatures
  stored in-repo at `signatures/version1/cla.json`, no third-party SaaS.
- `CONTRIBUTING.md` — contribution guide covering the CLA step, dev setup, and
  pre-PR checks; README Contributing section points to it.

## ⚠️ Required before this is functional / final

1. **Legal review of `CLA.md`** — it is marked DRAFT; SandboxAQ Legal must own
   the final wording before it is binding.
2. **Add a `PERSONAL_ACCESS_TOKEN` repo secret** (PAT, repo scope) — the CLA
   workflow needs it to persist signatures and re-run the status check.

## Notes on dash / emdash

`dash/` is a derivative of emdash (upstream Apache-2.0). The combined work +
SandboxAQ contributions carry Apache-2.0 + Commons Clause; emdash's original code
remains Apache-2.0, and NOTICE continues to credit it.

## Out of scope (follow-ups under CHOO-1251)

- Security review packet for the infosec team
- `SECURITY.md` (vulnerability disclosure policy)
- Scrub-gate automation (CI secret-scan gate on top of the existing
  `.gitleaks.toml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)