### PR TITLE
fix(switchdash): fix slow boot from agent-storage migration + restore vanished sessions (CHOO-1440)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/agents/agent-storage-migration-marker.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/agent-storage-migration-marker.ts
@@ -1,0 +1,23 @@
+import { eq, sql } from 'drizzle-orm';
+import { db } from '@main/db/client';
+import { kv } from '@main/db/schema';
+
+/**
+ * Persisted marker recording that the CHOO-1440 agent-storage migration has
+ * completed a full, error-free pass. Once set, {@link migrateAgentStorage}
+ * short-circuits at boot instead of re-opening every agent's workspace
+ * filesystem (an SSH/SFTP round trip per remote agent) on every launch.
+ */
+const MARKER_KEY = 'agentStorageMigrationComplete';
+
+export async function isAgentStorageMigrationComplete(): Promise<boolean> {
+  const [row] = await db.select().from(kv).where(eq(kv.key, MARKER_KEY)).limit(1);
+  return row?.value === '1';
+}
+
+export async function markAgentStorageMigrationComplete(): Promise<void> {
+  await db
+    .insert(kv)
+    .values({ key: MARKER_KEY, value: '1', updatedAt: sql`CURRENT_TIMESTAMP` })
+    .onConflictDoUpdate({ target: kv.key, set: { value: '1', updatedAt: sql`CURRENT_TIMESTAMP` } });
+}

--- a/dash/apps/switchdash-desktop/src/main/core/agents/migrate-agent-storage.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/migrate-agent-storage.test.ts
@@ -70,6 +70,9 @@ const h = vi.hoisted(() => {
     ),
     discoverLocal: vi.fn(async () => []),
     updateAgent: vi.fn(async () => undefined),
+    isComplete: vi.fn(async () => false),
+    markComplete: vi.fn(async () => undefined),
+    backfill: vi.fn(async () => 0),
   };
 });
 
