### PR TITLE
fix(switchdash): skip connection-status probe for a stopped managed server (CHOO-1657)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/managed-server-status.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/managed-server-status.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getLocalStatus = vi.hoisted(() => vi.fn());
+const getRemoteStatus = vi.hoisted(() => vi.fn());
+
+vi.mock('./local-server-service', () => ({
+  localServerService: { getStatus: getLocalStatus },
+}));
+vi.mock('./remote-server-service', () => ({
+  remoteServerService: { getStatus: getRemoteStatus },
+}));
+
+const { isManagedServerRunning } = await import('./managed-server-status');
+
+function server(overrides: Record<string, unknown>) {
+  return {
+    id: 'srv',
+    name: 'S',
+    gatewayUrl: 'http://localhost:3300',
+    apiUrl: 'http://localhost:8000',
+    managed: true,
+    managementKind: 'local',
+    sshHost: null,
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  } as never;
+}
+
+describe('isManagedServerRunning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false for an external (non-managed) server without probing any service', () => {
+    expect(isManagedServerRunning(server({ managed: false }))).toBe(false);
+    expect(getLocalStatus).not.toHaveBeenCalled();
+    expect(getRemoteStatus).not.toHaveBeenCalled();
+  });
+
+  it('reads the local status for a local-managed server', () => {
+    getLocalStatus.mockReturnValue({ phase: 'running' });
+    expect(isManagedServerRunning(server({ managementKind: 'local' }))).toBe(true);
+
+    getLocalStatus.mockReturnValue({ phase: 'stopped' });
+    expect(isManagedServerRunning(server({ managementKind: 'local' }))).toBe(false);
+  });
+
+  it('treats a legacy managed row (null kind) as local', () => {
+    getLocalStatus.mockReturnValue({ phase: 'running' });
+    expect(isManagedServerRunning(server({ managementKind: null }))).toBe(true);
+    expect(getRemoteStatus).not.toHaveBeenCalled();
+  });
+
+  it('reads the per-host status for a remote-managed server', () => {
+    getRemoteStatus.mockReturnValue({ phase: 'running' });
+    expect(isManagedServerRunning(server({ managementKind: 'remote', sshHost: 'host-a' }))).toBe(
+      true
+    );
+    expect(getRemoteStatus).toHaveBeenCalledWith('host-a');
+
+    getRemoteStatus.mockReturnValue({ phase: 'stopped' });
+    expect(isManagedServerRunning(server({ managementKind: 'remote', sshHost: 'host-a' }))).toBe(
+      false
+    );
+  });
+
+  it('returns false for a remote-managed server with no ssh host', () => {
+    expect(isManagedServerRunning(server({ managementKind: 'remote', sshHost: null }))).toBe(false);
+    expect(getRemoteStatus).not.toHaveBeenCalled();
+  });
+
+  it('treats non-running phases (starting/stopping/error) as not running', () => {
+    for (const phase of ['starting', 'stopping', 'error']) {
+      getLocalStatus.mockReturnValue({ phase });
+      expect(isManagedServerRunning(server({ managementKind: 'local' }))).toBe(false);
+    }
+  });
+});

