### PR TITLE
style(switchdash): fix format:check on remove-switch-settings.test.ts (CHOO-1364 follow-up)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/agents/remove-switch-settings.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/remove-switch-settings.test.ts
@@ -1,7 +1,7 @@
 import type { PluginFs } from '@switchdash/core/agents/plugins';
 import { describe, expect, it } from 'vitest';
-import { mergeSwitchSettings } from './write-switch-settings';
 import { removeSwitchCredentials } from './remove-switch-settings';
+import { mergeSwitchSettings } from './write-switch-settings';
 
 const SETTINGS_PATH = '.claude/settings.local.json';
 
@@ -45,7 +45,12 @@ describe('removeSwitchCredentials (default .claude teardown)', () => {
     const fs = fakeFs({
       [SETTINGS_PATH]: JSON.stringify({
         permissions: { allow: ['Bash', 'mcp__plugin_switch-connector_switch'] },
-        env: { EDITOR: 'vim', SWITCH_API_ENDPOINT: 'e', SWITCH_API_TOKEN: 't', SWITCH_AGENT_ID: 'a' },
+        env: {
+          EDITOR: 'vim',
+          SWITCH_API_ENDPOINT: 'e',
+          SWITCH_API_TOKEN: 't',
+          SWITCH_AGENT_ID: 'a',
+        },
       }),
     });
 


### PR DESCRIPTION
Follow-up to #53 (CHOO-1364). That PR was squash-merged before the `oxfmt` fix for the new `remove-switch-settings.test.ts` landed, so `main` is currently red on the *Switchdash (dash)* `format:check` job. This applies the formatter (import sort + object wrapping) to green it.

No logic change — formatting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)