### PR TITLE
feat(engagements): room-network engagement provisioner + FlintAI Optimize and Prove preset (CHOO-1177)

### DIFF
--- a/core/switch_core/engagements_yaml.py
+++ b/core/switch_core/engagements_yaml.py
@@ -1,0 +1,279 @@
+"""Declarative provisioning of a multi-room engagement from YAML.
+
+An *engagement* is a room group plus a set of rooms and the directed links
+between them — the reusable shape behind a team's room network (e.g. a
+workforce hub that delegates work out to feature / bug hubs). It builds on the
+single-room provisioning in :mod:`switch_core.rooms_yaml`: each room is a
+:class:`~switch_core.rooms_yaml.RoomSpec` provisioned via
+:meth:`RoomYamlService.provision_room`, filed under a freshly created group,
+then wired together with cross-room links.
+
+Provisioning is preflight-then-group-then-rooms-then-links: agent and bridge
+names are validated across every room up front (fail loud before anything is
+created, so a typo does not leave an orphan group), then the group and rooms
+are created, then links are attached best-effort — per-room attachment
+failures and link failures are collected into the result rather than silently
+dropped.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from pydantic import BaseModel, ValidationError, model_validator
+
+from switch_core.rooms_yaml import ProvisionResult, RoomSpec
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from switch_core.bridges.resource.service import ResourceService
+    from switch_core.db.stores.agent_store import AgentStore
+    from switch_core.db.stores.collaboration_bridge_store import (
+        CollaborationBridgeStore,
+    )
+    from switch_core.db.stores.room_group_store import RoomGroupStore
+    from switch_core.rooms_yaml import RoomYamlService
+
+logger = logging.getLogger(__name__)
+
+
+# ── Spec models ───────────────────────────────────────────────────────────
+
+
+class GroupSpec(BaseModel):
+    """The room group that holds the engagement. ``parent`` names an existing
+    group to nest under (resolved by name); omit for a top-level group."""
+
+    model_config = {"extra": "forbid"}
+    name: str
+    description: str | None = None
+    color: str | None = None
+    parent: str | None = None
+
+
+class EngagementRoomSpec(RoomSpec):
+    """A room in an engagement: a standard :class:`RoomSpec` plus a stable
+    ``key`` used to reference it from ``links``, and the per-room extras the
+    single-room spec does not carry (join-event listeners, agent aliases)."""
+
+    key: str
+    join_event_listeners: list[str] = []
+    aliases: dict[str, str] = {}
+
+
+class LinkSpec(BaseModel):
+    """A directed pointer from one engagement room to another. ``from`` / ``to``
+    are room ``key`` values; ``label`` is the relationship hint shown to
+    participants."""
+
+    model_config = {"extra": "forbid", "populate_by_name": True}
+    from_key: str
+    to_key: str
+    label: str
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_from_to(cls, data: Any) -> Any:
+        # `from` is a Python keyword, so the YAML keys `from`/`to` are mapped
+        # onto `from_key`/`to_key` here rather than via field aliases.
+        if isinstance(data, dict):
+            data = dict(data)
+            if "from" in data:
+                data["from_key"] = data.pop("from")
+            if "to" in data:
+                data["to_key"] = data.pop("to")
+        return data
+
+
+class EngagementSpec(BaseModel):
+    model_config = {"extra": "forbid"}
+    group: GroupSpec
+    rooms: list[EngagementRoomSpec]
+    links: list[LinkSpec] = []
+
+    @model_validator(mode="after")
+    def _validate(self) -> EngagementSpec:
+        if not self.rooms:
+            raise ValueError("engagement must define at least one room")
+        keys = [r.key for r in self.rooms]
+        dupes = sorted({k for k in keys if keys.count(k) > 1})
+        if dupes:
+            raise ValueError(f"duplicate room keys: {', '.join(dupes)}")
+        known = set(keys)
+        for link in self.links:
+            for side, key in (("from", link.from_key), ("to", link.to_key)):
+                if key not in known:
+                    raise ValueError(f"link {side} references unknown room key {key!r}")
+            if link.from_key == link.to_key:
+                raise ValueError(
+                    f"link cannot point a room at itself: {link.from_key!r}"
+                )
+        for room in self.rooms:
+            if room.users and room.bridge is None:
+                raise ValueError(
+                    f"room {room.key!r} attaches users but has no bridge "
+                    "(users live on a collaboration bridge)"
+                )
+        return self
+
+
+class EngagementProvisionResult(BaseModel):
+    group_id: str
+    group_name: str
+    rooms: list[ProvisionResult] = []
+    created_links: list[dict[str, str]] = []
+    failed_links: list[dict[str, str]] = []
+
+
+class EngagementYamlService:
+    """Parse / provision a multi-room engagement as YAML. Free of HTTP concerns
+    so it is unit-testable and reusable for MCP / CLI surfaces. Delegates each
+    room to :class:`RoomYamlService` and only adds the group + links on top."""
+
+    def __init__(
+        self,
+        *,
+        room_yaml: RoomYamlService,
+        room_group_store: RoomGroupStore,
+        resource_service: ResourceService,
+        agent_store: AgentStore,
+        bridge_store: CollaborationBridgeStore,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        self._room_yaml = room_yaml
+        self._groups = room_group_store
+        self._resources = resource_service
+        self._agent_store = agent_store
+        self._bridge_store = bridge_store
+        self._session_factory = session_factory
+
+    # ── Parse ─────────────────────────────────────────────────────────────
+
+    def parse(self, text: str) -> EngagementSpec:
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid YAML: {e}") from e
+        if not isinstance(data, dict) or "engagement" not in data:
+            raise ValueError("YAML must have a single top-level 'engagement:' mapping")
+        try:
+            return EngagementSpec.model_validate(data["engagement"])
+        except ValidationError as e:
+            raise ValueError(f"Invalid engagement spec: {e}") from e
+
+    # ── Provision ─────────────────────────────────────────────────────────
+
+    async def provision(
+        self, spec: EngagementSpec, *, user_id: str, is_admin: bool
+    ) -> EngagementProvisionResult:
+        await self._preflight(spec)
+
+        parent_id = await self._resolve_parent_group_id(spec.group.parent)
+        async with self._session_factory() as session:
+            group = await self._groups.create(
+                session,
+                name=spec.group.name,
+                description=spec.group.description,
+                color=spec.group.color,
+                parent_group_id=parent_id,
+            )
+            await session.commit()
+            group_id, group_name = group.id, group.name
+
+        key_to_room_id: dict[str, str] = {}
+        room_results: list[ProvisionResult] = []
+        for room in spec.rooms:
+            result = await self._room_yaml.provision_room(
+                room,
+                user_id=user_id,
+                is_admin=is_admin,
+                group_id=group_id,
+                join_event_listeners=room.join_event_listeners or None,
+                aliases=room.aliases or None,
+            )
+            room_results.append(result)
+            key_to_room_id[room.key] = result.room_id
+
+        created_links, failed_links = await self._create_links(
+            spec.links, key_to_room_id
+        )
+
+        return EngagementProvisionResult(
+            group_id=group_id,
+            group_name=group_name,
+            rooms=room_results,
+            created_links=created_links,
+            failed_links=failed_links,
+        )
+
+    async def _preflight(self, spec: EngagementSpec) -> None:
+        """Fail loud on bad agent / bridge names across every room before we
+        create the group, so a typo does not leave a half-built engagement."""
+        bridge_names = {r.bridge for r in spec.rooms if r.bridge is not None}
+        agent_names = sorted({n for r in spec.rooms for n in r.agents})
+        async with self._session_factory() as session:
+            if bridge_names:
+                bridges = await self._bridge_store.get_all(session)
+                by_name: dict[str, int] = {}
+                for b in bridges:
+                    by_name[b.display_name] = by_name.get(b.display_name, 0) + 1
+                for name in sorted(bridge_names):
+                    count = by_name.get(name, 0)
+                    if count == 0:
+                        raise ValueError(f"Unknown bridge: {name!r}")
+                    if count > 1:
+                        raise ValueError(
+                            f"Ambiguous bridge name {name!r}: {count} bridges match"
+                        )
+            if agent_names:
+                found = await self._agent_store.get_by_names(session, agent_names)
+                found_names = {a.name for a in found}
+                missing = [n for n in agent_names if n not in found_names]
+                if missing:
+                    raise ValueError(f"Unknown agents: {', '.join(missing)}")
+
+    async def _resolve_parent_group_id(self, parent_name: str | None) -> str | None:
+        if parent_name is None:
+            return None
+        async with self._session_factory() as session:
+            groups = await self._groups.get_all(session)
+        matches = [g for g in groups if g.name == parent_name]
+        if not matches:
+            raise ValueError(f"Unknown parent group: {parent_name!r}")
+        if len(matches) > 1:
+            raise ValueError(
+                f"Ambiguous parent group name {parent_name!r}: "
+                f"{len(matches)} groups match"
+            )
+        return matches[0].id
+
+    async def _create_links(
+        self, links: list[LinkSpec], key_to_room_id: dict[str, str]
+    ) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+        created: list[dict[str, str]] = []
+        failed: list[dict[str, str]] = []
+        # Each link gets its own session so one failure (e.g. a duplicate link)
+        # is isolated and does not roll back the links that succeeded.
+        for link in links:
+            source_id = key_to_room_id[link.from_key]
+            target_id = key_to_room_id[link.to_key]
+            try:
+                async with self._session_factory() as session:
+                    await self._resources.attach_linked_room(
+                        session,
+                        source_room_id=source_id,
+                        target_room_id=target_id,
+                        label=link.label,
+                    )
+                    await session.commit()
+                created.append(
+                    {"from": link.from_key, "to": link.to_key, "label": link.label}
+                )
+            except Exception as e:
+                failed.append(
+                    {"from": link.from_key, "to": link.to_key, "error": str(e)}
+                )
+        return created, failed

--- a/core/switch_core/gateway/app.py
+++ b/core/switch_core/gateway/app.py
@@ -30,6 +30,7 @@ from switch_core.gateway.connectors import router as connectors_router
 from switch_core.gateway.dependencies import init_dependencies
 from switch_core.gateway.documents import router as documents_router
 from switch_core.gateway.ecosystem import router as ecosystem_router
+from switch_core.gateway.engagements import router as engagements_router
 from switch_core.gateway.oidc_routes import register_oidc_client
 from switch_core.gateway.oidc_routes import router as oidc_router
 from switch_core.gateway.packages import router as packages_router
@@ -98,6 +99,7 @@ def create_gateway_app(
     app.include_router(auth_router, tags=["auth"])
     app.include_router(oidc_router, tags=["auth"])
     app.include_router(rooms_router, prefix="/rooms", tags=["rooms"])
+    app.include_router(engagements_router, prefix="/engagements", tags=["engagements"])
     app.include_router(room_groups_router, prefix="/room-groups", tags=["room-groups"])
     app.include_router(agents_router, prefix="/agents", tags=["agents"])
     app.include_router(

--- a/core/switch_core/gateway/dependencies.py
+++ b/core/switch_core/gateway/dependencies.py
@@ -24,6 +24,7 @@ from switch_core.db.stores.room_group_store import RoomGroupStore
 from switch_core.db.stores.room_store import RoomStore
 from switch_core.db.stores.server_connector_store import ServerConnectorStore
 from switch_core.db.stores.user_store import UserStore
+from switch_core.engagements_yaml import EngagementYamlService
 from switch_core.room_service import RoomService
 from switch_core.rooms_yaml import RoomYamlService
 
@@ -88,6 +89,17 @@ def get_room_yaml_service() -> RoomYamlService:
         bridge_store=_state["bridge_store"],
         external_user_store=_state["external_user_store"],
         room_role_store=protocol.room_role_store,
+        session_factory=_state["session_factory"],
+    )
+
+
+def get_engagement_yaml_service() -> EngagementYamlService:
+    return EngagementYamlService(
+        room_yaml=get_room_yaml_service(),
+        room_group_store=_state["room_group_store"],
+        resource_service=_state["resource_service"],
+        agent_store=_state["agent_store"],
+        bridge_store=_state["bridge_store"],
         session_factory=_state["session_factory"],
     )
 

--- a/core/switch_core/gateway/engagements.py
+++ b/core/switch_core/gateway/engagements.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from switch_core.db.models import User
+from switch_core.engagements_yaml import (
+    EngagementProvisionResult,
+    EngagementYamlService,
+)
+from switch_core.gateway.auth import get_current_user
+from switch_core.gateway.dependencies import get_engagement_yaml_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/from-yaml", status_code=201)
+async def create_engagement_from_yaml(
+    request: Request,
+    engagements: Annotated[EngagementYamlService, Depends(get_engagement_yaml_service)],
+    user: Annotated[User, Depends(get_current_user)],
+) -> EngagementProvisionResult:
+    """Provision a multi-room engagement (a room group + rooms + links) from a
+    YAML spec. The body is the raw YAML text. Agent / bridge names are
+    validated up front (fail-loud), then the group and rooms are created and
+    links attached best-effort — per-room attachment and link failures are
+    surfaced in the result rather than dropped."""
+    text = (await request.body()).decode("utf-8")
+    try:
+        spec = engagements.parse(text)
+        return await engagements.provision(
+            spec, user_id=user.id, is_admin=user.role == "admin"
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e

--- a/core/switch_core/rooms_yaml.py
+++ b/core/switch_core/rooms_yaml.py
@@ -183,6 +183,31 @@ class RoomYamlService:
     async def provision(
         self, spec: RoomSpec, *, user_id: str, is_admin: bool
     ) -> ProvisionResult:
+        """Provision a single standalone room (no group / listeners / aliases)."""
+        return await self.provision_room(
+            spec,
+            user_id=user_id,
+            is_admin=is_admin,
+            group_id=None,
+            join_event_listeners=None,
+            aliases=None,
+        )
+
+    async def provision_room(
+        self,
+        spec: RoomSpec,
+        *,
+        user_id: str,
+        is_admin: bool,
+        group_id: str | None,
+        join_event_listeners: list[str] | None,
+        aliases: dict[str, str] | None,
+    ) -> ProvisionResult:
+        """Provision one room from a spec, optionally filed under a group with
+        join-event listeners and agent aliases. This is the reusable per-room
+        primitive the engagement provisioner builds on; ``provision`` is the
+        standalone single-room wrapper. Cross-room links are attached by the
+        caller after all rooms exist (target ids do not exist until then)."""
         bridge_id = await self._resolve_bridge_id(spec.bridge)
         if spec.users and bridge_id is None:
             raise ValueError(
@@ -210,6 +235,9 @@ class RoomYamlService:
             write_visibility=spec.write_visibility,
             roles=spec.roles or None,
             reference_ids=attached_ref_ids or None,
+            group_id=group_id,
+            join_event_listeners=join_event_listeners,
+            aliases=aliases,
         )
         result = await self._rooms.create_room(config)
         room_id = result.room.id

--- a/core/tests/switch_core/test_engagements_yaml.py
+++ b/core/tests/switch_core/test_engagements_yaml.py
@@ -1,0 +1,396 @@
+"""Tests for declarative multi-room engagement provisioning
+(switch_core.engagements_yaml).
+
+Exercised against a real PostgreSQL instance (per the project rule). Matrix /
+bridge side effects are out of scope, so ``RoomService.create_room`` is replaced
+by a DB-only fake that creates the room row and honours the fields the
+engagement layer relies on (group_id, agents, roles) — enough for group
+membership, link creation, preflight, and best-effort logic to be tested for
+real. Links are created through the real ``ResourceService`` against real room
+rows the fake writes.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import insert, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.bridges.resource.service import ResourceService
+from switch_core.db.models import (
+    Agent,
+    ApiKey,
+    Client,
+    Room,
+    RoomGroup,
+    RoomLink,
+    RoomRole,
+    User,
+    room_agents,
+)
+from switch_core.db.stores.agent_store import AgentStore
+from switch_core.db.stores.collaboration_bridge_store import CollaborationBridgeStore
+from switch_core.db.stores.document_store import DocumentStore
+from switch_core.db.stores.external_user_store import ExternalUserStore
+from switch_core.db.stores.package_store import PackageStore
+from switch_core.db.stores.reference_store import ReferenceStore
+from switch_core.db.stores.room_group_store import RoomGroupStore
+from switch_core.db.stores.room_link_store import RoomLinkStore
+from switch_core.db.stores.room_role_store import RoomRoleStore
+from switch_core.db.stores.room_store import RoomStore
+from switch_core.engagements_yaml import EngagementYamlService
+from switch_core.room_service import RoomCreateConfig, RoomCreateResult
+from switch_core.rooms_yaml import RoomYamlService
+
+
+class FakeRoomService:
+    """DB-only stand-in for RoomService.create_room, honouring the fields the
+    engagement layer depends on: fail-loud agent resolution, room-row creation
+    (with group_id), and role attachment."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        agent_store: AgentStore,
+    ) -> None:
+        self._sf = session_factory
+        self._agents = agent_store
+
+    async def create_room(self, config: RoomCreateConfig) -> RoomCreateResult:
+        async with self._sf() as session:
+            agent_ids: list[str] = []
+            if config.agent_names:
+                agents = await self._agents.get_by_names(session, config.agent_names)
+                name_to_id = {a.name: a.id for a in agents}
+                missing = [n for n in config.agent_names if n not in name_to_id]
+                if missing:
+                    raise ValueError(f"Unknown agents: {', '.join(missing)}")
+                agent_ids = [name_to_id[n] for n in config.agent_names]
+
+            room = Room(
+                matrix_room_id=f"!{uuid.uuid4().hex}:test.local",
+                name=config.name,
+                description=config.description,
+                channel_type=config.channel_type or "channel_public",
+                bridge_id=config.bridge_id,
+                instructions=config.instructions,
+                created_by=config.created_by,
+                owner_id=config.owner_id,
+                group_id=config.group_id,
+                read_visibility=config.read_visibility,
+                write_visibility=config.write_visibility,
+            )
+            session.add(room)
+            await session.flush()
+            for aid in agent_ids:
+                await session.execute(
+                    insert(room_agents).values(room_id=room.id, agent_id=aid)
+                )
+            for spec in config.roles or []:
+                session.add(
+                    RoomRole(
+                        room_id=room.id,
+                        name=spec.name,
+                        instructions=spec.instructions,
+                        exclusive=spec.exclusive,
+                    )
+                )
+            await session.commit()
+            return RoomCreateResult(room=room, failed_attachments=[])
+
+
+async def _make_agent(session: AsyncSession, name: str, user_id: str) -> Agent:
+    api_key = ApiKey(
+        user_id=user_id,
+        key_hash=f"hash-{name}",
+        encrypted_key="enc",
+        label=name,
+        type="agent",
+    )
+    client = Client(
+        matrix_user_id=f"@{name}:test.local",
+        display_name=name,
+        type="agent",
+        password="x",
+    )
+    session.add_all([api_key, client])
+    await session.flush()
+    agent = Agent(
+        name=name,
+        description=f"{name} desc",
+        agent_type="always_on",
+        connector_type="claude_code",
+        integration_profile={"connection_model": "always_on"},
+        client_id=client.id,
+        api_key_id=api_key.id,
+    )
+    session.add(agent)
+    await session.flush()
+    return agent
+
+
+@pytest_asyncio.fixture
+async def env(session_factory: async_sessionmaker[AsyncSession]):
+    """Seed a user + a manager and worker agent, and wire up the service."""
+    resource_service = ResourceService(
+        reference_store=ReferenceStore(),
+        document_store=DocumentStore(),
+        package_store=PackageStore(),
+        room_link_store=RoomLinkStore(),
+        session_factory=session_factory,
+    )
+    agent_store = AgentStore()
+    room_group_store = RoomGroupStore()
+    room_yaml = RoomYamlService(
+        room_service=FakeRoomService(session_factory, agent_store),  # type: ignore[arg-type]
+        resource_service=resource_service,
+        room_store=RoomStore(),
+        agent_store=agent_store,
+        bridge_store=CollaborationBridgeStore(),
+        external_user_store=ExternalUserStore(),
+        room_role_store=RoomRoleStore(),
+        session_factory=session_factory,
+    )
+    svc = EngagementYamlService(
+        room_yaml=room_yaml,
+        room_group_store=room_group_store,
+        resource_service=resource_service,
+        agent_store=agent_store,
+        bridge_store=CollaborationBridgeStore(),
+        session_factory=session_factory,
+    )
+
+    async with session_factory() as session:
+        user = User(name="alice", email="alice@example.com", role="member")
+        session.add(user)
+        await session.flush()
+        user_id = user.id
+        await _make_agent(session, "claude-code.manager", user_id)
+        await _make_agent(session, "claude-code.worker", user_id)
+        await session.commit()
+
+    return {
+        "svc": svc,
+        "resource_service": resource_service,
+        "session_factory": session_factory,
+        "user_id": user_id,
+    }
+
+
+def _svc(env) -> EngagementYamlService:
+    return env["svc"]
+
+
+# ── parse ──────────────────────────────────────────────────────────────────
+
+
+def test_parse_minimal(env):
+    spec = _svc(env).parse(
+        """
+        engagement:
+          group:
+            name: "Team"
+          rooms:
+            - key: hub
+              name: "Hub"
+              description: "d"
+        """
+    )
+    assert spec.group.name == "Team"
+    assert [r.key for r in spec.rooms] == ["hub"]
+    assert spec.links == []
+
+
+def test_parse_rejects_missing_engagement_key(env):
+    with pytest.raises(ValueError, match="top-level 'engagement:'"):
+        _svc(env).parse("group:\n  name: x\n")
+
+
+def test_parse_rejects_malformed_yaml(env):
+    with pytest.raises(ValueError, match="Invalid YAML"):
+        _svc(env).parse("engagement: [unclosed\n")
+
+
+def test_parse_rejects_no_rooms(env):
+    with pytest.raises(ValueError, match="at least one room"):
+        _svc(env).parse(
+            """
+            engagement:
+              group: { name: "T" }
+              rooms: []
+            """
+        )
+
+
+def test_parse_rejects_duplicate_room_keys(env):
+    with pytest.raises(ValueError, match="duplicate room keys: hub"):
+        _svc(env).parse(
+            """
+            engagement:
+              group: { name: "T" }
+              rooms:
+                - { key: hub, name: "A", description: "d" }
+                - { key: hub, name: "B", description: "d" }
+            """
+        )
+
+
+def test_parse_rejects_link_to_unknown_key(env):
+    with pytest.raises(ValueError, match="unknown room key 'ghost'"):
+        _svc(env).parse(
+            """
+            engagement:
+              group: { name: "T" }
+              rooms:
+                - { key: hub, name: "A", description: "d" }
+              links:
+                - { from: hub, to: ghost, label: "x" }
+            """
+        )
+
+
+def test_parse_rejects_self_link(env):
+    with pytest.raises(ValueError, match="point a room at itself"):
+        _svc(env).parse(
+            """
+            engagement:
+              group: { name: "T" }
+              rooms:
+                - { key: hub, name: "A", description: "d" }
+              links:
+                - { from: hub, to: hub, label: "x" }
+            """
+        )
+
+
+def test_parse_rejects_users_without_bridge(env):
+    with pytest.raises(ValueError, match="attaches users but has no bridge"):
+        _svc(env).parse(
+            """
+            engagement:
+              group: { name: "T" }
+              rooms:
+                - key: hub
+                  name: "A"
+                  description: "d"
+                  users: ["bob"]
+            """
+        )
+
+
+# ── provision ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_provision_creates_group_rooms_and_links(env):
+    spec = _svc(env).parse(
+        """
+        engagement:
+          group:
+            name: "FlintAI Optimize and Prove"
+            description: "engagement group"
+          rooms:
+            - key: workforce
+              name: "Workforce Hub"
+              description: "planning"
+              agents: ["claude-code.manager"]
+              roles:
+                - { name: planner, instructions: "plan", exclusive: true }
+            - key: feature
+              name: "Feature Hub"
+              description: "features"
+              agents: ["claude-code.worker"]
+          links:
+            - { from: workforce, to: feature, label: "feature work" }
+            - { from: feature, to: workforce, label: "parent hub" }
+        """
+    )
+    result = await _svc(env).provision(spec, user_id=env["user_id"], is_admin=False)
+
+    assert result.group_name == "FlintAI Optimize and Prove"
+    assert len(result.rooms) == 2
+    assert len(result.created_links) == 2
+    assert result.failed_links == []
+
+    sf = env["session_factory"]
+    async with sf() as session:
+        group = await session.get(RoomGroup, result.group_id)
+        assert group is not None
+        # Both rooms filed under the engagement group.
+        room_ids = [r.room_id for r in result.rooms]
+        for rid in room_ids:
+            room = await session.get(Room, rid)
+            assert room.group_id == result.group_id
+        # Both directed links persisted.
+        links = (await session.execute(select(RoomLink))).scalars().all()
+        assert len(links) == 2
+
+
+@pytest.mark.asyncio
+async def test_provision_unknown_agent_fails_loud_before_group(env):
+    spec = _svc(env).parse(
+        """
+        engagement:
+          group: { name: "Should Not Exist" }
+          rooms:
+            - key: hub
+              name: "Hub"
+              description: "d"
+              agents: ["claude-code.ghost"]
+        """
+    )
+    with pytest.raises(ValueError, match="Unknown agents: claude-code.ghost"):
+        await _svc(env).provision(spec, user_id=env["user_id"], is_admin=False)
+
+    # Preflight ran before the group was created — no orphan group left behind.
+    async with env["session_factory"]() as session:
+        groups = (await session.execute(select(RoomGroup))).scalars().all()
+        assert all(g.name != "Should Not Exist" for g in groups)
+
+
+@pytest.mark.asyncio
+async def test_provision_unknown_bridge_fails_loud(env):
+    spec = _svc(env).parse(
+        """
+        engagement:
+          group: { name: "T" }
+          rooms:
+            - key: hub
+              name: "Hub"
+              description: "d"
+              bridge: "No Such Bridge"
+        """
+    )
+    with pytest.raises(ValueError, match="Unknown bridge: 'No Such Bridge'"):
+        await _svc(env).provision(spec, user_id=env["user_id"], is_admin=False)
+
+
+@pytest.mark.asyncio
+async def test_provision_duplicate_link_is_best_effort(env):
+    spec = _svc(env).parse(
+        """
+        engagement:
+          group: { name: "Dup Links" }
+          rooms:
+            - { key: a, name: "A", description: "d" }
+            - { key: b, name: "B", description: "d" }
+          links:
+            - { from: a, to: b, label: "first" }
+            - { from: a, to: b, label: "again" }
+        """
+    )
+    result = await _svc(env).provision(spec, user_id=env["user_id"], is_admin=False)
+    # First link created; the duplicate is reported, not raised, and does not
+    # roll back the successful one.
+    assert len(result.created_links) == 1
+    assert len(result.failed_links) == 1
+    assert result.failed_links[0]["from"] == "a"
+    assert result.failed_links[0]["to"] == "b"
+
+    async with env["session_factory"]() as session:
+        links = (await session.execute(select(RoomLink))).scalars().all()
+        assert len(links) == 1
+        assert links[0].label == "first"

--- a/deploy/engagements/README.md
+++ b/deploy/engagements/README.md
@@ -1,0 +1,147 @@
+# Engagements
+
+A reusable way to stand up a **team** on Switch: a room network where each
+engineer's Claude Code agent does the work and opens PRs, the engineer reviews
+on GitHub, and everything is coordinated in Slack.
+
+An **engagement** is a room group plus a set of rooms and the directed links
+between them, declared in one YAML file and provisioned in a single command. It
+builds on the single-room provisioning in `switch_core.rooms_yaml`.
+
+The shipped preset — [`flintai-optimize-and-prove.yaml`](./flintai-optimize-and-prove.yaml)
+— is both the concrete first instance for the "FlintAI Optimize and Prove" team
+and the template you copy for the next team.
+
+## The room network
+
+Three hubs, filed under one room group, Slack-bridged:
+
+- **Workforce Hub** — the front door. A manager agent discusses the work with
+  the team, co-authors a design doc, breaks it into a Jira epic, and delegates
+  each item to the Feature or Bug Hub.
+- **Feature Hub** — turns each feature task into a dedicated child room +
+  `feature-request/<slug>` branch, where a worker implements and opens a PR.
+- **Bug Hub** — the same loop for bugs, on `bug-fix/<slug>` branches.
+
+The lifecycle:
+
+```
+discuss goals ─▶ design doc ─▶ Jira epic ─▶ per-task room + branch + PR
+              ─▶ human review on GitHub ─▶ address comments ─▶ team merge into main
+```
+
+Child rooms are **not** part of the preset — the manager creates them at runtime
+as work arrives (one item = one room + branch + PR), and archives them on merge.
+
+## Roles
+
+Assumable, room-scoped instruction bundles:
+
+- **design** (Workforce, exclusive) — reads the PRD + discussion, co-authors the
+  design doc (a room document), sets technical direction. No code, no Jira.
+- **planner** (Workforce, exclusive) — turns the design into a Jira epic +
+  items and delegates each to a worker with a child room + branch.
+- **worker** (Feature/Bug + child rooms, shared) — implements one task on its
+  branch, opens a PR, addresses review comments. Never merges.
+
+Modeling note: `design` and `planner` are roles worn by the manager agent, so a
+team needs only one manager agent registered (plus one worker per member) rather
+than separate design/task agents. If you prefer genuinely separate agents,
+register them and add them to the Workforce Hub instead.
+
+## Prerequisites
+
+- A running **published Switch** instance, with **switchdash** on each operator's
+  machine (it auto-starts a Claude Code session when an `auto_session` agent is
+  addressed and no session is live).
+- An **active Slack collaboration bridge** (`list_bridges` shows it; note its
+  display name).
+- The team members are **known to Switch on that Slack bridge** (each has
+  messaged the workspace at least once), so they can be added by username.
+- **GitHub access** for the worker agents: the operator/user grants `gh` +
+  `git` push access in each agent's session so it can open PRs. (Switch does not
+  hold these credentials; it is the user's responsibility to permit the agent.)
+- A **Jira tool** in the manager agent's session (e.g. the Atlassian MCP) so the
+  `planner` role can create the epic + items. Without it, the planner can draft
+  the list and a human creates the issues.
+
+## Provisioning
+
+### 1. Register the agents
+
+No agent is auto-created by the preset. Register them first (gateway UI →
+Agents, or `POST /gateway/agents/register`), as `claude-code` known agents:
+
+- **Manager agent** — e.g. `claude-code.flint-manager`, `auto_session=true`,
+  `repo_dir` = the repo checkout, `channels_enabled=true`. It orchestrates all
+  three hubs; give it the Jira tool + gh/git in its session.
+- **One worker agent per team member** — e.g. `claude-code.flint-steven`,
+  `auto_session=true`, `repo_dir` = that member's checkout, `channels_enabled=true`,
+  with gh/git access.
+
+The provisioner validates every agent name up front and fails loud on an unknown
+one before creating anything — so register agents (or fix names) first.
+
+### 2. Fill in the preset
+
+Copy the preset for your team and edit the `ROSTER` / placeholder markers:
+
+- `bridge:` on each room → your Slack bridge's display name.
+- reference `value.urls` → the team's real GitHub repo and Jira project.
+- the manager agent name (`claude-code.flint-manager`) → your registered manager
+  (update the `agents`, `aliases`, and `join_event_listeners` entries together).
+- under each hub, add one worker agent (`agents:`) and one Slack username
+  (`users:`) per team member.
+
+### 3. Provision
+
+```bash
+just provision-engagement deploy/engagements/flintai-optimize-and-prove.yaml
+```
+
+This logs into the gateway with the admin credentials from `.env`, then POSTs
+the spec to `POST /gateway/engagements/from-yaml`. It:
+
+1. validates all agent + bridge names (fail loud);
+2. creates the room group;
+3. creates each hub under the group (Slack channel, agents, users, roles,
+   aliases, join-event listeners, references);
+4. wires the hub-to-hub links.
+
+Per-room attachment failures and link failures are returned in the response
+(`rooms[].failed_attachments`, `failed_links`) rather than dropped — check the
+output.
+
+Override the gateway target with `SWITCH_GATEWAY_URL` (default
+`http://localhost:${API_HOST_PORT}/gateway`). You can also POST the YAML to the
+endpoint directly from any authenticated client.
+
+## Running the workflow
+
+1. In the **Workforce Hub**, the team discusses what needs to be done with the
+   manager agent and agrees the goals.
+2. The manager assumes **design**, co-authors the design doc (a room document in
+   the hub), and gets sign-off.
+3. The manager assumes **planner**, creates the Jira epic + items, and for each
+   item spins out a child room + branch under the **Feature** or **Bug Hub** and
+   assigns a worker.
+4. In each child room, the worker implements the task and opens a PR against
+   `main`. The reviewer reviews on GitHub and pings the worker to address
+   comments; the worker pushes fixes to the same PR.
+5. On approval, the rest of the team is invited to review + merge into `main`.
+   The child room is archived and the merge reported back to the Workforce Hub.
+
+## Adding / removing a team member
+
+- **Add**: register a worker agent for them, then add their agent to the Feature
+  and Bug hubs (`agents:` in the preset + re-provision, or `invite_agent_to_room`
+  / `!invite-agent` in-room) and their Slack user to the hubs.
+- **Remove**: remove their agent + user from the hubs; archive or reassign any
+  in-flight child rooms.
+
+## Extending
+
+The engagement spec (`switch_core.engagements_yaml`) is generic: any room group
++ rooms + links network can be expressed the same way. Add more hubs, more
+roles, or more links as a team's workflow grows — this preset is just one
+shape.

--- a/deploy/engagements/flintai-optimize-and-prove.yaml
+++ b/deploy/engagements/flintai-optimize-and-prove.yaml
@@ -1,0 +1,238 @@
+# Engagement preset — "FlintAI Optimize and Prove" (CHOO-1177)
+#
+# A reusable room-network template for an engineering team.
+# It provisions one room group holding three hubs — Workforce, Feature, Bug —
+# that together run the lifecycle:
+#
+#   discuss goals -> design doc -> Jira epic -> per-task room+branch+PR
+#                 -> human review on GitHub -> team merge into main
+#
+# The Workforce Hub is where a manager agent discusses the work, co-authors a
+# design doc, and breaks it into a Jira epic, then delegates each item to the
+# Feature or Bug Hub. Those hubs spin out a dedicated child room + branch per
+# item at runtime (child rooms are NOT part of this preset — the manager
+# creates them as work arrives).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# BEFORE PROVISIONING — fill in the roster and adjust these placeholders:
+#   • `bridge:` — set to your Slack bridge's display name (see `list_bridges`).
+#   • references `value.urls` — point at the team's real GitHub repo and Jira
+#     project.
+#   • the manager agent name (`claude-code.flint-manager`) — register this agent
+#     first (see deploy/engagements/README.md), or rename to an existing one.
+#   • ROSTER — under each hub, add one worker agent + one Slack user per team
+#     member (marked "ROSTER" below). Agents must be registered first; the
+#     provisioner fails loud on unknown agent/bridge names before creating
+#     anything.
+# ─────────────────────────────────────────────────────────────────────────────
+
+engagement:
+  group:
+    name: "FlintAI Optimize and Prove"
+    description: >-
+      Engagement room network for a team. A workforce hub that plans and
+      delegates, plus feature and bug hubs that spin out per-task rooms and
+      branches for implementation, review, and merge.
+
+  rooms:
+    # ── Workforce Hub ────────────────────────────────────────────────────────
+    - key: workforce
+      name: "Workforce Hub — FlintAI Optimize and Prove"
+      description: >-
+        Planning + coordination hub. Where work is discussed, scoped into a
+        design doc, broken into a Jira epic, and delegated out to the feature
+        and bug hubs.
+      bridge: "Slack"
+      instructions: |
+        This is the Workforce Hub for the "FlintAI Optimize and Prove"
+        engagement — the front door for a piece of work and the team's
+        coordination point.
+
+        Flow for the manager agent:
+        1. Discuss freely with the human(s) to agree what needs to be done and
+           the list of goals.
+        2. Assume the `design` role to read the PRD and the discussion and
+           co-author a design doc (stored as a room document here) that sets the
+           technical direction. Get human sign-off on the design before
+           planning.
+        3. Assume the `planner` role to turn the agreed design into a Jira epic
+           + itemized tasks (using your Jira tool), then delegate each item:
+           decide whether it is a feature or a bug, route it to the Feature Hub
+           or Bug Hub, and have a dedicated child room + branch spun out for it
+           with a worker assigned.
+        4. Track status here and report merges back as they land. Keep the human
+           steering at every gate — do not skip ahead without agreement.
+
+        Address humans with targeted messages. Post plans and status at the room
+        root so the work reads top-to-bottom.
+      roles:
+        - name: design
+          exclusive: true
+          instructions: >-
+            Design role. Read the PRD and the room discussion, then work with
+            the human to produce and maintain a design doc (a room document in
+            this hub) that sets the technical direction. Do not write code or
+            create Jira items — your output is an agreed, written design the team
+            signs off on before planning begins.
+        - name: planner
+          exclusive: true
+          instructions: >-
+            Planner role. Turn the agreed design doc into a Jira epic and an
+            itemized task list using your Jira tool. For each item, decide
+            feature vs bug, route it to the Feature or Bug Hub, and delegate it
+            to a worker with a dedicated child room + branch. Track status and
+            keep the human informed. Do not implement tasks yourself.
+      aliases:
+        claude-code.flint-manager: manager
+      join_event_listeners:
+        - claude-code.flint-manager
+      agents:
+        - claude-code.flint-manager
+        # ROSTER: (optional) add worker agents here if you want them present in
+        # the workforce hub for planning visibility. Users go under `users`.
+      users: []
+        # ROSTER: add each team member's Slack username, e.g.
+        # - steven
+      references:
+        - type: github
+          name: "GitHub repo — FlintAI Optimize and Prove"
+          description: "The repository the team develops in."
+          instructions: >-
+            Open PRs against this repo and coordinate reviews here. Worker
+            agents need gh/git access granted in their session to push branches
+            and open PRs.
+          value:
+            urls:
+              - "https://github.com/your-org/your-repo"
+        - type: jira
+          name: "Jira project — FlintAI Optimize and Prove"
+          description: "The Jira project/epic the planner manages."
+          instructions: >-
+            The planner creates the epic + task items here. Requires a Jira tool
+            (e.g. the Atlassian MCP) configured in the manager agent's session.
+          value:
+            urls:
+              - "https://your-org.atlassian.net/browse/FLINT"
+
+    # ── Feature Hub ──────────────────────────────────────────────────────────
+    - key: feature
+      name: "Feature Hub — FlintAI Optimize and Prove"
+      description: >-
+        Home for feature development. Spins out a dedicated room + feature
+        branch per feature task; workers implement and open PRs; the reviewer
+        reviews on GitHub and the team merges.
+      bridge: "Slack"
+      instructions: |
+        This is the Feature Hub for the "FlintAI Optimize and Prove"
+        engagement. It turns each feature task delegated from the Workforce Hub
+        into a dedicated room + feature branch and drives it to merge.
+
+        For each delegated feature item:
+        1. Create a child room and a branch named `feature-request/<slug>`; add
+           the assigned worker agent and the reviewing human, and attach the
+           GitHub repo reference.
+        2. The worker implements the item on the branch and opens a PR against
+           `main`.
+        3. The reviewer reviews on GitHub and pings the worker in the child room
+           to address comments; the worker pushes fixes to the same PR.
+        4. Once the reviewer approves, invite the rest of the team to review and
+           merge into `main`.
+        5. On merge, archive the child room and report the merge back to the
+           Workforce Hub.
+
+        Workers implement and open PRs but never merge. Address humans with
+        targeted messages.
+      roles:
+        - name: worker
+          exclusive: false
+          instructions: >-
+            Worker role. Implement a single assigned task on its branch, open a
+            PR against main, and respond to review comments by pushing fixes to
+            the same PR. Report progress in your room. Do not merge — the
+            reviewing human approves and the team merges.
+      aliases:
+        claude-code.flint-manager: manager
+      join_event_listeners:
+        - claude-code.flint-manager
+      agents:
+        - claude-code.flint-manager
+        # ROSTER: add one worker agent per team member, e.g.
+        # - claude-code.flint-steven
+      users: []
+        # ROSTER: add each team member's Slack username, e.g.
+        # - steven
+      references:
+        - type: github
+          name: "GitHub repo — FlintAI Optimize and Prove (feature)"
+          description: "The repository feature work targets."
+          instructions: >-
+            Feature branches (`feature-request/<slug>`) and their PRs target
+            this repo.
+          value:
+            urls:
+              - "https://github.com/your-org/your-repo"
+
+    # ── Bug Hub ──────────────────────────────────────────────────────────────
+    - key: bug
+      name: "Bug Hub — FlintAI Optimize and Prove"
+      description: >-
+        Home for bug fixes. Spins out a dedicated room + bug-fix branch per bug;
+        workers implement and open PRs; the reviewer reviews on GitHub and the
+        team merges.
+      bridge: "Slack"
+      instructions: |
+        This is the Bug Hub for the "FlintAI Optimize and Prove" engagement. It
+        turns each bug delegated from the Workforce Hub into a dedicated room +
+        bug-fix branch and drives it to merge.
+
+        For each delegated bug:
+        1. Create a child room and a branch named `bug-fix/<slug>`; add the
+           assigned worker agent and the reviewing human, and attach the GitHub
+           repo reference.
+        2. The worker fixes the bug on the branch and opens a PR against `main`.
+        3. The reviewer reviews on GitHub and pings the worker in the child room
+           to address comments; the worker pushes fixes to the same PR.
+        4. Once the reviewer approves, invite the rest of the team to review and
+           merge into `main`.
+        5. On merge, archive the child room and report the merge back to the
+           Workforce Hub.
+
+        Workers implement and open PRs but never merge. Address humans with
+        targeted messages.
+      roles:
+        - name: worker
+          exclusive: false
+          instructions: >-
+            Worker role. Implement a single assigned bug fix on its branch, open
+            a PR against main, and respond to review comments by pushing fixes to
+            the same PR. Report progress in your room. Do not merge — the
+            reviewing human approves and the team merges.
+      aliases:
+        claude-code.flint-manager: manager
+      join_event_listeners:
+        - claude-code.flint-manager
+      agents:
+        - claude-code.flint-manager
+        # ROSTER: add one worker agent per team member, e.g.
+        # - claude-code.flint-steven
+      users: []
+        # ROSTER: add each team member's Slack username, e.g.
+        # - steven
+      references:
+        - type: github
+          name: "GitHub repo — FlintAI Optimize and Prove (bug)"
+          description: "The repository bug fixes target."
+          instructions: >-
+            Bug-fix branches (`bug-fix/<slug>`) and their PRs target this repo.
+          value:
+            urls:
+              - "https://github.com/your-org/your-repo"
+
+  # ── Hub topology ────────────────────────────────────────────────────────────
+  # The workforce hub points at the two execution hubs; each execution hub
+  # points back at the workforce hub.
+  links:
+    - { from: workforce, to: feature, label: "feature work" }
+    - { from: workforce, to: bug, label: "bug work" }
+    - { from: feature, to: workforce, label: "workforce hub" }
+    - { from: bug, to: workforce, label: "workforce hub" }

--- a/justfile
+++ b/justfile
@@ -68,6 +68,28 @@ test *args:
 test-integration *args:
     uv run --project core pytest -c core/pyproject.toml core/tests/integration -m integration {{ args }}
 
+# ── Provision a multi-room engagement from a YAML preset ──────────────────────
+# Logs into the gateway with the admin credentials from .env, then POSTs the
+# engagement spec (a room group + rooms + links) to the engagements endpoint.
+# Override the target with SWITCH_GATEWAY_URL (default
+# http://localhost:${API_HOST_PORT}/gateway). See deploy/engagements/README.md.
+provision-engagement file:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    base="${SWITCH_GATEWAY_URL:-http://localhost:${API_HOST_PORT:-8000}/gateway}"
+    jar="$(mktemp)"
+    trap 'rm -f "$jar"' EXIT
+    echo "→ Logging in to $base as ${GATEWAY_ADMIN_EMAIL}"
+    curl -fsS -c "$jar" -X POST "$base/auth/login" \
+        -H 'Content-Type: application/json' \
+        -d "{\"email\":\"${GATEWAY_ADMIN_EMAIL}\",\"password\":\"${GATEWAY_ADMIN_PASSWORD}\"}" \
+        >/dev/null
+    echo "→ Provisioning engagement from {{ file }}"
+    curl -fsS -b "$jar" -X POST "$base/engagements/from-yaml" \
+        -H 'Content-Type: application/x-yaml' \
+        --data-binary "@{{ file }}"
+    echo
+
 # ── Gateway UI ─────────────────────────────────────────────────────────────────
 gateway-install:
     cd gateway && npm install


### PR DESCRIPTION
## Summary

Implements CHOO-1177: a reusable way to stand up a team on Switch as a **room
network** — a workforce hub that plans and delegates, plus feature and bug hubs
that spin out per-task rooms + branches for implementation, human review on
GitHub, and team merge.

This packages the same workforce → feature/bug hub pattern Switch already runs
operationally into a **declarative, checked-in preset** so it can be stood up
for any team on the published Switch + switchdash.

## What's included

**Engagement provisioner** (`core/switch_core/engagements_yaml.py`)
- `EngagementYamlService`: provisions a room group + multiple rooms + the
  directed links between them from one YAML spec, reusing the existing
  `RoomService.create_room` per room.
- Extracted `RoomYamlService.provision_room` as the shared per-room primitive
  (adds group / join-event listeners / aliases); `provision` now wraps it.
- Preflights all agent + bridge names up front (fail loud before anything is
  created — no orphan group on a typo); best-effort on per-room attachments and
  links (each link isolated in its own session, failures surfaced in the result).

**Operator surface**
- `POST /gateway/engagements/from-yaml` endpoint + DI wiring.
- `just provision-engagement <file>` (logs in with the gateway admin creds from
  `.env`, then POSTs the spec).

**Preset + runbook** (`deploy/engagements/`)
- `flintai-optimize-and-prove.yaml`: the workforce/feature/bug hub network with
  roles (`design`, `planner`, `worker`), instructions encoding the lifecycle,
  aliases, join-listeners, GitHub + Jira references, and hub links. The
  per-member roster (worker agents + Slack users) is left as a marked fill-in.
- `README.md`: prerequisites, agent registration, provisioning, the end-to-end
  workflow, and adding/removing a team member.

**Tests** (`core/tests/switch_core/test_engagements_yaml.py`) — 12 tests: parse
validation, happy-path group+rooms+links provisioning, preflight fail-loud (no
orphan group), and best-effort duplicate-link handling.

## Key decisions (agreed with the collaborating dev)

- **Both concrete + template**: the preset is the first instance *and* the
  reusable template.
- **No agent auto-registration**: agents are registered separately and
  referenced by name; the runbook documents registration.
- **design/planner as roles** on the manager agent (not separate agents) to keep
  the agent set small.
- **Jira**: the `planner` uses a Jira tool (e.g. Atlassian MCP) in the manager's
  session; the preset attaches a Jira reference. **GitHub creds** are granted by
  the user in the agent's session.

## Testing

- `test_engagements_yaml.py` (12) + `test_rooms_yaml.py` (18, refactor
  regression) pass against real Postgres.
- `ruff format --check .`, `ruff check .`, and `mypy core/switch_core/` all clean.

## Notes

- Branch base is `5647b18` (already in `main`), so this PR is exactly the 3
  engagement commits / 9 files.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)