### PR TITLE
feat(switchdash): sidebar & session UX polish (CHOO-1644)

### DIFF
--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/location-titlebar.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/location-titlebar.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Ellipsis, Trash2 } from 'lucide-react';
+import { ChevronDown, Ellipsis, Server, Trash2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useConfirmDeleteAgent } from '@renderer/features/locations/hooks/use-confirm-delete-agent';
 import {
@@ -16,6 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@renderer/lib/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 
 const MountedLocationTitlebarLeft = observer(function LocationTitlebarLeft({
   locationId,
@@ -74,6 +75,31 @@ const LocationTitlebarLeft = observer(function LocationTitlebarLeft({
   );
 });
 
+/**
+ * Read-only display of a remote agent's working directory within its SSH host.
+ * The local titlebar surfaces the path via the "Open in" menu, but that menu is
+ * hidden for remote agents — so their location within the host would otherwise
+ * not be shown anywhere. The full `host:dir` is available in the tooltip.
+ */
+function RemoteLocationPath({ host, dir }: { host: string; dir: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div className="flex h-7 max-w-[280px] items-center gap-1.5 rounded-md border border-border bg-background px-2 text-xs text-foreground-muted">
+            <Server className="size-3.5 shrink-0" />
+            <span className="shrink-0">{host}</span>
+            <span className="truncate text-foreground-tertiary-passive">{dir}</span>
+          </div>
+        }
+      />
+      <TooltipContent side="bottom">
+        {host}:{dir}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 export const LocationTitlebar = observer(function LocationTitlebar() {
   const {
     params: { locationId },
@@ -93,8 +119,10 @@ export const LocationTitlebar = observer(function LocationTitlebar() {
       leftSlot={<MountedLocationTitlebarLeft locationId={locationId} />}
       rightSlot={
         <div className="mr-2 flex items-center gap-2">
-          {mounted.data.sshHost === null && (
+          {mounted.data.sshHost === null ? (
             <OpenInMenu path={mounted.data.dir} className="h-7 bg-background" />
+          ) : (
+            <RemoteLocationPath host={mounted.data.sshHost} dir={mounted.data.dir} />
           )}
         </div>
       }

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/location-item.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/location-item.tsx
@@ -216,7 +216,10 @@ export const SidebarLocationItem = observer(function SidebarLocationItem({
                     <TooltipTrigger>
                       <Server className="h-3.5 w-3.5 shrink-0 text-foreground-muted" />
                     </TooltipTrigger>
-                    <TooltipContent>Runs remotely on {location.data.sshHost}</TooltipContent>
+                    <TooltipContent>
+                      Runs remotely on {location.data.sshHost}
+                      {location.data.dir ? ` · ${location.data.dir}` : ''}
+                    </TooltipContent>
                   </Tooltip>
                 )}
                 {locationViewKind(location) === 'path_not_found' && (

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/locations-group-label.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/locations-group-label.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from '@renderer/lib/ui/dropdown-menu';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
+import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
 import type { AgentConnectionKind } from '@shared/core/agents/agent-connection';
@@ -38,67 +39,34 @@ const GROUPING_OPTIONS: {
   { value: 'room', label: 'Rooms', icon: DoorOpen },
 ];
 
-/** Plain-text title for the active grouping, shown on the left of the header. */
-const GroupingTitle = observer(function GroupingTitle() {
-  const active =
-    GROUPING_OPTIONS.find((opt) => opt.value === sidebarStore.grouping) ?? GROUPING_OPTIONS[0];
-  return <span className="truncate text-sm font-medium">{active.label}</span>;
-});
-
 /**
- * View switcher for the grouped sidebar — an icon button (next to sort/add)
- * that expands into the available groupings (agent-focused / room-focused).
+ * View switcher for the grouped sidebar — a segmented control that shows both
+ * groupings (Agents / Rooms) side by side, with the active one highlighted, so
+ * the choice is discoverable at a glance rather than hidden behind an icon menu.
  * Observer-wrapped so the active selection updates reactively.
  */
-const ViewGroupingDropdown = observer(function ViewGroupingDropdown() {
-  const active =
-    GROUPING_OPTIONS.find((opt) => opt.value === sidebarStore.grouping) ?? GROUPING_OPTIONS[0];
-  const ActiveIcon = active.icon;
+const ViewGroupingToggle = observer(function ViewGroupingToggle() {
   return (
-    <DropdownMenu>
-      <Tooltip>
-        <DropdownMenuTrigger
-          render={
-            <TooltipTrigger
-              render={
-                <button
-                  type="button"
-                  aria-label="Group sidebar by"
-                  className={buttonVariants({
-                    size: 'icon-xs',
-                    variant: 'ghost',
-                    className: 'hover:bg-transparent text-foreground-muted hover:text-foreground',
-                  })}
-                >
-                  <ActiveIcon />
-                </button>
-              }
-            />
-          }
-        />
-        <TooltipContent>Group by</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent className="min-w-44" align="end">
-        <DropdownMenuGroup>
-          <DropdownMenuLabel>Group by</DropdownMenuLabel>
-          <DropdownMenuRadioGroup value={sidebarStore.grouping}>
-            {GROUPING_OPTIONS.map((opt) => {
-              const OptIcon = opt.icon;
-              return (
-                <DropdownMenuRadioItem
-                  key={opt.value}
-                  value={opt.value}
-                  onClick={() => sidebarStore.setGrouping(opt.value)}
-                >
-                  <OptIcon className="mr-1.5 h-4 w-4" />
-                  {opt.label}
-                </DropdownMenuRadioItem>
-              );
-            })}
-          </DropdownMenuRadioGroup>
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <ToggleGroup
+      size="sm"
+      multiple={false}
+      value={[sidebarStore.grouping]}
+      onValueChange={([value]) => {
+        const opt = GROUPING_OPTIONS.find((o) => o.value === value);
+        if (opt) sidebarStore.setGrouping(opt.value);
+      }}
+      aria-label="Group sidebar by"
+    >
+      {GROUPING_OPTIONS.map((opt) => {
+        const OptIcon = opt.icon;
+        return (
+          <ToggleGroupItem key={opt.value} value={opt.value} aria-label={opt.label}>
+            <OptIcon className="mr-1 h-3.5 w-3.5" />
+            {opt.label}
+          </ToggleGroupItem>
+        );
+      })}
+    </ToggleGroup>
   );
 });
 
@@ -209,10 +177,9 @@ export const LocationsGroupLabel = observer(function LocationsGroupLabel() {
   const showAddLocationModal = useShowModal('addAgentModal');
 
   return (
-    <div className="flex h-[40px] items-center justify-between pr-2.5 pl-5">
-      <GroupingTitle />
+    <div className="flex h-[40px] items-center justify-between pr-2.5 pl-2.5">
+      <ViewGroupingToggle />
       <div className="flex items-center gap-1">
-        <ViewGroupingDropdown />
         <DropdownMenu>
           <Tooltip>
             <DropdownMenuTrigger

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/session-item.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/session-item.tsx
@@ -1,5 +1,6 @@
 import { MessageSquare } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import { useEffect, useRef } from 'react';
 import { SessionContextMenu } from '@renderer/features/sessions/components/session-context-menu';
 import {
   getSessionManagerStore,
@@ -12,6 +13,7 @@ import {
   useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { sidebarStore } from '@renderer/lib/stores/app-state';
 import { cn } from '@renderer/utils/utils';
 import { useAppSettingsKey } from '../settings/use-app-settings-key';
 import { SidebarMenuAction, SidebarMenuRow } from './sidebar-primitives';
@@ -42,6 +44,17 @@ export const SidebarSessionItem = observer(function SidebarSessionItem({
   const { value: interfaceSettings } = useAppSettingsKey('interface');
   const isActive =
     currentView === 'session' && params.sessionId === sessionId && params.locationId === locationId;
+
+  // A deeplink reveal expands the tree and asks this session's row to center
+  // itself; reading the flag in render (not just the effect) lets the row react
+  // whether it was already mounted or only just appeared after the expand.
+  const rowRef = useRef<HTMLDivElement>(null);
+  const shouldScrollIntoView = sidebarStore.pendingScrollSessionId === sessionId;
+  useEffect(() => {
+    if (!shouldScrollIntoView) return;
+    rowRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    sidebarStore.clearPendingScroll();
+  }, [shouldScrollIntoView]);
 
   const session = getSessionStore(locationId, sessionId)!;
   const sessionManager = getSessionManagerStore(locationId);
@@ -93,6 +106,7 @@ export const SidebarSessionItem = observer(function SidebarSessionItem({
       onDelete={handleDelete}
     >
       <SidebarMenuRow
+        ref={rowRef}
         className={cn(
           'group/row flex items-center justify-between px-1 h-8 gap-1',
           rowVariant === 'pinned' && 'pl-2'

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-grouped-list.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-grouped-list.tsx
@@ -19,7 +19,7 @@ import {
   RoomRow,
   roomLabel,
 } from './sidebar-room-grouping';
-import { agentRoomGroupKey, roomViewGroupKey, UNASSIGNED_ROOM_KEY } from './sidebar-store';
+import { agentRoomGroupKey, roomViewGroupKey } from './sidebar-store';
 import { SidebarSubagentList } from './sidebar-subagent-list';
 
 /** dnd container ids. Each identifies a reorderable sibling set. */
@@ -84,7 +84,7 @@ const AgentFocusedTree = observer(function AgentFocusedTree() {
       true
     );
     containers[container] = ordered.map((session) => session.data.id);
-    const depth = roomKey === UNASSIGNED_ROOM_KEY ? 1 : 2;
+    const depth = 2;
     return (
       <SortableContext
         items={ordered.map((session) => makeDndId(container, session.data.id))}
@@ -121,16 +121,6 @@ const AgentFocusedTree = observer(function AgentFocusedTree() {
               {/* The agent's own rooms/sessions come first, then its subagents. */}
               {expanded &&
                 grouped.map(([roomKey, roomSessions]) => {
-                  // Sessions with no room sit at the same depth as the agent's
-                  // room rows (and subagent rows) — they are direct children of
-                  // the agent, just without a room header above them.
-                  if (roomKey === UNASSIGNED_ROOM_KEY) {
-                    return (
-                      <Fragment key={roomKey}>
-                        {renderSessionGroup(locationId, roomKey, roomSessions)}
-                      </Fragment>
-                    );
-                  }
                   const groupKey = agentRoomGroupKey(locationId, roomKey);
                   const roomExpanded = sidebarStore.isGroupExpanded(groupKey);
                   return (

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -161,6 +161,17 @@ describe('SidebarStore grouping', () => {
     expect(store.isGroupExpanded(roomViewGroupKey('room-1'))).toBe(true);
   });
 
+  it('tracks and clears a pending scroll-to-session request', () => {
+    const store = new SidebarStore(locationManager([]));
+    expect(store.pendingScrollSessionId).toBeNull();
+
+    store.requestScrollToSession('session-1');
+    expect(store.pendingScrollSessionId).toBe('session-1');
+
+    store.clearPendingScroll();
+    expect(store.pendingScrollSessionId).toBeNull();
+  });
+
   it("returns a location's visible sessions for grouped views", () => {
     const store = new SidebarStore(
       locationManagerWithSessions([

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
@@ -131,6 +131,12 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
   filterConnections = observable.set<AgentConnectionKind>();
   filterProviderIds = observable.set<AgentProviderId>();
   filterHasLiveSession = false;
+  /**
+   * Session whose row should scroll itself into view once it mounts. Set by the
+   * deeplink handler (after revealing/expanding the tree) so the landed session
+   * is centered in the sidebar; the row clears it after scrolling.
+   */
+  pendingScrollSessionId: string | null = null;
 
   constructor(private readonly locationManager: LocationManagerStore) {
     makeAutoObservable(this, {
@@ -515,6 +521,16 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
     this.ensureLocationExpanded(locationId);
     this.ensureGroupExpanded(agentRoomGroupKey(locationId, roomId));
     this.ensureGroupExpanded(roomViewGroupKey(roomId));
+  }
+
+  /** Ask the given session's sidebar row to scroll itself into view when it renders. */
+  requestScrollToSession(sessionId: string): void {
+    this.pendingScrollSessionId = sessionId;
+  }
+
+  /** Clear the pending scroll request (called by the row once it has scrolled). */
+  clearPendingScroll(): void {
+    this.pendingScrollSessionId = null;
   }
 
   /** Set the sort key and clear all manual session orders so the list fully re-sorts. */

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-rooms/session-deeplink-listener.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-rooms/session-deeplink-listener.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { toast } from 'sonner';
 import { agentsStore } from '@renderer/features/locations/stores/agents-store';
 import { getLocationManagerStore } from '@renderer/features/locations/stores/location-selectors';
 import { getSessionManagerStore } from '@renderer/features/sessions/stores/session-selectors';
@@ -71,6 +72,10 @@ export function SessionDeeplinkListener(): null {
             agentId,
             server,
           });
+          toast.error('No agent session found for this link', {
+            description:
+              'This switchdash has no local session for the linked room. Open it on the client running that agent.',
+          });
           return;
         }
         // Scope the sidebar to the session's server first; otherwise its location
@@ -87,6 +92,7 @@ export function SessionDeeplinkListener(): null {
         const serverId = agentsStore.serverIdForLocation(match.locationId);
         if (serverId) await switchServersStore.setActive(serverId);
         sidebarStore.revealSessionInRoom(match.locationId, roomId);
+        sidebarStore.requestScrollToSession(match.sessionId);
         appState.navigation.navigate('session', match);
       })();
     });

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -216,7 +216,7 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
             {isScoped && (
               <span
                 aria-hidden
-                className="absolute top-1/2 left-0 h-4 w-0.5 -translate-y-1/2 rounded-full bg-accent"
+                className="bg-accent absolute top-1/2 left-0 h-4 w-0.5 -translate-y-1/2 rounded-full"
               />
             )}
             <span className="flex min-w-0 items-center gap-2">

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -58,6 +58,10 @@ export const ServersSidebarSection = observer(function ServersSidebarSection() {
   // Offer to start a local server whenever there isn't one already, even if the
   // user has remote servers registered.
   const hasManagedServer = store.servers.some((s) => s.managed);
+  // The selected server scopes the whole sidebar. When the list is collapsed the
+  // rows are hidden, so surface the active server's name here to keep it clear
+  // which server is selected in any context.
+  const activeServer = store.servers.find((s) => s.id === store.activeServerId);
 
   return (
     <div className="flex flex-col">
@@ -65,15 +69,20 @@ export const ServersSidebarSection = observer(function ServersSidebarSection() {
         <button
           type="button"
           onClick={() => store.toggleServersExpanded()}
-          className="flex items-center gap-1 rounded-md px-1 py-0.5 text-foreground-tertiary-passive hover:text-foreground-tertiary"
+          className="flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5 text-foreground-tertiary-passive hover:text-foreground-tertiary"
           aria-label={store.serversExpanded ? 'Collapse servers' : 'Expand servers'}
         >
           {store.serversExpanded ? (
-            <ChevronDown className="size-3.5" />
+            <ChevronDown className="size-3.5 shrink-0" />
           ) : (
-            <ChevronRight className="size-3.5" />
+            <ChevronRight className="size-3.5 shrink-0" />
           )}
           <MicroLabel className="text-foreground-tertiary-passive">Servers</MicroLabel>
+          {!store.serversExpanded && activeServer && (
+            <span className="min-w-0 truncate text-xs font-medium text-foreground-muted">
+              · {activeServer.name}
+            </span>
+          )}
         </button>
         <Tooltip>
           <TooltipTrigger
@@ -177,7 +186,9 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
   const connected = store.isConnected(serverId);
   const isViewing = isCurrentView(currentView, 'server') && params.serverId === serverId;
   // The active server scopes the whole sidebar (agents/rooms/sessions). Selecting
-  // a server makes it active and opens its page.
+  // a server makes it active and opens its page. The scoped server stays
+  // highlighted regardless of which view is open — navigating to an agent,
+  // session, or room must not clear the "this server is selected" affordance.
   const isScoped = store.activeServerId === serverId;
 
   // A managed server that isn't running has no gateway to reach, so it can't be
@@ -195,13 +206,19 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
       <ContextMenuTrigger
         render={
           <SidebarMenuButton
-            isActive={isViewing}
+            isActive={isScoped}
             onClick={() => {
               void store.setActive(serverId);
               navigate('server', { serverId });
             }}
-            className="justify-between"
+            className="relative justify-between"
           >
+            {isScoped && (
+              <span
+                aria-hidden
+                className="absolute top-1/2 left-0 h-4 w-0.5 -translate-y-1/2 rounded-full bg-accent"
+              />
+            )}
             <span className="flex min-w-0 items-center gap-2">
               <ServerIcon server={server} isScoped={isScoped} />
               <span className={cn('truncate', isScoped && 'font-medium text-foreground')}>


### PR DESCRIPTION
Batch of 5 switchdash sidebar / session UX-polish items for CHOO-1644.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-1644

## Changes

1. **Deeplink open — center the sidebar + no-session feedback.** Opening a session deeplink expanded the tree but never scrolled to the landed session, and a link with no matching local session did nothing visible. Added a pending scroll-to-session request that the session row honors via `scrollIntoView({ block: 'center' })` once it mounts (handles the row not existing until the expand), and a toast when no local session matches the link.
2. **Agents / Rooms views made obvious.** Replaced the icon-only grouping dropdown (which showed just the active view's icon) with a visible segmented control showing both "Agents" and "Rooms" side by side, active one highlighted.
3. **Remote agent path within host restored.** The titlebar surfaced the working directory only for local agents (via the Open-in menu); remote agents showed no path. Added a read-only `host:path` chip in the titlebar for remote agents, and included the path in the sidebar remote tooltip.
4. **Agent view "Unassigned room" header.** The Agent view rendered roomless sessions bare at depth 1 with no header, unlike the Room view. It now renders the same collapsible "Unassigned" room header, mirroring the Room view.
5. **Selected-server clarity.** The server row highlight tracked "viewing the server page", so navigating to an agent/session/room cleared it even though that server still scopes the sidebar. Highlight is now driven by the scoped (active) server, with an accent-bar marker, and the active server name is surfaced in the collapsed "Servers" header so the selection is clear in any context.

## Testing

- `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck` — clean
- `pnpm run test` — 1239 passed (added a sidebar-store test for the pending-scroll request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)