### PR TITLE
fix(switchdash): key remote session reconciler claim per-sidecar, not per-location

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/agents/remote-session-reconciler.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/remote-session-reconciler.test.ts
@@ -372,18 +372,50 @@ describe('RemoteSessionReconciler', () => {
     expect(provisionSession).not.toHaveBeenCalled();
   });
 
-  it('stops a duplicate reconciler whose agent shares an already-claimed sidecar', async () => {
-    // agent-1 and agent-2 share host+repoDir → one sidecar, one snapshot.
-    // Whoever reconciles it first holds the claim; the other stops itself.
+  it('stops a duplicate reconciler that targets the same sidecar (same host+dir+name)', async () => {
+    // Two agent rows resolving to the same host+repoDir AND the same name share
+    // ONE sidecar and one snapshot. Whoever reconciles it first holds the claim;
+    // the other stops itself. The name is what makes the sidecar identical.
     httpGetJsonOverChannel.mockResolvedValue({ sessions: [] });
+    getAgentById.mockResolvedValueOnce({ ...REMOTE_AGENT, name: 'shared' } as unknown as never);
     remoteSessionReconciler.start('agent-1');
     await vi.waitFor(() => expect(httpGetJsonOverChannel).toHaveBeenCalled());
 
-    getAgentById.mockResolvedValueOnce({ ...REMOTE_AGENT, id: 'agent-2' } as unknown as never);
+    getAgentById.mockResolvedValueOnce({
+      ...REMOTE_AGENT,
+      id: 'agent-2',
+      name: 'shared',
+    } as unknown as never);
     const callsBefore = httpGetJsonOverChannel.mock.calls.length;
     await reconcile('agent-2');
 
     // agent-2's pass bailed before polling the sidecar.
     expect(httpGetJsonOverChannel.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('lets co-located agents with different names each reconcile their own sidecar', async () => {
+    // Regression: two agents in the SAME dir but with different names each own a
+    // distinct per-name sidecar. Keying the claim on host+dir alone collapsed
+    // them onto one claim and starved the loser of session discovery, so its
+    // VM-spawned sessions never surfaced in the sidebar. Different name → different
+    // sidecar key → both reconcile.
+    httpGetJsonOverChannel.mockResolvedValue({ sessions: [] });
+    getAgentById.mockResolvedValueOnce({
+      ...REMOTE_AGENT,
+      name: 'onboarder',
+    } as unknown as never);
+    remoteSessionReconciler.start('agent-1');
+    await vi.waitFor(() => expect(httpGetJsonOverChannel).toHaveBeenCalled());
+
+    getAgentById.mockResolvedValueOnce({
+      ...REMOTE_AGENT,
+      id: 'agent-2',
+      name: 'manager',
+    } as unknown as never);
+    const callsBefore = httpGetJsonOverChannel.mock.calls.length;
+    await reconcile('agent-2');
+
+    // agent-2 polled its own sidecar rather than bailing on the shared location.
+    expect(httpGetJsonOverChannel.mock.calls.length).toBe(callsBefore + 1);
   });
 });

--- a/dash/apps/switchdash-desktop/src/main/core/agents/remote-session-reconciler.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/remote-session-reconciler.ts
@@ -91,10 +91,13 @@ class RemoteSessionReconciler {
   private readonly adopted = new Map<string, Set<string>>();
   /** sessionId → consecutive reconcile passes it has been absent from `/sessions`. */
   private readonly missingStreak = new Map<string, number>();
-  /** sidecar key (host::repoDir) → agentId currently reconciling that sidecar.
-   * The sidecar — and its /sessions snapshot — is scoped to host+dir, so two
-   * agents sharing a dir would double-poll it and race to adopt the same
-   * session ids. One reconciler per sidecar; duplicates stop themselves. */
+  /** sidecar key (host::repoDir::credsSlug) → agentId currently reconciling that
+   * sidecar. A sidecar — and its /sessions snapshot — is scoped to host+dir+agent
+   * name (ensureAgentSidecar keys it by credsSlug = agent.name), so two agents in
+   * the SAME dir but with different names each own a distinct sidecar and must both
+   * reconcile. Only two agent rows resolving to the same host+dir+name share one
+   * sidecar; those double-poll and race to adopt the same ids, so one reconciler
+   * per sidecar — those duplicates stop themselves. */
   private readonly sidecarKeys = new Map<string, string>();
 
   constructor() {
@@ -240,7 +243,12 @@ class RemoteSessionReconciler {
       return;
     }
 
-    if (!this.claimSidecar(agentId, location)) return;
+    // The sidecar is scoped to host+dir+agent name, so the claim key must carry
+    // the same credsSlug (agent.name ?? id) the probe uses — else co-located
+    // agents with different names collapse onto one claim and all but one are
+    // starved of session discovery.
+    const sidecarKey = `${location.id}::${agent.name ?? agent.id}`;
+    if (!this.claimSidecar(agentId, sidecarKey)) return;
 
     // The manager is mid-backoff rebuilding the transport: let it finish
     // rather than racing it with connect attempts every tick. Disconnected and
@@ -299,24 +307,25 @@ class RemoteSessionReconciler {
   }
 
   /**
-   * Claim the agent's sidecar (host+repoDir) for reconciliation. Returns false
-   * — and stops this agent's loop — when another live agent already reconciles
-   * the same sidecar, so shared-dir agents cannot double-poll one snapshot and
-   * race each other's adoptions.
+   * Claim the agent's sidecar (host+repoDir+agent name) for reconciliation.
+   * Returns false — and stops this agent's loop — when another live agent already
+   * reconciles the SAME sidecar (two rows resolving to one host+dir+name), so
+   * genuine duplicates cannot double-poll one snapshot and race each other's
+   * adoptions. Co-located agents with different names own distinct sidecars, get
+   * distinct keys, and both proceed.
    */
-  private claimSidecar(agentId: string, location: { id: string }): boolean {
-    const key = location.id;
-    const holder = this.sidecarKeys.get(key);
+  private claimSidecar(agentId: string, sidecarKey: string): boolean {
+    const holder = this.sidecarKeys.get(sidecarKey);
     if (holder !== undefined && holder !== agentId && this.timers.has(holder)) {
       log.info('RemoteSessionReconciler: sidecar already reconciled by another agent — stopping', {
         agentId,
-        key,
+        key: sidecarKey,
         holder,
       });
       this.stop(agentId);
       return false;
     }
-    this.sidecarKeys.set(key, agentId);
+    this.sidecarKeys.set(sidecarKey, agentId);
     return true;
   }
 


### PR DESCRIPTION
## Problem

A remote agent's sidecar reported a healthy live session (`Live sessions: 1` in the Sidecar panel, tmux pane alive on the VM), but the session never appeared under the agent in the left sidebar.

### Root cause

`RemoteSessionReconciler` (the loop that adopts VM-spawned sessions into sidebar rows) de-duped reconcilers by **location** (`location.id` = host + dir):

```ts
private claimSidecar(agentId, location): boolean {
  const key = location.id;   // host+dir only
  ...if another live agent holds this key → this.stop(agentId)
}
```

But sidecars are created **per agent**: `ensureAgentSidecar` keys them by `credsSlug` (= `agent.name`), giving each agent its own `.switchdash/agents/<name>/` subdir, port, token, and tmux session.

When two Switch agents share one working dir (one location) — e.g. `switch-onboarder` and `switch-onboarding-manager` both in `dev-vm:/…/shared-switch-agents` — the first to tick claimed the location and the **second agent's reconciler stopped itself**. The survivor only ever probes its *own* per-name sidecar, so the starved agent's VM-spawned sessions were never polled, never adopted, and never surfaced in the UI — despite the sidecar being fully healthy.

Observed on `dev-vm`:

| Sidecar (per-name) | Port | Sessions | In sidebar? |
|---|---|---|---|
| `switch-onboarder` | 32897 | 3 | ✅ |
| `switch-onboarding-manager` | 34001 | `9cb00e72` (room 98f231b5) | ❌ starved |

## Fix

Key the claim on **host + dir + credsSlug** (the same slug the probe uses), so co-located agents with different names each reconcile their own sidecar. Genuine duplicates (two rows resolving to the same host+dir+name) still collapse onto one claim.

## Tests

- Updated the existing dedup test to target the *same* sidecar (same host+dir+**name**) — the case that legitimately still collapses.
- Added a regression test: two co-located agents with **different** names each reconcile their own sidecar (the bug).
- Full local gate green: `vitest --project node` (21 passed), `typecheck`, `oxlint`, `oxfmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)