### PR TITLE
feat(switchdash): agent error indicator + retry button (CHOO-1639)

### DIFF
--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/main-panel/main-panel.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/main-panel/main-panel.tsx
@@ -1,9 +1,10 @@
-import { Loader2, TriangleAlert } from 'lucide-react';
+import { Loader2, RefreshCw, TriangleAlert } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useConfirmDeleteAgent } from '@renderer/features/locations/hooks/use-confirm-delete-agent';
 import { useParams } from '@renderer/lib/layout/navigation-provider';
 import { isUnregisteredLocation } from '../../stores/location';
 import {
+  getLocationManagerStore,
   getLocationStore,
   locationDisplayName,
   locationViewKind,
@@ -39,7 +40,12 @@ export const LocationMainPanel = observer(function LocationMainPanel() {
   }
 
   if (kind === 'mount_error') {
-    return <LocationBootstrapErrorPanel message={unmountedMountErrorMessage(store)} />;
+    return (
+      <LocationBootstrapErrorPanel
+        locationId={locationId}
+        message={unmountedMountErrorMessage(store)}
+      />
+    );
   }
 
   if (kind !== 'ready') {
@@ -58,14 +64,31 @@ function LocationBootstrappingPanel() {
   );
 }
 
-function LocationBootstrapErrorPanel({ message }: { message: string }) {
+function LocationBootstrapErrorPanel({
+  locationId,
+  message,
+}: {
+  locationId: string;
+  message: string;
+}) {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center p-8">
-      <div className="flex max-w-xs flex-col items-center gap-2 text-center">
+      <div className="flex max-w-xs flex-col items-center gap-3 text-center">
+        <TriangleAlert className="h-6 w-6 text-foreground-destructive" />
         <p className="font-mono text-sm font-medium text-foreground-destructive">
           Failed to set up location
         </p>
         <p className="font-mono text-xs text-foreground-passive">{message}</p>
+        <button
+          type="button"
+          className="mt-1 inline-flex items-center gap-1.5 text-xs text-foreground-muted underline underline-offset-2 transition-colors hover:text-foreground"
+          onClick={() => {
+            void getLocationManagerStore().mountLocation(locationId);
+          }}
+        >
+          <RefreshCw className="h-3 w-3" />
+          Retry connection
+        </button>
       </div>
     </div>
   );

--- a/dash/apps/switchdash-desktop/src/renderer/features/sessions/main-panel.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sessions/main-panel.tsx
@@ -1,7 +1,9 @@
-import { Loader2 } from 'lucide-react';
+import { Loader2, RefreshCw, TriangleAlert } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import { getLocationManagerStore } from '@renderer/features/locations/stores/location-selectors';
 import { useSessionViewContext } from '@renderer/features/sessions/session-view-context';
 import {
+  getSessionManagerStore,
   getSessionStore,
   sessionErrorMessage,
   sessionViewKind,
@@ -48,15 +50,31 @@ export const SessionMainPanel = observer(function SessionMainPanel() {
   }
 
   if (kind === 'provision-error' || kind === 'location-error') {
+    const retrySession = () => {
+      if (kind === 'location-error') {
+        void getLocationManagerStore().mountLocation(locationId);
+      } else {
+        void getSessionManagerStore(locationId)?.provisionSession(sessionId);
+      }
+    };
     return (
       <div className="flex h-full w-full flex-col items-center justify-center p-8">
-        <div className="flex max-w-xs flex-col items-center gap-2 text-center">
+        <div className="flex max-w-xs flex-col items-center gap-3 text-center">
+          <TriangleAlert className="h-6 w-6 text-foreground-destructive" />
           <p className="font-mono text-sm font-medium text-foreground-destructive">
             Failed to set up session
           </p>
           <p className="font-mono text-xs text-foreground-muted">
             {sessionErrorMessage(sessionStore)}
           </p>
+          <button
+            type="button"
+            className="mt-1 inline-flex items-center gap-1.5 text-xs text-foreground-muted underline underline-offset-2 transition-colors hover:text-foreground"
+            onClick={retrySession}
+          >
+            <RefreshCw className="h-3 w-3" />
+            Retry connection
+          </button>
         </div>
       </div>
     );

--- a/dash/apps/switchdash-desktop/src/renderer/features/sessions/stores/session-selectors.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sessions/stores/session-selectors.ts
@@ -151,6 +151,17 @@ export function sessionErrorMessage(store: SessionStore | undefined): string | u
   return undefined;
 }
 
+/** Returns true if any session under this location has a provision or create error. */
+export function hasSessionError(locationId: string): boolean {
+  const manager = getSessionManagerStore(locationId);
+  if (!manager) return false;
+  for (const session of manager.sessions.values()) {
+    if (isUnregistered(session) && session.phase === 'create-error') return true;
+    if (isUnprovisioned(session) && session.phase === 'provision-error') return true;
+  }
+  return false;
+}
+
 /** Returns the mount error message for the location. */
 export function locationMountErrorMessage(locationId: string): string {
   const store = getLocationManagerStore().locations.get(locationId);

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/location-item.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/location-item.tsx
@@ -5,6 +5,7 @@ import {
   ExternalLink,
   Loader2,
   Plus,
+  RefreshCw,
   Server,
   Trash2,
   TriangleAlert,
@@ -17,9 +18,11 @@ import {
   type UnregisteredLocation,
 } from '@renderer/features/locations/stores/location';
 import {
+  getLocationManagerStore,
   getLocationStore,
   locationViewKind,
 } from '@renderer/features/locations/stores/location-selectors';
+import { hasSessionError } from '@renderer/features/sessions/stores/session-selectors';
 import { switchRoomsStore } from '@renderer/features/switch-servers/switch-rooms-store';
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
 import { rpc } from '@renderer/lib/ipc';
@@ -222,6 +225,33 @@ export const SidebarLocationItem = observer(function SidebarLocationItem({
                       <TriangleAlert className="h-3.5 w-3.5 shrink-0 text-foreground-destructive" />
                     </TooltipTrigger>
                     <TooltipContent>Agent not found at path</TooltipContent>
+                  </Tooltip>
+                )}
+                {locationViewKind(location) === 'mount_error' && (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <button
+                          type="button"
+                          className="inline-flex cursor-pointer"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void getLocationManagerStore().mountLocation(locationId);
+                          }}
+                        />
+                      }
+                    >
+                      <RefreshCw className="h-3.5 w-3.5 shrink-0 text-foreground-destructive" />
+                    </TooltipTrigger>
+                    <TooltipContent>Connection failed — click to retry</TooltipContent>
+                  </Tooltip>
+                )}
+                {locationViewKind(location) === 'ready' && hasSessionError(locationId) && (
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <TriangleAlert className="h-3.5 w-3.5 shrink-0 text-foreground-destructive" />
+                    </TooltipTrigger>
+                    <TooltipContent>A session failed to connect</TooltipContent>
                   </Tooltip>
                 )}
               </span>


### PR DESCRIPTION
## Summary

- Add a **per-agent error indicator in the sidebar** for mount failures (red RefreshCw icon, clickable to retry) and session provision failures (red TriangleAlert)
- Add a **"Retry connection" button** to the location error panel and session error panel (provision-error / location-error)
- New `hasSessionError()` selector to detect session-level failures for sidebar badge

Closes CHOO-1639.

## Test plan

- [ ] Trigger a location mount error (e.g. misconfigure the agent path) and verify the sidebar shows a red RefreshCw icon on that agent row
- [ ] Click the RefreshCw sidebar icon — verify it retries the connection
- [ ] Navigate to the agent's main pane — verify the error panel shows a TriangleAlert icon and "Retry connection" button
- [ ] Click "Retry connection" in the main pane — verify it retries mounting
- [ ] Trigger a session provision error (e.g. "Connection lost before handshake") and verify the sidebar agent row shows a red TriangleAlert
- [ ] Navigate to the failing session — verify the error panel shows a "Retry connection" button
- [ ] Click "Retry connection" — verify it retries provisioning
- [ ] Verify all checks pass: `pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)