--- a/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/managed-server-status.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/managed-server-status.ts
@@ -1,0 +1,25 @@
+import type { SwitchServer } from '@shared/core/switch-servers/switch-servers';
+import { localServerService } from './local-server-service';
+import { remoteServerService } from './remote-server-service';
+
+/**
+ * Whether a switchdash-managed server's stack is currently running — i.e. its
+ * lifecycle phase is `running`. Routes to the right supervisor the same way
+ * {@link managedServerSecretsKey} does: a remote-managed server reads its
+ * per-host status; everything else (local, or a legacy managed row with a null
+ * kind) reads the single local status. Both services reconcile the real stack
+ * state at boot (`initialize()`), so the phase is authoritative.
+ *
+ * Only meaningful for managed servers; returns `false` for external
+ * (non-managed) ones, so callers can gate a would-be network call on it without
+ * separately checking `server.managed`.
+ */
+export function isManagedServerRunning(server: SwitchServer): boolean {
+  if (!server.managed) return false;
+  if (server.managementKind === 'remote') {
+    return (
+      server.sshHost !== null && remoteServerService.getStatus(server.sshHost).phase === 'running'
+    );
+  }
+  return localServerService.getStatus().phase === 'running';
+}

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchMe = vi.hoisted(() => vi.fn());
+const getServer = vi.hoisted(() => vi.fn());
+const isManagedServerRunning = vi.hoisted(() => vi.fn());
+
+// Stub the modules the controller imports that would otherwise pull electron /
+// ssh / agent side effects at load. We only exercise getConnectionStatus.
+vi.mock('@main/core/agents/agent-defaults', () => ({ suggestAgentDefaults: vi.fn() }));
+vi.mock('@main/core/agents/propagate-server-api-url', () => ({ propagateServerApiUrl: vi.fn() }));
+vi.mock('@main/core/agents/resolve-servers', () => ({ resolveAgentServers: vi.fn() }));
+vi.mock('@main/core/agents/write-remote-switch-settings', () => ({
+  writeRemoteSwitchSettings: vi.fn(),
+}));
+vi.mock('@main/core/agents/write-switch-settings', () => ({ writeSwitchSettings: vi.fn() }));
+vi.mock('@main/core/app/service', () => ({ appService: { openExternal: vi.fn() } }));
+vi.mock('@main/core/fs/impl/ssh-fs', () => ({ SshFileSystem: vi.fn() }));
+vi.mock('@main/core/locations/location-transport', () => ({ sshConnectionIdForHost: vi.fn() }));
+vi.mock('@main/core/ssh/connect/connect-agent-ssh', () => ({ ensureSshConnected: vi.fn() }));
+vi.mock('@main/core/managed-switch-server/managed-server-status', () => ({
+  isManagedServerRunning,
+}));
+vi.mock('./auth', () => ({ oidcLogin: vi.fn(), passwordLogin: vi.fn() }));
+vi.mock('./gateway-web', () => ({ openAuthenticatedGatewayPage: vi.fn() }));
+vi.mock('./gateway-client', () => ({
+  fetchMe,
+  agentExistsOnServer: vi.fn(),
+  fetchAgentDetail: vi.fn(),
+  fetchAgentRooms: vi.fn(),
+  fetchAgents: vi.fn(),
+  fetchAuthConfig: vi.fn(),
+  fetchRoomRoles: vi.fn(),
+  fetchRooms: vi.fn(),
+  registerKnownAgent: vi.fn(),
+  GatewayError: class GatewayError extends Error {},
+}));
+vi.mock('./servers-store', () => ({
+  getServer,
+  addServer: vi.fn(),
+  deleteSessionCookie: vi.fn(),
+  getActiveServerId: vi.fn(),
+  listServers: vi.fn(),
+  removeServer: vi.fn(),
+  renameServer: vi.fn(),
+  setActiveServerId: vi.fn(),
+  updateServer: vi.fn(),
+}));
+
+const { switchServersController } = await import('./controller');
+
+const USER = { id: 'u1', name: 'Dev', email: 'dev@example.com', role: 'admin' };
+
+function server(overrides: Record<string, unknown>) {
+  return {
+    id: 'srv',
+    name: 'S',
+    gatewayUrl: 'http://localhost:3300',
+    apiUrl: 'http://localhost:8000',
+    managed: false,
+    managementKind: null,
+    sshHost: null,
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+describe('getConnectionStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('short-circuits to disconnected for a managed server that is not running, without probing', async () => {
+    getServer.mockResolvedValue(server({ managed: true, managementKind: 'local' }));
+    isManagedServerRunning.mockReturnValue(false);
+
+    const status = await switchServersController.getConnectionStatus('srv');
+
+    expect(status).toEqual({ serverId: 'srv', connected: false, user: null });
+    expect(fetchMe).not.toHaveBeenCalled();
+  });
+
+  it('probes a managed server that is running', async () => {
+    getServer.mockResolvedValue(server({ managed: true, managementKind: 'local' }));
+    isManagedServerRunning.mockReturnValue(true);
+    fetchMe.mockResolvedValue(USER);
+
+    const status = await switchServersController.getConnectionStatus('srv');
+
+    expect(status).toEqual({ serverId: 'srv', connected: true, user: USER });
+    expect(fetchMe).toHaveBeenCalledOnce();
+  });
+
+  it('probes an external (non-managed) server regardless of the running check', async () => {
+    getServer.mockResolvedValue(server({ managed: false }));
+    fetchMe.mockResolvedValue(USER);
+
+    const status = await switchServersController.getConnectionStatus('srv');
+
+    expect(status).toEqual({ serverId: 'srv', connected: true, user: USER });
+    expect(isManagedServerRunning).not.toHaveBeenCalled();
+    expect(fetchMe).toHaveBeenCalledOnce();
+  });
+});

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
@@ -7,6 +7,7 @@ import { writeSwitchSettings } from '@main/core/agents/write-switch-settings';
 import { appService } from '@main/core/app/service';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
 import { sshConnectionIdForHost } from '@main/core/locations/location-transport';