@@ -101,6 +104,13 @@ vi.mock('./updateAgent', () => ({ updateAgent: h.updateAgent }));
 vi.mock('@main/core/switch-servers/gateway-client', () => ({ fetchAgentDetail: vi.fn() }));
 vi.mock('@main/core/switch-servers/servers-store', () => ({ getServer: vi.fn() }));
 vi.mock('@main/lib/logger', () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('./agent-storage-migration-marker', () => ({
+  isAgentStorageMigrationComplete: h.isComplete,
+  markAgentStorageMigrationComplete: h.markComplete,
+}));
+vi.mock('@main/core/sessions/operations/backfillSessionAgentName', () => ({
+  backfillSessionAgentName: h.backfill,
+}));
 
 import { migrateAgentStorage } from './migrate-agent-storage';
 
@@ -173,5 +183,76 @@ describe('migrateAgentStorage', () => {
 
     expect(h.writeCredentials).not.toHaveBeenCalled();
     expect(await ws.exists('.switch/agents/cc-hoot-main.json')).toBe(false);
+  });
+
+  it('skips the whole pass (no workspace opened) once the marker is set', async () => {
+    h.isComplete.mockResolvedValueOnce(true);
+    const resolveWorkspaceFsFor = (await import('./agent-workspace-fs')).resolveWorkspaceFsFor;
+
+    await migrateAgentStorage();
+
+    expect(resolveWorkspaceFsFor).not.toHaveBeenCalled();
+    expect(h.writeCredentials).not.toHaveBeenCalled();
+    expect(h.markComplete).not.toHaveBeenCalled();
+  });
+
+  it('latches the marker after a clean pass', async () => {
+    h.state.workspace = fakeFs({
+      '.switch/agents/cc-hoot-main.json': credsJson('sw-1'),
+      '.claude/agents/cc-hoot-main.md': '# def',
+    });
+
+    await migrateAgentStorage();
+
+    expect(h.markComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not latch the marker when an agent migration throws', async () => {
+    h.state.workspace = fakeFs({
+      '.switch/agents/cc-hoot-main.json': credsJson('sw-1'),
+      '.claude/agents/cc-hoot-main.md': '# def',
+    });
+    h.readDefinition.mockRejectedValueOnce(new Error('host unreachable'));
+
+    await migrateAgentStorage();
+
+    expect(h.markComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not latch the marker when an agent name cannot be resolved', async () => {
+    h.state.agents = [{ ...baseAgent, definitionName: null }];
+    h.discoverLocal.mockResolvedValueOnce([]);
+    h.state.workspace = fakeFs({});
+
+    await migrateAgentStorage();
+
+    expect(h.markComplete).not.toHaveBeenCalled();
+  });
+
+  it('backfills session agentName so migrated sessions stay grouped under the agent', async () => {
+    h.state.workspace = fakeFs({
+      '.switch/agents/cc-hoot-main.json': credsJson('sw-1'),
+      '.claude/agents/cc-hoot-main.md': '# def',
+    });
+
+    await migrateAgentStorage();
+
+    expect(h.backfill).toHaveBeenCalledWith('agent-id-1', 'cc-hoot-main');
+  });
+
+  it('backfills even when definitionName was already set (repairs a prior migration)', async () => {
+    // definitionName is already populated (an earlier migration ran) but old
+    // sessions still carry no agentName — the backfill must still repair them.
+    h.state.agents = [{ ...baseAgent, definitionName: 'cc-hoot-main' }];
+    h.backfill.mockResolvedValueOnce(3);
+    h.state.workspace = fakeFs({
+      '.switch/agents/cc-hoot-main.json': credsJson('sw-1'),
+      '.claude/agents/cc-hoot-main.md': '# def',
+    });
+
+    await migrateAgentStorage();
+
+    expect(h.updateAgent).not.toHaveBeenCalled();
+    expect(h.backfill).toHaveBeenCalledWith('agent-id-1', 'cc-hoot-main');
   });
 });

--- a/dash/apps/switchdash-desktop/src/main/core/agents/migrate-agent-storage.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/migrate-agent-storage.ts
@@ -1,10 +1,15 @@
 import { getLocationById } from '@main/core/locations/store';
 import { getPlugin } from '@main/core/providers/plugin-registry';
+import { backfillSessionAgentName } from '@main/core/sessions/operations/backfillSessionAgentName';
 import { parseSwitchAgentCredentials } from '@main/core/switch-rooms/switch-credentials';
 import { fetchAgentDetail } from '@main/core/switch-servers/gateway-client';
 import { getServer } from '@main/core/switch-servers/servers-store';
 import { log } from '@main/lib/logger';
 import type { Agent } from '@shared/core/agents/agents';
+import {
+  isAgentStorageMigrationComplete,
+  markAgentStorageMigrationComplete,
+} from './agent-storage-migration-marker';
 import { resolveWorkspaceFsFor } from './agent-workspace-fs';
 import { getAgents } from './getAgents';
 import { agentSettingsRelativePath, SWITCH_SETTINGS_RELATIVE_PATH } from './switch-settings-paths';
@@ -25,12 +30,21 @@ import { updateAgent } from './updateAgent';
  * through the same provider filesystem abstraction.
  */
 export async function migrateAgentStorage(): Promise<void> {
+  // Once a full pass has migrated every agent, never re-run: the steady-state
+  // migration re-opens each agent's workspace filesystem (an SSH/SFTP round trip
+  // per remote agent) on every boot for no benefit.
+  if (await isAgentStorageMigrationComplete()) return;
+
   const agents = await getAgents();
   let migrated = 0;
+  let allComplete = true;
   for (const agent of agents) {
     try {
-      if (await migrateOne(agent)) migrated += 1;
+      const result = await migrateOne(agent);
+      if (result.changed) migrated += 1;
+      if (!result.complete) allComplete = false;
     } catch (error) {
+      allComplete = false;
       log.warn('migrateAgentStorage: failed to migrate agent', {
         agentId: agent.id,
         error: String(error),
@@ -40,15 +54,26 @@ export async function migrateAgentStorage(): Promise<void> {
   if (migrated > 0) {
     log.info('migrateAgentStorage: migrated agents to the neutral storage layout', { migrated });
   }
+  // Only latch the marker when every agent reached the final layout this pass.
+  // A transient failure (unreachable host, gateway down) leaves it unset so the
+  // next boot retries — cheaply, since the migration now runs off the boot path.
+  if (allComplete) await markAgentStorageMigrationComplete();
 }
 
-/** Migrate one agent (local or remote); returns whether anything changed. */
-async function migrateOne(agent: Agent): Promise<boolean> {
+interface MigrateResult {
+  /** Whether this pass wrote anything for the agent. */
+  changed: boolean;
+  /** Whether the agent is now fully in the new layout (nothing left to retry). */
+  complete: boolean;
+}
+
+/** Migrate one agent (local or remote). */
+async function migrateOne(agent: Agent): Promise<MigrateResult> {
   const behavior = getPlugin(agent.providerId).behavior.repoAgents;
-  if (!behavior) return false;
+  if (!behavior) return { changed: false, complete: true };
 
   const location = await getLocationById(agent.locationId);
-  if (!location) return false;
+  if (!location) return { changed: false, complete: true };
 
   const workspace = await resolveWorkspaceFsFor(location.sshHost, location.dir);
   try {
@@ -60,7 +85,9 @@ async function migrateOne(agent: Agent): Promise<boolean> {
     let name = agent.definitionName;
     let description = agent.name;
     if (!name) {
-      if (!agent.switchAgentId) return false;
+      // No switchAgentId → nothing anchors a real name; leave for a later boot
+      // in case the row is still being populated.
+      if (!agent.switchAgentId) return { changed: false, complete: false };
       const discovered = await behavior.discoverLocal(workspace.fs, workspace.homeFs);
       const match = discovered.find((d) => d.switchAgentId === agent.switchAgentId);
       if (match) {
@@ -73,7 +100,8 @@ async function migrateOne(agent: Agent): Promise<boolean> {
             agentId: agent.id,
             switchAgentId: agent.switchAgentId,
           });
-          return false;
+          // Resolution may fail transiently (gateway down); retry next boot.
+          return { changed: false, complete: false };
         }
         name = registered.name;
         description = registered.description;
@@ -136,7 +164,22 @@ async function migrateOne(agent: Agent): Promise<boolean> {
       changed = true;
     }
 
-    return changed;
+    // 4. Backfill this agent's own pre-existing sessions: they froze no
+    //    `agentName` (created before it had a definitionName), so the sidebar —
+    //    which pairs a session to its agent by `agentName === definitionName` —
+    //    would orphan them once definitionName is set. Idempotent, and run even
+    //    when definitionName was already populated so installs that ran an
+    //    earlier migration (before this backfill existed) are repaired too.
+    const backfilled = await backfillSessionAgentName(agent.id, name);
+    if (backfilled > 0) {
+      log.info('migrateAgentStorage: backfilled session agentName for migrated agent', {
+        agentId: agent.id,
+        backfilled,
+      });
+      changed = true;
+    }
+
+    return { changed, complete: true };
   } finally {
     workspace.close();
   }

--- a/dash/apps/switchdash-desktop/src/main/core/sessions/operations/backfillSessionAgentName.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/sessions/operations/backfillSessionAgentName.ts
@@ -1,0 +1,36 @@
+import { eq } from 'drizzle-orm';
+import { db } from '@main/db/client';
+import { sessions } from '@main/db/schema';
+
+/**
+ * Backfill `config.agentName` on an agent's own pre-existing sessions to match
+ * its definitionName.
+ *
+ * `createSession` freezes a session's `agentName` from its agent's
+ * `definitionName` at creation time, and the sidebar joins a session to its
+ * agent by `agentName === definitionName`. Sessions created before the agent had
+ * a definitionName froze no `agentName`, so once the CHOO-1440 migration
+ * populates `definitionName` those sessions match no agent and vanish from the
+ * tree (they still exist and open via deeplink). This restores the pairing.
+ *
+ * Idempotent: only sessions with no `agentName`/`subagentName` are touched, so
+ * re-running is a no-op and sessions launched as a different definition (a former
+ * subagent) are left alone. Returns the number of sessions updated.
+ */
+export async function backfillSessionAgentName(
+  agentId: string,
+  definitionName: string
+): Promise<number> {
+  const rows = await db.select().from(sessions).where(eq(sessions.agentId, agentId));
+  let updated = 0;
+  for (const row of rows) {
+    const config = row.config ?? {};
+    if (config.agentName || config.subagentName) continue;
+    await db
+      .update(sessions)
+      .set({ config: { ...config, agentName: definitionName } })
+      .where(eq(sessions.id, row.id));
+    updated += 1;
+  }
+  return updated;
+}

--- a/dash/apps/switchdash-desktop/src/main/index.ts
+++ b/dash/apps/switchdash-desktop/src/main/index.ts
@@ -121,11 +121,12 @@ void app.whenReady().then(async () => {
     log.warn('switch-agents: failed to reconcile agent → server links at boot', { error: e });
   }
 
-  try {
-    await migrateAgentStorage();
-  } catch (e) {
+  // Kept off the boot path: this can open an SSH/SFTP connection per remote
+  // agent, so awaiting it here delayed the window opening. Session relaunch below
+  // waits on it (it needs each agent's definitionName); nothing else does.
+  const migrationReady = migrateAgentStorage().catch((e) => {
     log.warn('switch-agents: failed to migrate agent storage layout at boot', { error: e });
-  }
+  });
 
   const agentHookReady = agentHookService.initialize().catch((e) => {
     log.error('Failed to start agent event service:', e);
@@ -153,7 +154,7 @@ void app.whenReady().then(async () => {
   // Restore first so already-live sessions register their room connections,
   // then start the auto_session watchers — the watcher's "is a session already
   // attending this room?" check relies on those connections being present.
-  void Promise.all([agentHookReady, dependenciesReady]).then(async () => {
+  void Promise.all([agentHookReady, dependenciesReady, migrationReady]).then(async () => {
     try {
       await restoreSwitchRoomSessions();
     } catch (e) {


### PR DESCRIPTION
## Problem

Two issues, both stemming from the CHOO-1440 agent-storage migration that runs at boot:

1. **Boot takes forever.** `migrateAgentStorage()` was `await`ed before the main window was created, and re-ran in full on *every* launch — opening a workspace filesystem (an SSH/SFTP round trip per remote agent) for every agent even when nothing needed migrating. An unreachable remote host could stall the whole boot.

2. **Existing sessions vanished from the sidebar** after the migration. They still existed in the DB (openable via deeplink) but no longer appeared in the tree.

## Root causes

**Boot:** the migration blocked window creation (awaited at `index.ts` before `createMainWindow()`), and had no completion marker, so its per-agent filesystem/SSH work ran on every boot.

**Vanished sessions:** the sidebar pairs a session with its agent by matching the session's frozen `agentName` against the agent's current `definitionName`. `createSession` freezes `agentName` from the agent's `definitionName` at creation time. Pre-existing sessions were created when the agent's `definitionName` was `null`, so they froze *no* `agentName` and matched the sidebar's null-definition catch-all. The migration then set the agent's `definitionName`, so those sessions matched no agent and disappeared.

## Changes

- **One-time completion marker** in the `kv` table (`agent-storage-migration-marker.ts`): once a full, error-free pass migrates every agent, steady-state boots skip the migration entirely. Transient failures (unreachable host, gateway down, unresolved name) leave the marker unset so the next boot retries.
- **Migration off the boot path** (`index.ts`): no longer awaited before the window opens; its promise is chained only into the session-relaunch step (the one thing that needs `definitionName`).
- **`backfillSessionAgentName` operation**: idempotently sets `config.agentName` on an agent's own sessions that froze none, matching its `definitionName` — exactly the transform `createSession` applies to new sessions. Run for every resolved agent during the migration (not only when `definitionName` is newly set) so installs that already ran an earlier migration are repaired. Sessions launched as a different definition (former subagents) already carry a name and are left untouched.

## Notes

- The completion marker uses a brand-new `kv` key that no released build has set, so the fixed build is guaranteed one clean migration pass — including the backfill — before it latches.
- Deeper fragility left as a follow-up: grouping sessions by a frozen `agentName` string that can drift from the agent row is inherently brittle; the robust design would group by the session's `agentId` FK, but legacy former-subagent sessions can share a parent `agentId`, so an id-only regroup needs care.

## Testing

- `migrate-agent-storage.test.ts`: 10 passing tests (incl. skip-when-marked, latch-after-clean-pass, no-latch-on-failure, backfill-on-set, backfill-when-already-set/repair).
- Full agents + sessions suites pass (109 tests); `typecheck`, `lint`, `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)