### PR TITLE
fix(switchdash): don't dismiss data-entry modals on outside-click (CHOO-1659)

### DIFF
--- a/dash/apps/switchdash-desktop/src/renderer/app/modal-registry.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/app/modal-registry.ts
@@ -22,6 +22,13 @@ export type ModalRegistryEntry<TProps = unknown, TResult = unknown> = {
   component: ModalComponent<TProps, TResult>;
   size?: ModalSize;
   position?: ModalPosition;
+  /**
+   * Whether a click on the backdrop dismisses the modal. Defaults to `true`.
+   * Set `false` for data-entry modals so a stray outside click does not
+   * discard in-progress input; the Escape key and close/Cancel buttons still
+   * dismiss.
+   */
+  dismissOnOutsideClick?: boolean;
 };
 
 export function createModal<TProps, TResult>(
@@ -33,19 +40,25 @@ export function createModal<TProps, TResult>(
 
 export const modalRegistry = {
   commandPaletteModal: createModal(CommandPaletteModal, { size: 'md' }),
-  sessionModal: createModal(CreateSessionModal),
-  addAgentModal: createModal(AddAgentModal),
+  sessionModal: createModal(CreateSessionModal, { dismissOnOutsideClick: false }),
+  addAgentModal: createModal(AddAgentModal, { dismissOnOutsideClick: false }),
   confirmActionModal: createModal(ConfirmActionDialog, { size: 'xs' }),
   deleteAgentModal: createModal(DeleteAgentModal, { size: 'sm' }),
   resetAgentModal: createModal(ResetAgentModal, { size: 'sm' }),
   confirmExternalLinkModal: createModal(ExternalLinkChoiceDialog, { size: 'sm' }),
   unsavedChangesModal: createModal(UnsavedChangesDialog, { size: 'xs' }),
-  feedbackModal: createModal(FeedbackModal),
-  renameSessionModal: createModal(RenameSessionModal, { size: 'xs' }),
+  feedbackModal: createModal(FeedbackModal, { dismissOnOutsideClick: false }),
+  renameSessionModal: createModal(RenameSessionModal, {
+    size: 'xs',
+    dismissOnOutsideClick: false,
+  }),
   deleteSessionModal: createModal(DeleteSessionModal, { size: 'sm' }),
-  addServerModal: createModal(AddServerModal, { size: 'md' }),
-  assignServerModal: createModal(AssignServerModal, { size: 'sm' }),
-  renameServerModal: createModal(RenameServerModal, { size: 'xs' }),
+  addServerModal: createModal(AddServerModal, { size: 'md', dismissOnOutsideClick: false }),
+  assignServerModal: createModal(AssignServerModal, { size: 'sm', dismissOnOutsideClick: false }),
+  renameServerModal: createModal(RenameServerModal, {
+    size: 'xs',
+    dismissOnOutsideClick: false,
+  }),
   deleteServerModal: createModal(DeleteServerModal, { size: 'sm' }),
   // oxlint-disable-next-line typescript/no-explicit-any
 } satisfies Record<string, ModalRegistryEntry<any, any>>;

--- a/dash/apps/switchdash-desktop/src/renderer/lib/modal/dismissal.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/modal/dismissal.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { shouldCloseModalOnDismiss } from './dismissal';
+
+describe('shouldCloseModalOnDismiss', () => {
+  it('closes on outside-press when the modal allows it', () => {
+    expect(
+      shouldCloseModalOnDismiss({
+        reason: 'outside-press',
+        closeGuardActive: false,
+        dismissOnOutsideClick: true,
+      })
+    ).toBe(true);
+  });
+
+  it('blocks outside-press when the modal opts out', () => {
+    expect(
+      shouldCloseModalOnDismiss({
+        reason: 'outside-press',
+        closeGuardActive: false,
+        dismissOnOutsideClick: false,
+      })
+    ).toBe(false);
+  });
+
+  it('still closes on escape-key even when outside-click is disabled', () => {
+    expect(
+      shouldCloseModalOnDismiss({
+        reason: 'escape-key',
+        closeGuardActive: false,
+        dismissOnOutsideClick: false,
+      })
+    ).toBe(true);
+  });
+
+  it('blocks both passive dismissals while the close guard is active', () => {
+    expect(
+      shouldCloseModalOnDismiss({
+        reason: 'outside-press',
+        closeGuardActive: true,
+        dismissOnOutsideClick: true,
+      })
+    ).toBe(false);
+    expect(
+      shouldCloseModalOnDismiss({
+        reason: 'escape-key',
+        closeGuardActive: true,
+        dismissOnOutsideClick: true,
+      })
+    ).toBe(false);
+  });
+
+  it('always closes on a deliberate close, regardless of flags', () => {
+    for (const reason of ['close-press', 'imperative-action', 'trigger-press']) {
+      expect(
+        shouldCloseModalOnDismiss({
+          reason,
+          closeGuardActive: true,
+          dismissOnOutsideClick: false,
+        })
+      ).toBe(true);
+    }
+  });
+});

--- a/dash/apps/switchdash-desktop/src/renderer/lib/modal/dismissal.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/modal/dismissal.ts
@@ -1,0 +1,25 @@
+/**
+ * Decides whether a modal should close in response to a Base UI Dialog
+ * `onOpenChange(false)` event.
+ *
+ * Passive dismissals are the backdrop click (`outside-press`) and the Escape
+ * key (`escape-key`); every other reason (close button, imperative close) is a
+ * deliberate close and always goes through.
+ *
+ * - An active close guard blocks both passive dismissals (used while a flow is
+ *   mid-operation and must not be interrupted).
+ * - A modal with `dismissOnOutsideClick: false` blocks the backdrop click only;
+ *   Escape still closes it. This keeps data-entry modals from discarding input
+ *   on a stray outside click while leaving the keyboard escape hatch intact.
+ */
+export function shouldCloseModalOnDismiss(params: {
+  reason: string;
+  closeGuardActive: boolean;
+  dismissOnOutsideClick: boolean;
+}): boolean {
+  const { reason, closeGuardActive, dismissOnOutsideClick } = params;
+  const isPassiveDismiss = reason === 'outside-press' || reason === 'escape-key';
+  if (closeGuardActive && isPassiveDismiss) return false;
+  if (reason === 'outside-press' && !dismissOnOutsideClick) return false;
+  return true;
+}

--- a/dash/apps/switchdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
@@ -10,6 +10,7 @@ import {
 } from '@renderer/app/modal-registry';
 import { Dialog, DialogOverlay, DialogPortal } from '@renderer/lib/ui/dialog';
 import { cn } from '@renderer/utils/utils';
+import { shouldCloseModalOnDismiss } from './dismissal';
 import { modalStore } from './modal-store';
 
 const SIZE_CLASSES: Record<ModalSize, string> = {
@@ -55,10 +56,12 @@ export const ModalRenderer = observer(function ModalRenderer() {
     eventDetails: DialogPrimitive.Root.ChangeEventDetails
   ) => {
     if (!open && modalStore.isOpen) {
-      const isPassiveDismiss =
-        eventDetails.reason === 'outside-press' || eventDetails.reason === 'escape-key';
-      if (modalStore.closeGuardActive && isPassiveDismiss) return;
-      modalStore.closeModal();
+      const shouldClose = shouldCloseModalOnDismiss({
+        reason: eventDetails.reason,
+        closeGuardActive: modalStore.closeGuardActive,
+        dismissOnOutsideClick: entry?.dismissOnOutsideClick !== false,
+      });
+      if (shouldClose) modalStore.closeModal();
     }
   };
 


### PR DESCRIPTION
## What & why

CHOO-1659: data-entry modals in switchdash discard in-progress input when the user clicks outside them. Base UI's `Dialog` closes on a backdrop click by default, and the shared `ModalRenderer` never opted out — so every modal, including forms, was dismissable by a stray outside click.

## Approach

- Add a declarative `dismissOnOutsideClick?: boolean` flag (default `true`) to `ModalRegistryEntry`.
- `handleOpenChange` in `modal-renderer.tsx` now consults the active entry and blocks **only** the `outside-press` reason when the flag is `false`. The **Escape key** and the **X / Cancel buttons** still dismiss (Esc is a deliberate keystroke; the backdrop misclick is the accidental one this ticket targets).
- The existing `closeGuardActive` behavior is unchanged.
- The dismissal decision is extracted into a small pure helper (`dismissal.ts`) with unit coverage (`dismissal.test.ts`).

## Modals that no longer dismiss on outside-click (data-entry)

Add Agent, Add Server, Create Session, Rename Session, Rename Server, Assign Server, Feedback.

## Still click-away dismissible (confirm / informational)

Command palette, Confirm-action, Delete Agent/Session/Server, Reset Agent, External-link choice, Unsaved-changes.

## Testing

- `format:check`, `lint`, `typecheck` — all pass.
- `vitest --project node` — 1229 tests pass, including the new `dismissal.test.ts` (5 cases: outside-press allowed/blocked, escape still closes, close-guard blocks both, deliberate closes always go through).
- The `browser` (terminal/xterm) and `main-db`/`migrations` projects are unrelated to this renderer-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)