### PR TITLE
feat(switchdash): per-agent remote sidecar UI (CHOO-1425)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/agent-runtime/impl/ensure-agent-sidecar.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agent-runtime/impl/ensure-agent-sidecar.ts
@@ -6,17 +6,15 @@ import {
   RemoteSidecarLauncher,
   type SidecarEndpoint,
   type SidecarHost,
+  type SidecarRunStatus,
 } from './remote-sidecar-launcher';
 import { resolveSidecarBundlePath } from './resolve-sidecar-bundle';
 
 /**
- * Deploy + launch (or reattach to) the one agent-scoped remote sidecar and
- * return its hook endpoint. Shared by the SSH agent runtime (which
- * points a UI-started session's hook env at the endpoint) and the auto-session
- * setup path (which just needs the sidecar — and its watcher — running). One
- * sidecar per remote repo dir, so both callers reattach to the same instance.
+ * The parameters every sidecar operation shares: enough to identify the agent's
+ * sidecar on the host and (re)generate its launch recipe.
  */
-export async function ensureAgentSidecar(params: {
+export interface AgentSidecarParams {
   providerId: string;
   /** Absolute remote repo dir; the agent's Switch creds + bundle live under it. */
   repoDir: string;
@@ -32,35 +30,41 @@ export async function ensureAgentSidecar(params: {
   ctx: IExecutionContext;
   connectionId: string;
   host: SidecarHost;
-}): Promise<SidecarEndpoint> {
-  const {
-    providerId,
-    repoDir,
-    deeplinkScheme,
-    autoApprove,
-    credsSlug,
-    definitionName,
-    ctx,
-    connectionId,
-    host,
-  } = params;
+}
+
+async function buildLauncher(params: AgentSidecarParams): Promise<RemoteSidecarLauncher> {
   const launchSpec = await generateAgentLaunchSpec({
-    providerId,
-    remoteRepoDir: repoDir,
-    deeplinkScheme,
-    autoApprove,
-    agentName: definitionName,
-    ctx,
-    connectionId,
+    providerId: params.providerId,
+    remoteRepoDir: params.repoDir,
+    deeplinkScheme: params.deeplinkScheme,
+    autoApprove: params.autoApprove,
+    agentName: params.definitionName,
+    ctx: params.ctx,
+    connectionId: params.connectionId,
   });
-  const launcher = new RemoteSidecarLauncher({
-    host,
+  return new RemoteSidecarLauncher({
+    host: params.host,
     bundlePath: resolveSidecarBundlePath(),
-    sidecarTmuxName: agentSidecarTmuxName(repoDir, credsSlug),
-    config: { repoDir, deeplinkScheme, launchSpec, credsSlug },
+    sidecarTmuxName: agentSidecarTmuxName(params.repoDir, params.credsSlug),
+    config: {
+      repoDir: params.repoDir,
+      deeplinkScheme: params.deeplinkScheme,
+      launchSpec,
+      credsSlug: params.credsSlug,
+    },
     log,
   });
-  return launcher.deployAndLaunch();
+}
+
+/**
+ * Deploy + launch (or reattach to) the one agent-scoped remote sidecar and
+ * return its hook endpoint. Shared by the SSH agent runtime (which points a
+ * UI-started session's hook env at the endpoint) and the auto-session setup path
+ * (which just needs the sidecar — and its watcher — running). One sidecar per
+ * remote repo dir, so both callers reattach to the same instance.
+ */
+export async function ensureAgentSidecar(params: AgentSidecarParams): Promise<SidecarEndpoint> {
+  return (await buildLauncher(params)).deployAndLaunch();
 }
 
 /**
@@ -70,49 +74,54 @@ export async function ensureAgentSidecar(params: {
  * just to poll. When no sidecar is up there is nothing to discover, so callers
  * treat null as "no sessions this tick".
  */
-export async function probeAgentSidecar(params: {
-  providerId: string;
-  repoDir: string;
-  deeplinkScheme: string;
-  /** The agent's bypass-permissions setting. Probe never writes the spec, so this
-   * only shapes the (unused) config; pass the real value for consistency. */
-  autoApprove: boolean;
-  /** Per-agent creds slug (definition name, else agent id). Probe never launches,
-   * so this only shapes the (unused) config; pass the real value for consistency. */
-  credsSlug: string;
-  /** The agent's definition name (null if none). Probe never launches; passed for
-   * consistency with ensureAgentSidecar. */
-  definitionName: string | null;
-  ctx: IExecutionContext;
-  connectionId: string;
-  host: SidecarHost;
-}): Promise<SidecarEndpoint | null> {
-  const {
-    providerId,
-    repoDir,
-    deeplinkScheme,
-    autoApprove,
-    credsSlug,
-    definitionName,
-    ctx,
-    connectionId,
-    host,
-  } = params;
-  const launchSpec = await generateAgentLaunchSpec({
-    providerId,
-    remoteRepoDir: repoDir,
-    deeplinkScheme,
-    autoApprove,
-    agentName: definitionName,
-    ctx,
-    connectionId,
-  });
-  const launcher = new RemoteSidecarLauncher({
-    host,
-    bundlePath: resolveSidecarBundlePath(),
-    sidecarTmuxName: agentSidecarTmuxName(repoDir, credsSlug),
-    config: { repoDir, deeplinkScheme, launchSpec, credsSlug },
-    log,
-  });
-  return launcher.probeExisting();
+export async function probeAgentSidecar(
+  params: AgentSidecarParams
+): Promise<SidecarEndpoint | null> {
+  return (await buildLauncher(params)).probeExisting();
+}
+
+/**
+ * Read-only status of an agent's sidecar for the UI (running? which build/
+ * protocol/epoch/pid? how many live sessions?), plus this client's own bundle
+ * hash so the caller can render the client-vs-host verdict. Never launches.
+ */
+export async function readAgentSidecarStatus(
+  params: AgentSidecarParams
+): Promise<{ status: SidecarRunStatus; clientHash: string }> {
+  const launcher = await buildLauncher(params);
+  const [status, clientHash] = await Promise.all([
+    launcher.readStatus(),
+    launcher.localBundleHash(),
+  ]);
+  return { status, clientHash };
+}
+
+/**
+ * Stop an agent's sidecar (kills its tmux session). Sessions keep running in
+ * their own panes; they simply lose room injection until a sidecar is back.
+ */
+export async function stopAgentSidecar(params: AgentSidecarParams): Promise<void> {
+  await (await buildLauncher(params)).stop();
+}
+
+/**
+ * Force a fresh sidecar process: stop the running one, then deploy + launch.
+ *
+ * `ensureAgentSidecar` alone reattaches to a same-build sidecar and defers an
+ * upgrade while sessions are live, so it is not a restart. This is the explicit
+ * "restart / force upgrade now" the UI offers — safe because sessions follow
+ * the new process via the endpoint file.
+ */
+export async function restartAgentSidecar(params: AgentSidecarParams): Promise<SidecarEndpoint> {
+  const launcher = await buildLauncher(params);
+  await launcher.stop();
+  return launcher.deployAndLaunch();
+}
+
+/** Best-effort tail of an agent's sidecar log, for the UI's debug view. */
+export async function readAgentSidecarLog(
+  params: AgentSidecarParams,
+  lines: number
+): Promise<string> {
+  return (await buildLauncher(params)).logTail(lines);
 }

--- a/dash/apps/switchdash-desktop/src/main/core/agent-runtime/impl/remote-sidecar-launcher.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agent-runtime/impl/remote-sidecar-launcher.ts
@@ -82,6 +82,26 @@ interface ReadyLine {
   /** Wire-contract version. Absent from a sidecar predating the field, which is
    * treated as 0. */
   protocolVersion: number | null;
+  /** OS process id of the running sidecar, for display. Absent from an older one. */
+  pid: number | null;
+}
+
+/**
+ * Read-only view of the sidecar running on the host, for the UI. Independent of
+ * whether this client's bundle matches — that comparison (the verdict) is the
+ * caller's to make, since it needs the client's own hash and protocol.
+ */
+export interface SidecarRunStatus {
+  running: boolean;
+  /** Whether this client can speak to it (protocol in range). */
+  compatible: boolean;
+  /** Build fingerprint the running sidecar reports for itself. */
+  hash: string | null;
+  protocolVersion: number | null;
+  epoch: number | null;
+  pid: number | null;
+  /** Sessions the running sidecar currently owns, from its durable state. */
+  liveSessions: number;
 }
 
 /** Narrow remote seam the launcher needs — satisfied by IExecutionContext + ssh-fs. */
@@ -132,7 +152,8 @@ function parseReady(raw: string): ReadyLine | null {
       'protocolVersion' in parsed && typeof parsed.protocolVersion === 'number'
         ? parsed.protocolVersion
         : null;
-    return { port: parsed.port, token: parsed.token, hash, epoch, protocolVersion };
+    const pid = 'pid' in parsed && typeof parsed.pid === 'number' ? parsed.pid : null;
+    return { port: parsed.port, token: parsed.token, hash, epoch, protocolVersion, pid };
   }
   return null;
 }
@@ -422,6 +443,45 @@ export class RemoteSidecarLauncher {
    * asks "can I talk to it", and answering that with the *upgrade* question made
    * every client on a different build report zero sessions and prune live rows.
    */
+  /**
+   * Read-only status of the sidecar on the host, for display. Never launches,
+   * deploys, or writes. Returns `running: false` when none is up; otherwise the
+   * running sidecar's self-reported identity plus its live-session count.
+   *
+   * The client-vs-host verdict is intentionally left to the caller — it needs
+   * this client's own bundle hash and protocol, which the launcher exposes via
+   * `localBundleHash()` and the shared protocol constant.
+   */
+  async readStatus(): Promise<SidecarRunStatus> {
+    const ready = await this.readRunning();
+    if (!ready) {
+      return {
+        running: false,
+        compatible: false,
+        hash: null,
+        protocolVersion: null,
+        epoch: null,
+        pid: null,
+        liveSessions: 0,
+      };
+    }
+    return {
+      running: true,
+      compatible: this.isCompatible(ready),
+      hash: ready.hash,
+      protocolVersion: ready.protocolVersion,
+      epoch: ready.epoch,
+      pid: ready.pid,
+      liveSessions: await this.runningSessionCount(),
+    };
+  }
+
+  /** This client's own bundle fingerprint, for the caller to compare against
+   * `readStatus().hash`. */
+  localBundleHash(): Promise<string> {
+    return this.hashBundle();
+  }
+
   async probeExisting(): Promise<SidecarEndpoint | null> {
     const ready = await this.readRunning();
     if (!ready) return null;
@@ -593,13 +653,18 @@ export class RemoteSidecarLauncher {
 
   /** Best-effort tail of the sidecar log, so a startup crash surfaces its actual
    * error (e.g. a SyntaxError from too-old node) instead of an opaque message. */
-  private async readLogTail(): Promise<string> {
+  private async readLogTail(lines = 20): Promise<string> {
     try {
-      const { stdout } = await this.host.exec('tail', ['-n', '20', this.logPath]);
+      const { stdout } = await this.host.exec('tail', ['-n', String(lines), this.logPath]);
       return stdout.trim();
     } catch {
       return '';
     }
+  }
+
+  /** Public log tail for the UI's debug panel. Best-effort — empty on any error. */
+  logTail(lines: number): Promise<string> {
+    return this.readLogTail(lines);
   }
 
   private async readReadyFile(): Promise<string | null> {

--- a/dash/apps/switchdash-desktop/src/main/core/sidecar/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/sidecar/controller.ts
@@ -1,0 +1,124 @@
+import { DEEPLINK_SCHEME } from '@main/app/deeplinks';
+import {
+  type AgentSidecarParams,
+  ensureAgentSidecar,
+  readAgentSidecarLog,
+  readAgentSidecarStatus,
+  restartAgentSidecar,
+  stopAgentSidecar,
+} from '@main/core/agent-runtime/impl/ensure-agent-sidecar';
+import { getRemoteAgentLocation } from '@main/core/agents/agent-location';
+import { connectRemoteAgent } from '@main/core/agents/connect-remote-agent';
+import { getAgentById } from '@main/core/agents/getAgentById';
+import { events } from '@main/lib/events';
+import { log } from '@main/lib/logger';
+import type { Agent } from '@shared/core/agents/agents';
+import { type AgentSidecarStatus, sidecarStatusChannel } from '@shared/events/sidecarEvents';
+import { createRPCController } from '@shared/lib/ipc/rpc';
+import { SIDECAR_PROTOCOL_VERSION } from '../../../sidecar/sidecar-protocol';
+import { verdictFor } from './verdict';
+
+const LOG_TAIL_LINES = 100;
+
+async function requireRemoteAgent(
+  agentId: string
+): Promise<{ agent: Agent; sshHost: string; repoDir: string; credsSlug: string }> {
+  const agent = await getAgentById(agentId);
+  if (!agent) throw new Error(`sidecar: unknown agent ${agentId}`);
+  const location = await getRemoteAgentLocation(agent);
+  if (!location) throw new Error(`sidecar: agent ${agentId} is not at a remote location`);
+  return {
+    agent,
+    sshHost: location.sshHost,
+    repoDir: location.dir,
+    credsSlug: agent.definitionName ?? agent.id,
+  };
+}
+
+/** Build the shared sidecar params from a connected remote agent. */
+async function paramsForAgent(agent: Agent): Promise<AgentSidecarParams> {
+  const conn = await connectRemoteAgent(agent);
+  return {
+    providerId: agent.providerId,
+    repoDir: conn.remoteRepoDir,
+    deeplinkScheme: DEEPLINK_SCHEME,
+    autoApprove: agent.autoApprove,
+    credsSlug: agent.definitionName ?? agent.id,
+    definitionName: agent.definitionName ?? null,
+    ctx: conn.ctx,
+    connectionId: conn.connectionId,
+    host: conn.host,
+  };
+}
+
+/**
+ * Read status for an agent, assemble the full UI shape, and broadcast it so any
+ * open page updates live. Shared by the read path and by every mutation, which
+ * re-read and re-emit once they finish.
+ */
+async function readAndBroadcast(agentId: string): Promise<AgentSidecarStatus> {
+  const { agent, sshHost, repoDir, credsSlug } = await requireRemoteAgent(agentId);
+  const { status, clientHash } = await readAgentSidecarStatus(await paramsForAgent(agent));
+  const full: AgentSidecarStatus = {
+    agentId,
+    running: status.running,
+    verdict: verdictFor(status, clientHash),
+    clientHash,
+    clientProtocol: SIDECAR_PROTOCOL_VERSION,
+    deployedHash: status.hash,
+    deployedProtocol: status.protocolVersion,
+    epoch: status.epoch,
+    pid: status.pid,
+    liveSessions: status.liveSessions,
+    repoDir,
+    sshHost,
+    credsSlug,
+  };
+  events.emit(sidecarStatusChannel, full);
+  return full;
+}
+
+export const sidecarController = createRPCController({
+  /** Read-only status for one agent's sidecar. Never launches one. */
+  getStatus: (agentId: string): Promise<AgentSidecarStatus> => readAndBroadcast(agentId),
+
+  /**
+   * Deploy the client's bundle if the running sidecar is a different, replaceable
+   * build (idle). Honours the defer policy — a busy sidecar is left running — so
+   * this is the "polite Update" action. Returns the refreshed status.
+   */
+  upgrade: async (agentId: string): Promise<AgentSidecarStatus> => {
+    const { agent } = await requireRemoteAgent(agentId);
+    await ensureAgentSidecar(await paramsForAgent(agent));
+    return readAndBroadcast(agentId);
+  },
+
+  /**
+   * Force a fresh sidecar process (stop + relaunch), even if the current one has
+   * live sessions — they survive via the endpoint file. The "restart / force
+   * upgrade now" action.
+   */
+  restart: async (agentId: string): Promise<AgentSidecarStatus> => {
+    const { agent } = await requireRemoteAgent(agentId);
+    await restartAgentSidecar(await paramsForAgent(agent));
+    return readAndBroadcast(agentId);
+  },
+
+  /** Stop the sidecar. Sessions keep running but lose room injection until it is back. */
+  stop: async (agentId: string): Promise<AgentSidecarStatus> => {
+    const { agent } = await requireRemoteAgent(agentId);
+    await stopAgentSidecar(await paramsForAgent(agent));
+    return readAndBroadcast(agentId);
+  },
+
+  /** Tail of the sidecar log on the host, for debugging. */
+  logTail: async (agentId: string): Promise<string> => {
+    const { agent } = await requireRemoteAgent(agentId);
+    try {
+      return await readAgentSidecarLog(await paramsForAgent(agent), LOG_TAIL_LINES);
+    } catch (error) {
+      log.warn('sidecarController: failed to read log tail', { agentId, error: String(error) });
+      return '';
+    }
+  },
+});

--- a/dash/apps/switchdash-desktop/src/main/core/sidecar/verdict.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/sidecar/verdict.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { SidecarRunStatus } from '@main/core/agent-runtime/impl/remote-sidecar-launcher';
+import { verdictFor } from './verdict';
+
+const CLIENT = 'client-hash';
+
+const status = (over: Partial<SidecarRunStatus>): SidecarRunStatus => ({
+  running: true,
+  compatible: true,
+  hash: CLIENT,
+  protocolVersion: 1,
+  epoch: 1,
+  pid: 100,
+  liveSessions: 0,
+  ...over,
+});
+
+describe('verdictFor', () => {
+  it('not-running when nothing is up', () => {
+    expect(verdictFor(status({ running: false }), CLIENT)).toBe('not-running');
+  });
+
+  it('up-to-date when the host runs this exact build', () => {
+    expect(verdictFor(status({ hash: CLIENT }), CLIENT)).toBe('up-to-date');
+  });
+
+  it('upgrade-available when a different build is running and idle', () => {
+    expect(verdictFor(status({ hash: 'other', liveSessions: 0 }), CLIENT)).toBe(
+      'upgrade-available'
+    );
+  });
+
+  it('upgrade-pending when a different build is running but busy', () => {
+    expect(verdictFor(status({ hash: 'other', liveSessions: 3 }), CLIENT)).toBe('upgrade-pending');
+  });
+
+  it('incompatible outranks any build comparison', () => {
+    // Even the same hash is moot if we cannot speak its protocol — though in
+    // practice an incompatible sidecar is a different build anyway.
+    expect(verdictFor(status({ compatible: false, hash: 'other', liveSessions: 5 }), CLIENT)).toBe(
+      'incompatible'
+    );
+  });
+});

--- a/dash/apps/switchdash-desktop/src/main/core/sidecar/verdict.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/sidecar/verdict.ts
@@ -1,0 +1,16 @@
+import type { SidecarRunStatus } from '@main/core/agent-runtime/impl/remote-sidecar-launcher';
+import type { SidecarVerdict } from '@shared/events/sidecarEvents';
+
+/**
+ * Turn a raw host status + this client's build into the client-vs-host verdict.
+ *
+ * Compatibility (can I talk to it) is checked before the build comparison (is an
+ * upgrade available), mirroring the launcher's deploy policy — a build that
+ * differs is not a problem, only a protocol that does not fit is.
+ */
+export function verdictFor(status: SidecarRunStatus, clientHash: string): SidecarVerdict {
+  if (!status.running) return 'not-running';
+  if (!status.compatible) return 'incompatible';
+  if (status.hash === clientHash) return 'up-to-date';
+  return status.liveSessions > 0 ? 'upgrade-pending' : 'upgrade-available';
+}

--- a/dash/apps/switchdash-desktop/src/main/rpc.ts
+++ b/dash/apps/switchdash-desktop/src/main/rpc.ts
@@ -15,6 +15,7 @@ import { searchController } from './core/search/controller';
 import { sessionController } from './core/sessions/controller';
 import { appSettingsController } from './core/settings/controller';
 import { providerSettingsController } from './core/settings/provider-settings-controller';
+import { sidecarController } from './core/sidecar/controller';
 import { switchRoomsController } from './core/switch-rooms/controller';
 import { switchServersController } from './core/switch-servers/controller';
 import { switchSetupController } from './core/switch-setup/controller';
@@ -42,6 +43,7 @@ export const rpcRouter = createRPCRouter({
   localSwitchServer: localSwitchServerController,
   remoteSwitchServer: remoteSwitchServerController,
   remoteHosts: remoteHostsController,
+  sidecar: sidecarController,
   fs: createRPCNamespace({
     watch: filesController,
   }),

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/settings-view/sections/sidecar-settings-section.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/settings-view/sections/sidecar-settings-section.tsx
@@ -1,0 +1,232 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, CheckCircle2, Loader2, Power, RefreshCw, XCircle } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { events, rpc } from '@renderer/lib/ipc';
+import { Badge } from '@renderer/lib/ui/badge';
+import { Button } from '@renderer/lib/ui/button';
+import { Field, FieldDescription, FieldTitle } from '@renderer/lib/ui/field';
+import { log } from '@renderer/utils/logger';
+import type { AgentSidecarStatus, SidecarVerdict } from '@shared/events/sidecarEvents';
+import { sidecarStatusChannel } from '@shared/events/sidecarEvents';
+
+/**
+ * Per-agent remote sidecar status + lifecycle controls.
+ *
+ * The sidecar is the on-VM process that keeps a remote agent connected to its
+ * Switch rooms while switchdash is closed. It is deployed and upgraded silently
+ * on connect; this section makes that state visible — which build the host runs
+ * vs. which this client ships — and lets the operator update, restart, or stop it
+ * by hand. Rendered only for remote agents (a local agent has no sidecar).
+ */
+
+const SHORT_HASH = 7;
+
+const statusQueryKey = (agentId: string): string[] => ['sidecar-status', agentId];
+
+function shortHash(hash: string | null): string {
+  return hash ? hash.slice(0, SHORT_HASH) : '—';
+}
+
+const VERDICT_DISPLAY: Record<
+  SidecarVerdict,
+  {
+    label: string;
+    variant: 'default' | 'secondary' | 'destructive' | 'outline';
+    icon: typeof CheckCircle2;
+  }
+> = {
+  'up-to-date': { label: 'Up to date', variant: 'secondary', icon: CheckCircle2 },
+  'upgrade-available': { label: 'Update available', variant: 'default', icon: RefreshCw },
+  'upgrade-pending': { label: 'Update pending', variant: 'outline', icon: AlertTriangle },
+  incompatible: { label: 'Incompatible', variant: 'destructive', icon: AlertTriangle },
+  'not-running': { label: 'Not running', variant: 'outline', icon: XCircle },
+};
+
+export function SidecarSettingsSection({ agentId }: { agentId: string }) {
+  const queryClient = useQueryClient();
+  const queryKey = statusQueryKey(agentId);
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey,
+    queryFn: () => rpc.sidecar.getStatus(agentId),
+  });
+
+  // Live refresh: the controller broadcasts on every probe/upgrade/restart/stop,
+  // so seed the cache from the event stream instead of polling.
+  useEffect(() => {
+    return events.on(sidecarStatusChannel, (status: AgentSidecarStatus) => {
+      if (status.agentId === agentId) queryClient.setQueryData(statusQueryKey(agentId), status);
+    });
+  }, [agentId, queryClient]);
+
+  const actionOptions = {
+    onError: (error: unknown) => log.error('sidecar action failed', { agentId, error }),
+    onSettled: () => void queryClient.invalidateQueries({ queryKey }),
+  };
+  const upgrade = useMutation({ mutationFn: () => rpc.sidecar.upgrade(agentId), ...actionOptions });
+  const restart = useMutation({ mutationFn: () => rpc.sidecar.restart(agentId), ...actionOptions });
+  const stop = useMutation({ mutationFn: () => rpc.sidecar.stop(agentId), ...actionOptions });
+  const busy = upgrade.isPending || restart.isPending || stop.isPending;
+
+  return (
+    <Field>
+      <div className="flex items-center justify-between gap-3">
+        <FieldTitle>Remote sidecar</FieldTitle>
+        {data && <VerdictBadge verdict={data.verdict} />}
+      </div>
+      <FieldDescription className="text-foreground-muted">
+        The on-host process that keeps this agent connected to its Switch rooms while switchdash is
+        closed. Updated automatically when switchdash connects; you can also manage it here.
+      </FieldDescription>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-sm text-foreground-muted">
+          <Loader2 className="size-3.5 animate-spin" /> Checking sidecar…
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2 text-sm">
+          <span className="text-foreground-muted">
+            Couldn&apos;t reach the host to check the sidecar.
+          </span>
+          <Button size="sm" variant="outline" onClick={() => void refetch()}>
+            <RefreshCw className="size-3.5" /> Retry
+          </Button>
+        </div>
+      )}
+
+      {data && (
+        <div className="flex flex-col gap-3">
+          <VersionRows status={data} />
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy || data.verdict === 'up-to-date' || data.verdict === 'incompatible'}
+              onClick={() => upgrade.mutate()}
+            >
+              {upgrade.isPending ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
+              Update
+            </Button>
+            <Button size="sm" variant="outline" disabled={busy} onClick={() => restart.mutate()}>
+              {restart.isPending ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
+              {data.verdict === 'incompatible' ? 'Replace' : 'Restart'}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy || !data.running}
+              onClick={() => stop.mutate()}
+            >
+              {stop.isPending ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Power className="size-3.5" />
+              )}
+              Stop
+            </Button>
+          </div>
+
+          {data.verdict === 'upgrade-pending' && (
+            <p className="text-xs text-foreground-muted">
+              An update is ready but held back because {data.liveSessions} session
+              {data.liveSessions === 1 ? '' : 's'} {data.liveSessions === 1 ? 'is' : 'are'} running.
+              It applies next time the sidecar is idle — or use Restart to apply it now (running
+              sessions reconnect automatically).
+            </p>
+          )}
+
+          <SidecarLog agentId={agentId} />
+        </div>
+      )}
+    </Field>
+  );
+}
+
+function VerdictBadge({ verdict }: { verdict: SidecarVerdict }) {
+  const { label, variant, icon: Icon } = VERDICT_DISPLAY[verdict];
+  return (
+    <Badge variant={variant}>
+      <Icon className="size-3" /> {label}
+    </Badge>
+  );
+}
+
+function VersionRows({ status }: { status: AgentSidecarStatus }) {
+  return (
+    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+      <Row
+        label="This client ships"
+        value={`build ${shortHash(status.clientHash)} · protocol v${status.clientProtocol}`}
+      />
+      <Row
+        label="Host running"
+        value={
+          status.running
+            ? `build ${shortHash(status.deployedHash)} · protocol v${status.deployedProtocol ?? '?'}` +
+              (status.epoch !== null ? ` · restart #${status.epoch}` : '') +
+              (status.pid !== null ? ` · pid ${status.pid}` : '')
+            : 'not running'
+        }
+      />
+      <Row label="Live sessions" value={String(status.liveSessions)} />
+      <Row label="Host" value={status.sshHost} />
+      <Row label="Working dir" value={status.repoDir} mono />
+    </dl>
+  );
+}
+
+function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <>
+      <dt className="text-foreground-muted">{label}</dt>
+      <dd className={mono ? 'truncate font-mono text-xs' : 'truncate'}>{value}</dd>
+    </>
+  );
+}
+
+function SidecarLog({ agentId }: { agentId: string }) {
+  const [open, setOpen] = useState(false);
+  const { data, isFetching, refetch } = useQuery({
+    queryKey: ['sidecar-log', agentId],
+    queryFn: () => rpc.sidecar.logTail(agentId),
+    enabled: open,
+  });
+
+  if (!open) {
+    return (
+      <Button size="xs" variant="ghost" className="self-start" onClick={() => setOpen(true)}>
+        Show recent log
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-foreground-muted">Recent sidecar log</span>
+        <Button size="xs" variant="ghost" disabled={isFetching} onClick={() => void refetch()}>
+          {isFetching ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <RefreshCw className="size-3" />
+          )}
+          Refresh
+        </Button>
+      </div>
+      <pre className="max-h-48 overflow-auto rounded-md border border-border bg-background-2 p-2 text-xs whitespace-pre-wrap">
+        {data ? data : 'No log output.'}
+      </pre>
+    </div>
+  );
+}

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/settings-view/settings-panel.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/settings-view/settings-panel.tsx
@@ -4,6 +4,7 @@ import { AddressingPolicySettingsSection } from '@renderer/features/locations/co
 import { AgentDefinitionSettingsSection } from '@renderer/features/locations/components/settings-view/sections/agent-definition-settings-section';
 import { AutoApproveSettingsSection } from '@renderer/features/locations/components/settings-view/sections/auto-approve-settings-section';
 import { AutoSessionSettingsSection } from '@renderer/features/locations/components/settings-view/sections/auto-session-settings-section';
+import { SidecarSettingsSection } from '@renderer/features/locations/components/settings-view/sections/sidecar-settings-section';
 import {
   asMounted,
   getLocationStore,
@@ -39,12 +40,16 @@ export const SettingsPanel = observer(function SettingsPanel() {
     : (agents ?? [])[0];
   const agentId = agent?.id;
 
+  // The sidecar is a remote-only concern — a local agent runs no on-host process.
+  const isRemote = mounted.data.sshHost !== null;
+
   return (
     <div className="flex flex-col gap-6">
       <AutoSessionSettingsSection locationId={locationId} agentId={agentId} />
       <AutoApproveSettingsSection locationId={locationId} agentId={agentId} />
       <AddressingPolicySettingsSection locationId={locationId} agentId={agentId} />
       <AgentDefinitionSettingsSection locationId={locationId} agentId={agentId} />
+      {isRemote && agentId && <SidecarSettingsSection agentId={agentId} />}
     </div>
   );
 });

--- a/dash/apps/switchdash-desktop/src/shared/events/sidecarEvents.ts
+++ b/dash/apps/switchdash-desktop/src/shared/events/sidecarEvents.ts
@@ -1,0 +1,45 @@
+import { defineEvent } from '@shared/lib/ipc/events';
+
+/**
+ * The client-vs-host relationship for one agent's remote sidecar. Derived from
+ * comparing what this client ships against what the host reports running.
+ *
+ * - `not-running` — no sidecar is up on the host.
+ * - `up-to-date` — the host runs this client's exact build.
+ * - `upgrade-available` — a different build is running and can be replaced now
+ *   (the sidecar is idle).
+ * - `upgrade-pending` — a different build is running but has live sessions, so
+ *   the upgrade is deferred until it is idle rather than interrupting work.
+ * - `incompatible` — the host runs a protocol this client cannot speak; it must
+ *   be replaced before this client can use it.
+ */
+export type SidecarVerdict =
+  | 'not-running'
+  | 'up-to-date'
+  | 'upgrade-available'
+  | 'upgrade-pending'
+  | 'incompatible';
+
+/** Full per-agent sidecar status for the UI. */
+export interface AgentSidecarStatus {
+  agentId: string;
+  running: boolean;
+  verdict: SidecarVerdict;
+  /** What this client ships. */
+  clientHash: string;
+  clientProtocol: number;
+  /** What the host reports running (null when nothing is up). */
+  deployedHash: string | null;
+  deployedProtocol: number | null;
+  epoch: number | null;
+  pid: number | null;
+  liveSessions: number;
+  /** Where it lives on the host. */
+  repoDir: string;
+  sshHost: string;
+  credsSlug: string;
+}
+
+/** Pushed after any sidecar status change (probe, upgrade, restart, stop) so the
+ * per-agent page updates live instead of polling. */
+export const sidecarStatusChannel = defineEvent<AgentSidecarStatus>('remote-sidecar:status');


### PR DESCRIPTION
**Stacked on #74** (`feature-request/switchdash-sidecar-lifecycle-resiliency`) — it depends on that branch's backend (protocol version, probe, durable state). Base will be retargeted to `main` once #74 merges; review #74 first.

Adds the per-remote-agent sidecar page Louis asked for: see the client-vs-host version mismatch, update/restart/stop the sidecar, and see where it lives on the host — turning what was a silent on-connect behaviour into something visible and controllable.

## What's here (3 commits)

- **`7a78884` — backend surface.** New `sidecar` RPC namespace: `getStatus` / `upgrade` / `restart` / `stop` / `logTail`, keyed by agent id, plus a live `remote-sidecar:status` event. Reuses the launcher and `connectRemoteAgent` — no new mechanism. `upgrade` honours the defer-while-busy policy; `restart` forces a fresh process (sessions survive via the endpoint file). The verdict (not-running / up-to-date / upgrade-available / upgrade-pending / incompatible) is a pure, unit-tested function.
- **`4a298bf` — the panel.** `SidecarSettingsSection` in the agent's Settings tab, gated on the location being remote. Verdict badge, both builds/protocols side by side, live sessions, host + working dir, the three action buttons, and a collapsible on-host log tail. Reads via `rpc.sidecar.getStatus` and seeds its cache from the status broadcast, so it updates live after any action — mirroring the remote-host page's connection-event pattern.

## Design choices

- **Two versions, deliberately distinct in the UI** — "This client ships build X · protocol vN" vs "Host running build Y · protocol vM". That mirrors the backend split: protocol = can I talk to it, build = is an upgrade available.
- **Update vs Restart.** *Update* is the polite path (disabled when up-to-date/incompatible; defers if sessions are live, with a note). *Restart* forces it now and reconnects sessions. *Replace* label when incompatible.
- **Remote-only.** Gated on `location.sshHost !== null`, matching the controller's own `requireRemoteAgent` guard so the UI never calls into a local agent.

## Verification & caveat

typecheck clean, lint clean, full node suite green (161 files / 1275 tests), renderer builds. **The panel has not been clicked in a running window against a real remote agent** — the backend is unit-tested but the UI is "matches conventions + compiles", not "seen working". Worth a manual pass on a live remote agent before merge.

## Not included (deferred, happy to add)

- Auto-start (watch-enabled) toggle — it's a DB-backed agent setting with its own sync path (`remote-watcher`), so it belongs with the agent settings rather than bolted onto the sidecar controller. Easy follow-up if you want it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)