+import { isManagedServerRunning } from '@main/core/managed-switch-server/managed-server-status';
 import { ensureSshConnected } from '@main/core/ssh/connect/connect-agent-ssh';
 import type { AgentProviderKind } from '@shared/core/switch-servers/switch-servers';
 import type {
@@ -177,6 +178,13 @@ export const switchServersController = createRPCController({
 
   getConnectionStatus: async (serverId: string): Promise<ServerConnectionStatus> => {
     const server = await requireServer(serverId);
+    // A managed server whose stack isn't running is knowably unreachable — its
+    // gateway port isn't listening — so probing it only yields a network error
+    // that spams the logs (CHOO-1657). Report it as disconnected without the
+    // round-trip; genuine failures for a running stack still surface below.
+    if (server.managed && !isManagedServerRunning(server)) {
+      return { serverId, connected: false, user: null };
+    }
     try {
       const user = await fetchMe(server);
       return { serverId, connected: true, user };


### PR DESCRIPTION
## What & why

Jira: [CHOO-1657](https://sandboxquantum.atlassian.net/browse/CHOO-1657)

When a **managed** Switch server's stack isn't running, switchdash still polled `switchServers.getConnectionStatus` → `fetchMe` → `gatewayFetch`, which throws `GatewayError('network', "Could not reach http://localhost:PORT: fetch failed")`. The handler only swallowed `unauthorized`, so the network error re-threw and Electron's `ipcMain.handle` logged the rejected handler on **every poll** — spamming the logs for the entirely expected "server is down" case. The renderer already maps any failure to a "disconnected" status, so the throw achieved nothing useful.

## Change

- **New helper** `isManagedServerRunning(server)` in `managed-switch-server/managed-server-status.ts`. It routes local vs. remote the same way the existing `managedServerSecretsKey` does (remote → per-host status; local or legacy null-kind → local status) and reads each supervisor's lifecycle `phase`. Both services reconcile the real stack state at boot (`initialize()`), so the phase is authoritative. Returns `false` for external (non-managed) servers.
- **`getConnectionStatus`** short-circuits to `{ serverId, connected: false, user: null }` when `server.managed && !isManagedServerRunning(server)` — no network call, no error, no log.

## Non-regression

- Running managed server → phase `running` → still does the real `fetchMe` check.
- External / remote non-managed servers → `server.managed` is false → path unchanged.
- Genuinely unexpected errors for a running/reachable stack still propagate (fail-loud preserved).

## Tests

- `managed-server-status.test.ts` — 6 cases (external, local running/stopped, legacy null kind, remote per-host, remote missing host, non-running phases).
- `switch-servers/controller.test.ts` — stopped managed server returns disconnected **without** calling `fetchMe`; running managed server still probes; external server probes regardless.

Local checks: new tests 9/9, `typecheck` clean, `lint` clean, formatting clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1657]: https://sandboxquantum.atlassian.net/browse/CHOO-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