### PR TITLE
feat(switchdash): delete and rename connected servers (CHOO-1486)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
@@ -21,6 +21,7 @@ import type {
   RemoteAgentSummary,
   RemoteRoomRole,
   RemoteRoomSummary,
+  RenameServerParams,
   ServerConnectionStatus,
   SwitchAuthConfig,
   SwitchServer,
@@ -49,6 +50,7 @@ import {
   getServer,
   listServers,
   removeServer,
+  renameServer,
   setActiveServerId,
   updateServer,
 } from './servers-store';
@@ -133,6 +135,8 @@ export const switchServersController = createRPCController({
 
     return { server, propagation: { apiUrlChanged, agents: propagatedAgents } };
   },
+
+  renameServer: (params: RenameServerParams): Promise<SwitchServer> => renameServer(params),
 
   removeServer: (serverId: string): Promise<void> => removeServer(serverId),
 

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/servers-store.db.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/servers-store.db.test.ts
@@ -1,0 +1,144 @@
+import { openFixture } from '@tooling/utils/db';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppDb } from '@main/db/client';
+import { agents, kv, locations, switchServers } from '@main/db/schema';
+
+const mocks = vi.hoisted(() => ({
+  db: undefined as AppDb | undefined,
+}));
+
+vi.mock('@main/db/client', () => ({
+  get db() {
+    if (!mocks.db) throw new Error('Test database not initialized');
+    return mocks.db;
+  },
+}));
+
+// removeServer deletes the encrypted session cookie; the servers-store module
+// also constructs the encrypted-secrets singleton at import (which touches the
+// real db). Stub it so these tests stay on the DB-row path.
+const secretMocks = vi.hoisted(() => ({
+  deleteSecret: vi.fn(),
+}));
+vi.mock('@main/core/secrets/encrypted-app-secrets-store', () => ({
+  encryptedAppSecretsStore: {
+    getSecret: vi.fn(),
+    setSecret: vi.fn(),
+    deleteSecret: secretMocks.deleteSecret,
+  },
+}));
+
+// Imported after the mocks so the module binds to the mocked db + secrets store.
+const { ensureManagedServer, removeServer, renameServer } = await import('./servers-store');
+
+describe('servers-store: rename & delete', () => {
+  let fixture: Awaited<ReturnType<typeof openFixture>>;
+
+  beforeEach(async () => {
+    fixture = await openFixture('empty');
+    mocks.db = fixture.db;
+    fixture.sqlite.pragma('foreign_keys = OFF');
+    secretMocks.deleteSecret.mockReset();
+  });
+
+  afterEach(() => {
+    fixture.close();
+    mocks.db = undefined;
+  });
+
+  describe('renameServer', () => {
+    it('updates only the name, leaving URLs and managed metadata untouched', async () => {
+      await fixture.db.insert(switchServers).values({
+        id: 'remote-1',
+        name: 'Old name',
+        gatewayUrl: 'https://gw.example.com',
+        apiUrl: 'https://api.example.com',
+        managed: true,
+        managementKind: 'remote',
+        sshHost: 'host-a',
+      });
+
+      const renamed = await renameServer({ id: 'remote-1', name: '  New name  ' });
+
+      expect(renamed.name).toBe('New name');
+      expect(renamed.gatewayUrl).toBe('https://gw.example.com');
+      expect(renamed.apiUrl).toBe('https://api.example.com');
+      expect(renamed.managed).toBe(true);
+      expect(renamed.managementKind).toBe('remote');
+      expect(renamed.sshHost).toBe('host-a');
+    });
+
+    it('throws for an unknown server id', async () => {
+      await expect(renameServer({ id: 'nope', name: 'x' })).rejects.toThrow('No Switch server');
+    });
+  });
+
+  describe('ensureManagedServer name preservation', () => {
+    it('keeps a renamed managed server name across a restart (only URLs refresh)', async () => {
+      // First start: registers the local managed row under the default name.
+      const created = await ensureManagedServer(
+        {
+          name: 'Local Switch server',
+          gatewayUrl: 'http://localhost:8080',
+          apiUrl: 'http://localhost:8081',
+        },
+        { kind: 'local' }
+      );
+      // User renames it.
+      await renameServer({ id: created.id, name: 'My box' });
+
+      // Restart repicks ports (new URLs) and passes the hardcoded default name.
+      const restarted = await ensureManagedServer(
+        {
+          name: 'Local Switch server',
+          gatewayUrl: 'http://localhost:9090',
+          apiUrl: 'http://localhost:9091',
+        },
+        { kind: 'local' }
+      );
+
+      expect(restarted.id).toBe(created.id);
+      // The rename survives; the URLs still refresh to the new ports.
+      expect(restarted.name).toBe('My box');
+      expect(restarted.gatewayUrl).toBe('http://localhost:9090');
+      expect(restarted.apiUrl).toBe('http://localhost:9091');
+    });
+  });
+
+  describe('removeServer', () => {
+    it('unlinks the server’s agents (keeps them), deletes the row, and clears the active pointer', async () => {
+      await fixture.db
+        .insert(locations)
+        .values({ id: 'loc-1', name: 'Loc', sshHost: '', dir: '/repo/loc-1' });
+      await fixture.db.insert(switchServers).values({
+        id: 'srv-1',
+        name: 'Server',
+        gatewayUrl: 'https://gw.example.com',
+        apiUrl: 'https://api.example.com',
+      });
+      await fixture.db.insert(agents).values([
+        { id: 'agent-1', locationId: 'loc-1', name: 'A', providerId: 'claude', serverId: 'srv-1' },
+        { id: 'agent-2', locationId: 'loc-1', name: 'B', providerId: 'claude', serverId: 'srv-1' },
+      ]);
+      await fixture.db.insert(kv).values({ key: 'activeSwitchServerId', value: 'srv-1' });
+
+      await removeServer('srv-1');
+
+      const remainingServers = await fixture.db.select().from(switchServers);
+      expect(remainingServers).toHaveLength(0);
+
+      const remainingAgents = await fixture.db.select().from(agents);
+      expect(remainingAgents).toHaveLength(2);
+      expect(remainingAgents.every((a) => a.serverId === null)).toBe(true);
+
+      const [activePointer] = await fixture.db
+        .select()
+        .from(kv)
+        .where(eq(kv.key, 'activeSwitchServerId'));
+      expect(activePointer).toBeUndefined();
+
+      expect(secretMocks.deleteSecret).toHaveBeenCalledWith('switch-server-cookie:srv-1');
+    });
+  });
+});

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/servers-store.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/servers-store.ts
@@ -6,6 +6,7 @@ import { agents, kv, type SwitchServerRow, switchServers } from '@main/db/schema
 import type {
   AddServerParams,
   ManagedServerRef,
+  RenameServerParams,
   SwitchServer,
   UpdateServerParams,
 } from '@shared/core/switch-servers/switch-servers';
@@ -136,10 +137,13 @@ export async function ensureManagedServer(
     ref.kind === 'remote' ? await getRemoteManagedServer(ref.sshHost) : await getManagedServer();
   const existing = existingForTarget ?? (await getServerByGatewayUrl(gatewayUrl));
   if (existing) {
+    // Preserve the stored name on restart: the name is set once at creation and
+    // then owned by the user (rename). Only the URLs/kind refresh when a managed
+    // stack restarts (ports can change), so overwriting name here would clobber a
+    // rename — the local stack always restarts with a hardcoded default name.
     const [row] = await db
       .update(switchServers)
       .set({
-        name: params.name.trim(),
         gatewayUrl,
         apiUrl,
         managed: true,
@@ -199,6 +203,18 @@ export async function updateServer(params: UpdateServerParams): Promise<SwitchSe
       apiUrl: normaliseUrl(params.apiUrl),
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
+    .where(eq(switchServers.id, params.id))
+    .returning();
+  if (!row) {
+    throw new Error(`No Switch server with id ${params.id}`);
+  }
+  return mapRow(row);
+}
+
+export async function renameServer(params: RenameServerParams): Promise<SwitchServer> {
+  const [row] = await db
+    .update(switchServers)
+    .set({ name: params.name.trim(), updatedAt: sql`CURRENT_TIMESTAMP` })
     .where(eq(switchServers.id, params.id))
     .returning();
   if (!row) {

--- a/dash/apps/switchdash-desktop/src/renderer/app/modal-registry.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/app/modal-registry.ts
@@ -5,6 +5,8 @@ import { DeleteSessionModal } from '@renderer/features/sessions/delete-session-m
 import { RenameSessionModal } from '@renderer/features/sessions/rename-session-modal';
 import { AddServerModal } from '@renderer/features/switch-servers/AddServerModal';
 import { AssignServerModal } from '@renderer/features/switch-servers/assign-server-modal';
+import { DeleteServerModal } from '@renderer/features/switch-servers/DeleteServerModal';
+import { RenameServerModal } from '@renderer/features/switch-servers/RenameServerModal';
 import { ConfirmActionDialog } from '@renderer/lib/components/confirm-action-dialog';
 import { ExternalLinkChoiceDialog } from '@renderer/lib/components/external-link-choice-dialog';
 import { FeedbackModal } from '@renderer/lib/components/feedback-modal/feedback-modal';
@@ -39,5 +41,7 @@ export const modalRegistry = {
   deleteSessionModal: createModal(DeleteSessionModal, { size: 'sm' }),
   addServerModal: createModal(AddServerModal, { size: 'md' }),
   assignServerModal: createModal(AssignServerModal, { size: 'sm' }),
+  renameServerModal: createModal(RenameServerModal, { size: 'xs' }),
+  deleteServerModal: createModal(DeleteServerModal, { size: 'sm' }),
   // oxlint-disable-next-line typescript/no-explicit-any
 } satisfies Record<string, ModalRegistryEntry<any, any>>;

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/AddServerModal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/AddServerModal.tsx
@@ -595,7 +595,9 @@ const ExternalServerStep = observer(function ExternalServerStep({
   const trimmedApi = apiUrl.trim();
   const gatewayValid = looksLikeUrl(trimmedGateway);
   const apiValid = looksLikeUrl(trimmedApi);
-  const isValid = trimmedName.length > 0 && gatewayValid && apiValid;
+  // In edit mode the name is owned by the separate Rename action, so this form
+  // only edits the URLs — the name field isn't shown and isn't required.
+  const isValid = (isEdit || trimmedName.length > 0) && gatewayValid && apiValid;
 
   const gatewayMessage =
     trimmedGateway.length > 0 && !gatewayValid
@@ -637,25 +639,28 @@ const ExternalServerStep = observer(function ExternalServerStep({
   return (
     <>
       <DialogHeader showCloseButton={false}>
-        <DialogTitle>{isEdit ? 'Edit Switch server' : 'Connect to an existing server'}</DialogTitle>
+        <DialogTitle>{isEdit ? 'Edit connection' : 'Connect to an existing server'}</DialogTitle>
       </DialogHeader>
       <DialogContentArea className="pt-0">
         <FieldGroup>
-          <Field>
-            <FieldLabel>Name</FieldLabel>
-            <Input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Pilot"
-              autoFocus
-            />
-          </Field>
+          {!isEdit && (
+            <Field>
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Pilot"
+                autoFocus
+              />
+            </Field>
+          )}
           <Field>
             <FieldLabel>Gateway URL</FieldLabel>
             <Input
               value={gatewayUrl}
               onChange={(e) => setGatewayUrl(e.target.value)}
               placeholder="https://switch-gateway.example.com"
+              autoFocus={isEdit}
             />
             {gatewayMessage && <p className="text-destructive mt-1 text-xs">{gatewayMessage}</p>}
           </Field>

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/DeleteServerModal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/DeleteServerModal.tsx
@@ -1,0 +1,152 @@
+import { TriangleAlert } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import { useCallback, useEffect, useState } from 'react';
+import { agentsStore } from '@renderer/features/locations/stores/agents-store';
+import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
+import { Button } from '@renderer/lib/ui/button';
+import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
+import {
+  DialogContentArea,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/lib/ui/dialog';
+import { Field, FieldGroup, FieldLabel } from '@renderer/lib/ui/field';
+import { Input } from '@renderer/lib/ui/input';
+import { switchServersStore } from './switch-servers-store';
+
+type DeleteServerModalArgs = {
+  serverId: string;
+};
+
+type Props = BaseModalProps<void> & DeleteServerModalArgs;
+
+function countLinkedAgents(serverId: string): number {
+  let count = 0;
+  for (const agents of agentsStore.byLocation.values()) {
+    count += agents.filter((a) => a.serverId === serverId).length;
+  }
+  return count;
+}
+
+export const DeleteServerModal = observer(function DeleteServerModal({
+  serverId,
+  onSuccess,
+  onClose,
+}: Props) {
+  const server = switchServersStore.servers.find((s) => s.id === serverId);
+  const [linkedAgents, setLinkedAgents] = useState(() => countLinkedAgents(serverId));
+  const [confirmText, setConfirmText] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void agentsStore.load().then(() => setLinkedAgents(countLinkedAgents(serverId)));
+  }, [serverId]);
+
+  const managed = server?.managed ?? false;
+  // Managed delete tears down real infrastructure and data, so guard it with a
+  // type-the-name confirmation. External delete is a reversible de-register.
+  const needsTypeConfirm = managed;
+  const typeConfirmed = !needsTypeConfirm || confirmText.trim() === (server?.name ?? '').trim();
+
+  const handleDelete = useCallback(async () => {
+    if (!server || !typeConfirmed) return;
+    setIsDeleting(true);
+    setError(null);
+    const ok = await switchServersStore.deleteServer(serverId);
+    if (ok) {
+      onSuccess();
+    } else {
+      setError(switchServersStore.error ?? 'Failed to delete server.');
+      setIsDeleting(false);
+    }
+  }, [server, typeConfirmed, serverId, onSuccess]);
+
+  if (!server) {
+    return (
+      <>
+        <DialogHeader showCloseButton={false}>
+          <DialogTitle>Delete server</DialogTitle>
+        </DialogHeader>
+        <DialogContentArea className="pt-0">
+          <p className="text-sm text-foreground-muted">This server is no longer available.</p>
+        </DialogContentArea>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </>
+    );
+  }
+
+  const agentsNote =
+    linkedAgents === 0
+      ? 'No agents are linked to it.'
+      : `${linkedAgents} linked ${linkedAgents === 1 ? 'agent' : 'agents'} will be unlinked but kept — you can re-link them to another server.`;
+
+  return (
+    <>
+      <DialogHeader showCloseButton={false}>
+        <div className="flex items-center gap-2">
+          <TriangleAlert className="size-4 text-red-500" />
+          <DialogTitle>Delete “{server.name}”?</DialogTitle>
+        </div>
+      </DialogHeader>
+      <DialogContentArea className="space-y-3 pt-0">
+        {managed ? (
+          <p className="text-sm text-foreground-muted">
+            This permanently tears down the managed stack{' '}
+            {server.managementKind === 'remote' && server.sshHost
+              ? `on ${server.sshHost}`
+              : 'on this computer'}{' '}
+            — its containers, <strong className="text-foreground">all data and secrets</strong> —
+            and removes it from switchdash. This can’t be undone.
+          </p>
+        ) : (
+          <p className="text-sm text-foreground-muted">
+            This removes the server from switchdash. The server itself isn’t touched — you can add
+            it again later.
+          </p>
+        )}
+        <p className="text-sm text-foreground-muted">{agentsNote}</p>
+
+        {needsTypeConfirm && (
+          <FieldGroup>
+            <Field>
+              <FieldLabel>
+                Type <span className="font-medium text-foreground">{server.name}</span> to confirm
+              </FieldLabel>
+              <Input
+                value={confirmText}
+                onChange={(e) => {
+                  setConfirmText(e.target.value);
+                  setError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && typeConfirmed) void handleDelete();
+                }}
+                autoFocus
+              />
+            </Field>
+          </FieldGroup>
+        )}
+
+        {error && <p className="text-destructive text-xs">{error}</p>}
+      </DialogContentArea>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <ConfirmButton
+          variant="destructive"
+          onClick={() => void handleDelete()}
+          disabled={!typeConfirmed || isDeleting}
+        >
+          {isDeleting ? 'Deleting…' : 'Delete server'}
+        </ConfirmButton>
+      </DialogFooter>
+    </>
+  );
+});

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/RenameServerModal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/RenameServerModal.tsx
@@ -1,0 +1,88 @@
+import { observer } from 'mobx-react-lite';
+import { useCallback, useState } from 'react';
+import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
+import { Button } from '@renderer/lib/ui/button';
+import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
+import {
+  DialogContentArea,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/lib/ui/dialog';
+import { Field, FieldGroup, FieldLabel } from '@renderer/lib/ui/field';
+import { Input } from '@renderer/lib/ui/input';
+import { switchServersStore } from './switch-servers-store';
+
+type RenameServerModalArgs = {
+  serverId: string;
+  currentName: string;
+};
+
+type Props = BaseModalProps<void> & RenameServerModalArgs;
+
+export const RenameServerModal = observer(function RenameServerModal({
+  serverId,
+  currentName,
+  onSuccess,
+  onClose,
+}: Props) {
+  const [name, setName] = useState(currentName);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = name.trim();
+  const isEmpty = trimmed.length === 0;
+  const isUnchanged = trimmed === currentName.trim();
+  const isValid = !isEmpty && !isUnchanged;
+
+  const handleSubmit = useCallback(async () => {
+    if (!isValid) return;
+    setIsSubmitting(true);
+    setError(null);
+    const ok = await switchServersStore.renameServer(serverId, trimmed);
+    if (ok) {
+      onSuccess();
+    } else {
+      setError(switchServersStore.error ?? 'Failed to rename server.');
+      setIsSubmitting(false);
+    }
+  }, [isValid, serverId, trimmed, onSuccess]);
+
+  return (
+    <>
+      <DialogHeader showCloseButton={false}>
+        <DialogTitle>Rename server</DialogTitle>
+      </DialogHeader>
+      <DialogContentArea className="pt-0">
+        <FieldGroup>
+          <Field>
+            <FieldLabel>Server name</FieldLabel>
+            <Input
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void handleSubmit();
+              }}
+              autoFocus
+            />
+            {isEmpty && !isUnchanged && (
+              <p className="text-destructive mt-1 text-xs">Server name cannot be empty.</p>
+            )}
+            {error && <p className="text-destructive mt-1 text-xs">{error}</p>}
+          </Field>
+        </FieldGroup>
+      </DialogContentArea>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <ConfirmButton onClick={() => void handleSubmit()} disabled={!isValid || isSubmitting}>
+          {isSubmitting ? 'Renaming…' : 'Rename'}
+        </ConfirmButton>
+      </DialogFooter>
+    </>
+  );
+});

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -1,6 +1,7 @@
 import {
   ChevronDown,
   ChevronRight,
+  ExternalLink,
   Globe,
   HardDrive,
   Pencil,
@@ -168,6 +169,7 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
   const { params } = useParams('server');
   const showRenameServerModal = useShowModal('renameServerModal');
   const showDeleteServerModal = useShowModal('deleteServerModal');
+  const showEditServerModal = useShowModal('addServerModal');
 
   const server = store.servers.find((s) => s.id === serverId);
   if (!server) return null;
@@ -243,6 +245,21 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
           <Pencil className="size-4" />
           Rename…
         </ContextMenuItem>
+        {!server.managed && (
+          <ContextMenuItem
+            onClick={() =>
+              showEditServerModal({
+                serverId,
+                initialName: server.name,
+                initialGatewayUrl: server.gatewayUrl,
+                initialApiUrl: server.apiUrl,
+              })
+            }
+          >
+            <ExternalLink className="size-4" />
+            Edit connection…
+          </ContextMenuItem>
+        )}
         <ContextMenuItem
           variant="destructive"
           onClick={() =>

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -1,4 +1,13 @@
-import { ChevronDown, ChevronRight, Globe, HardDrive, Plus, Server } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Globe,
+  HardDrive,
+  Pencil,
+  Plus,
+  Server,
+  Trash2,
+} from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useEffect } from 'react';
 import {
@@ -9,6 +18,12 @@ import {
 } from '@renderer/lib/layout/navigation-provider';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { buttonVariants } from '@renderer/lib/ui/button';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@renderer/lib/ui/context-menu';
 import { MicroLabel } from '@renderer/lib/ui/label';
 import { Spinner } from '@renderer/lib/ui/spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
@@ -151,6 +166,8 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
   const { navigate } = useNavigate();
   const { currentView } = useWorkspaceSlots();
   const { params } = useParams('server');
+  const showRenameServerModal = useShowModal('renameServerModal');
+  const showDeleteServerModal = useShowModal('deleteServerModal');
 
   const server = store.servers.find((s) => s.id === serverId);
   if (!server) return null;
@@ -172,45 +189,75 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
   const needsSignIn = !dormant && !connected;
 
   return (
-    <SidebarMenuButton
-      isActive={isViewing}
-      onClick={() => {
-        void store.setActive(serverId);
-        navigate('server', { serverId });
-      }}
-      className="justify-between"
-    >
-      <span className="flex min-w-0 items-center gap-2">
-        <ServerIcon server={server} isScoped={isScoped} />
-        <span className={cn('truncate', isScoped && 'font-medium text-foreground')}>
-          {server.name}
-        </span>
-        {server.managed && (
-          <span className="shrink-0 rounded bg-background-tertiary px-1 py-px text-[10px] font-medium tracking-wide text-foreground-muted uppercase">
-            {server.managementKind === 'remote' ? (server.sshHost ?? 'Remote') : 'This computer'}
-          </span>
-        )}
-        <span
-          aria-hidden
-          className={cn(
-            'size-1.5 shrink-0 rounded-full',
-            dormant ? 'bg-foreground-muted' : connected ? 'bg-green-500' : 'bg-amber-500'
-          )}
-        />
-      </span>
-      {needsSignIn && (
-        <span
-          role="button"
-          tabIndex={0}
-          onClick={(e) => {
-            e.stopPropagation();
-            navigate('server', { serverId });
-          }}
-          className="shrink-0 rounded border border-red-500/40 px-1.5 py-0.5 text-xs font-medium text-red-500 hover:bg-red-500/10"
+    <ContextMenu>
+      <ContextMenuTrigger
+        render={
+          <SidebarMenuButton
+            isActive={isViewing}
+            onClick={() => {
+              void store.setActive(serverId);
+              navigate('server', { serverId });
+            }}
+            className="justify-between"
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <ServerIcon server={server} isScoped={isScoped} />
+              <span className={cn('truncate', isScoped && 'font-medium text-foreground')}>
+                {server.name}
+              </span>
+              {server.managed && (
+                <span className="shrink-0 rounded bg-background-tertiary px-1 py-px text-[10px] font-medium tracking-wide text-foreground-muted uppercase">
+                  {server.managementKind === 'remote'
+                    ? (server.sshHost ?? 'Remote')
+                    : 'This computer'}
+                </span>
+              )}
+              <span
+                aria-hidden
+                className={cn(
+                  'size-1.5 shrink-0 rounded-full',
+                  dormant ? 'bg-foreground-muted' : connected ? 'bg-green-500' : 'bg-amber-500'
+                )}
+              />
+            </span>
+            {needsSignIn && (
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigate('server', { serverId });
+                }}
+                className="shrink-0 rounded border border-red-500/40 px-1.5 py-0.5 text-xs font-medium text-red-500 hover:bg-red-500/10"
+              >
+                Sign in
+              </span>
+            )}
+          </SidebarMenuButton>
+        }
+      />
+      <ContextMenuContent>
+        <ContextMenuItem
+          onClick={() => showRenameServerModal({ serverId, currentName: server.name })}
         >
-          Sign in
-        </span>
-      )}
-    </SidebarMenuButton>
+          <Pencil className="size-4" />
+          Rename…
+        </ContextMenuItem>
+        <ContextMenuItem
+          variant="destructive"
+          onClick={() =>
+            showDeleteServerModal({
+              serverId,
+              onSuccess: () => {
+                if (isViewing) navigate('home');
+              },
+            })
+          }
+        >
+          <Trash2 className="size-4" />
+          Delete server…
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 });

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -166,6 +166,48 @@ export class SwitchServersStore {
     }
   }
 
+  async renameServer(id: string, name: string): Promise<boolean> {
+    this.clearError();
+    try {
+      await rpc.switchServers.renameServer({ id, name });
+      const servers = await rpc.switchServers.listServers();
+      runInAction(() => {
+        this.servers = servers;
+      });
+      return true;
+    } catch (cause) {
+      this.setError(cause);
+      return false;
+    }
+  }
+
+  /**
+   * Delete a server. For a managed server this first tears down its stack (the
+   * Docker/SSH reset — stops containers and destroys the stack's data), since
+   * removing the record while the stack keeps running would strand it. External
+   * servers have no stack, so this is a plain de-register. In both cases the
+   * server's agents are unlinked but kept (see {@link removeServer}), never
+   * deleted. Returns false if the teardown or de-register failed.
+   */
+  async deleteServer(serverId: string): Promise<boolean> {
+    this.clearError();
+    const server = this.servers.find((s) => s.id === serverId);
+    try {
+      if (server?.managed) {
+        if (server.managementKind === 'remote' && server.sshHost) {
+          await rpc.remoteSwitchServer.reset(server.sshHost);
+        } else {
+          await rpc.localSwitchServer.reset();
+        }
+      }
+    } catch (cause) {
+      this.setError(cause);
+      return false;
+    }
+    await this.removeServer(serverId);
+    return this.error === null;
+  }
+
   async removeServer(serverId: string): Promise<void> {
     this.clearError();
     try {

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
@@ -1,14 +1,21 @@
-import { ExternalLink, Pencil, RefreshCw } from 'lucide-react';
+import { ExternalLink, MoreVertical, Pencil, RefreshCw, Trash2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useEffect, useState } from 'react';
 import { type GuardResult, type ViewDefinition } from '@renderer/app/view-registry';
 import { Titlebar } from '@renderer/lib/components/titlebar/Titlebar';
 import { rpc } from '@renderer/lib/ipc';
-import { useParams } from '@renderer/lib/layout/navigation-provider';
+import { useNavigate, useParams } from '@renderer/lib/layout/navigation-provider';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { Alert, AlertDescription, AlertTitle } from '@renderer/lib/ui/alert';
 import { Badge } from '@renderer/lib/ui/badge';
 import { Button } from '@renderer/lib/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@renderer/lib/ui/dropdown-menu';
 import { Input } from '@renderer/lib/ui/input';
 import { Label } from '@renderer/lib/ui/label';
 import { Spinner } from '@renderer/lib/ui/spinner';
@@ -60,6 +67,9 @@ const ServerMainPanel = observer(function ServerMainPanel() {
   const store = switchServersStore;
   const server = store.servers.find((s) => s.id === serverId);
   const showEditServerModal = useShowModal('addServerModal');
+  const showRenameServerModal = useShowModal('renameServerModal');
+  const showDeleteServerModal = useShowModal('deleteServerModal');
+  const { navigate } = useNavigate();
 
   // A managed server that isn't running has no gateway to reach — its
   // connection status, sign-in, and web-app links are meaningless until it's up,
@@ -100,24 +110,53 @@ const ServerMainPanel = observer(function ServerMainPanel() {
               API: {server.apiUrl}
             </p>
           </div>
-          {!server.managed && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="shrink-0"
-              onClick={() =>
-                showEditServerModal({
-                  serverId,
-                  initialName: server.name,
-                  initialGatewayUrl: server.gatewayUrl,
-                  initialApiUrl: server.apiUrl,
-                })
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  className="shrink-0"
+                  aria-label="Server actions"
+                >
+                  <MoreVertical className="size-4" />
+                </Button>
               }
-            >
-              <Pencil className="size-3.5" />
-              Edit
-            </Button>
-          )}
+            />
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => showRenameServerModal({ serverId, currentName: server.name })}
+              >
+                <Pencil className="size-4" />
+                Rename…
+              </DropdownMenuItem>
+              {!server.managed && (
+                <DropdownMenuItem
+                  onClick={() =>
+                    showEditServerModal({
+                      serverId,
+                      initialName: server.name,
+                      initialGatewayUrl: server.gatewayUrl,
+                      initialApiUrl: server.apiUrl,
+                    })
+                  }
+                >
+                  <ExternalLink className="size-4" />
+                  Edit connection…
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={() =>
+                  showDeleteServerModal({ serverId, onSuccess: () => navigate('home') })
+                }
+              >
+                <Trash2 className="size-4" />
+                Delete server…
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </header>
 
         {store.error && (

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
@@ -51,6 +51,13 @@ export type UpdateServerParams = {
   apiUrl: string;
 };
 
+/** Rename a server (display name only). Works for managed and external servers;
+ * URLs and managed metadata are untouched. */
+export type RenameServerParams = {
+  id: string;
+  name: string;
+};
+
 /**
  * What happened to one agent when a server's API URL was cascaded to its
  * members. `updated` — the agent's `SWITCH_API_ENDPOINT` was rewritten.


### PR DESCRIPTION
## What & why

CHOO-1486 — https://sandboxquantum.atlassian.net/browse/CHOO-1486

Lets users **delete** a connected server and **rename** it (name only) in switchdash, for both **managed** servers (local/remote) and **external/remote** servers. Both actions are reachable from the sidebar (right-click a server) and the server detail header (⋯ menu).

## Behaviour (decisions confirmed with the steering dev)

- **Rename (name only)** — works for managed and external servers; URLs and managed metadata are untouched.
  - Fixes a latent bug: the local managed stack re-wrote its name from a hardcoded constant on every restart, so a rename wouldn't stick. `ensureManagedServer` now **preserves the stored name** on restart and only refreshes URLs/kind (ports can change).
- **Delete**
  - **External** → de-register only (existing `removeServer`).
  - **Managed** → tear down the Docker/SSH stack (full teardown: stop containers + destroy the stack's data/secrets) **then** de-register. Leaving the record while the stack keeps running — or leaving orphaned volumes for a server no longer in switchdash — would be dead, unreachable state.
  - **Agents of a deleted server are unlinked but kept** (`serverId → null`), never deleted — so they can be re-linked to another server.
- **Guardrails** — delete confirmation names the server and how many linked agents will be unlinked; **managed** delete additionally requires typing the server name to confirm (destructive teardown).

## Changes

- **Backend**: `RenameServerParams` type; `renameServer` in the servers store + controller; `ensureManagedServer` name-preservation.
- **Renderer store**: `renameServer` + `deleteServer` (managed teardown → de-register) on `switchServersStore`.
- **UI**: `RenameServerModal`, `DeleteServerModal` (linked-agent count + type-to-confirm for managed), registered in the modal registry; right-click context menu on the sidebar server entry; ⋯ actions menu in the detail header (keeps external "Edit connection" for URLs).
- **Tests**: `servers-store.db.test.ts` — rename (name-only + unknown-id throw), the managed name-preservation regression, and delete-unlinks-agents/clears-active-pointer.

## Verification

`pnpm run format:check`, `pnpm run typecheck`, `pnpm run lint`, and the `node` + `main-db` test projects (1218 tests) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)