### PR TITLE
fix(switchdash): gate remote managed servers on host reachability (CHOO-1780)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/managed-server-status.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/managed-server-status.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getLocalStatus = vi.hoisted(() => vi.fn());
 const getRemoteStatus = vi.hoisted(() => vi.fn());
+const isHostBlockedMock = vi.hoisted(() => vi.fn(() => false));
+const getReachability = vi.hoisted(() => vi.fn());
 
 vi.mock('./local-server-service', () => ({
   localServerService: { getStatus: getLocalStatus },
@@ -9,8 +11,26 @@ vi.mock('./local-server-service', () => ({
 vi.mock('./remote-server-service', () => ({
   remoteServerService: { getStatus: getRemoteStatus },
 }));
+vi.mock('@main/core/remote-hosts/production-host-reachability', () => ({
+  hostReachabilityService: { isBlocked: isHostBlockedMock, get: getReachability },
+}));
 
-const { isManagedServerRunning } = await import('./managed-server-status');
+const { isManagedServerRunning, managedServerHostBlocked } =
+  await import('./managed-server-status');
+
+function reachability(overrides: Record<string, unknown>) {
+  return {
+    sshHost: 'host-a',
+    status: 'reachable',
+    lastError: null,
+    lastCheckedAt: null,
+    lastReachableAt: null,
+    consecutiveFailures: 0,
+    nextProbeAt: null,
+    probing: false,
+    ...overrides,
+  };
+}
 
 function server(overrides: Record<string, unknown>) {
   return {
@@ -30,6 +50,7 @@ function server(overrides: Record<string, unknown>) {
 describe('isManagedServerRunning', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isHostBlockedMock.mockReturnValue(false);
   });
 
   it('returns false for an external (non-managed) server without probing any service', () => {
@@ -75,5 +96,64 @@ describe('isManagedServerRunning', () => {
       getLocalStatus.mockReturnValue({ phase });
       expect(isManagedServerRunning(server({ managementKind: 'local' }))).toBe(false);
     }
+  });
+
+  it('is not running when the remote host is unreachable, however stale the phase says running', () => {
+    getRemoteStatus.mockReturnValue({ phase: 'running' });
+    isHostBlockedMock.mockReturnValue(true);
+    expect(isManagedServerRunning(server({ managementKind: 'remote', sshHost: 'host-a' }))).toBe(
+      false
+    );
+    expect(isHostBlockedMock).toHaveBeenCalledWith('host-a');
+  });
+
+  it('runs again as soon as the host is reachable, with no change to the stack phase', () => {
+    getRemoteStatus.mockReturnValue({ phase: 'running' });
+    isHostBlockedMock.mockReturnValue(true);
+    const remote = server({ managementKind: 'remote', sshHost: 'host-a' });
+    expect(isManagedServerRunning(remote)).toBe(false);
+
+    isHostBlockedMock.mockReturnValue(false);
+    expect(isManagedServerRunning(remote)).toBe(true);
+  });
+
+  it('does not consult reachability for a local-managed server', () => {
+    getLocalStatus.mockReturnValue({ phase: 'running' });
+    expect(isManagedServerRunning(server({ managementKind: 'local' }))).toBe(true);
+    expect(isHostBlockedMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('managedServerHostBlocked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the reachability record for a remote-managed server on a blocked host', () => {
+    const blocked = reachability({ status: 'unreachable', lastError: 'Connection lost' });
+    getReachability.mockReturnValue(blocked);
+    expect(managedServerHostBlocked(server({ managementKind: 'remote', sshHost: 'host-a' }))).toBe(
+      blocked
+    );
+  });
+
+  it('returns null while the host is reachable', () => {
+    getReachability.mockReturnValue(reachability({ status: 'reachable' }));
+    expect(
+      managedServerHostBlocked(server({ managementKind: 'remote', sshHost: 'host-a' }))
+    ).toBeNull();
+  });
+
+  it('reports a suspended (auth-failed) host as blocked', () => {
+    getReachability.mockReturnValue(reachability({ status: 'suspended' }));
+    expect(
+      managedServerHostBlocked(server({ managementKind: 'remote', sshHost: 'host-a' }))
+    ).not.toBeNull();
+  });
+
+  it('returns null for local-managed and external servers without reading reachability', () => {
+    expect(managedServerHostBlocked(server({ managementKind: 'local' }))).toBeNull();
+    expect(managedServerHostBlocked(server({ managed: false }))).toBeNull();
+    expect(getReachability).not.toHaveBeenCalled();
   });
 });

--- a/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/managed-server-status.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/managed-server-status.ts
@@ -1,3 +1,5 @@
+import { hostReachabilityService } from '@main/core/remote-hosts/production-host-reachability';
+import { type HostReachability, isHostBlocked } from '@shared/core/remote-hosts/reachability';
 import type { SwitchServer } from '@shared/core/switch-servers/switch-servers';
 import { localServerService } from './local-server-service';
 import { remoteServerService } from './remote-server-service';
@@ -17,9 +19,26 @@ import { remoteServerService } from './remote-server-service';
 export function isManagedServerRunning(server: SwitchServer): boolean {
   if (!server.managed) return false;
   if (server.managementKind === 'remote') {
-    return (
-      server.sshHost !== null && remoteServerService.getStatus(server.sshHost).phase === 'running'
-    );
+    if (server.sshHost === null) return false;
+    // A `running` phase describes containers we last saw up on the far side of
+    // an SSH tunnel. If the host is unreachable that phase is stale — the
+    // forward is dead and nothing on it can be reached — so reachability is
+    // folded in here rather than persisted as a separate phase, keeping one
+    // source of truth and making recovery automatic (CHOO-1780).
+    if (hostReachabilityService.isBlocked(server.sshHost)) return false;
+    return remoteServerService.getStatus(server.sshHost).phase === 'running';
   }
   return localServerService.getStatus().phase === 'running';
+}
+
+/**
+ * The blocked reachability record for a remote-managed server's host, or null
+ * when the host is fine (or the server isn't remote-managed). Callers use this
+ * to report one honest host-level state instead of a downstream transport
+ * error.
+ */
+export function managedServerHostBlocked(server: SwitchServer): HostReachability | null {
+  if (!server.managed || server.managementKind !== 'remote' || server.sshHost === null) return null;
+  const reachability = hostReachabilityService.get(server.sshHost);
+  return isHostBlocked(reachability) ? reachability : null;
 }

--- a/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/remote-server-service.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/remote-server-service.ts
@@ -1,3 +1,5 @@
+import type { HostReachabilityChange } from '@main/core/remote-hosts/host-reachability-service';
+import { hostReachabilityService } from '@main/core/remote-hosts/production-host-reachability';
 import { listManagedServers } from '@main/core/switch-servers/servers-store';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
@@ -58,6 +60,7 @@ class RemoteServerService {
   }
 
   async detectDocker(sshHost: string): Promise<DockerAvailability> {
+    hostReachabilityService.requireReachable(sshHost);
     const host = await createRemoteServerHost(sshHost);
     try {
       return await host.detectDocker();
@@ -70,33 +73,56 @@ class RemoteServerService {
    * quit, so their desktop reachability is restored on launch. Best-effort per
    * host: an unreachable host is left `stopped` rather than failing boot. */
   async initialize(): Promise<void> {
+    hostReachabilityService.on('change', ({ current }: HostReachabilityChange) => {
+      if (current.status === 'reachable') void this.onHostReachable(current.sshHost);
+    });
+    for (const [sshHost, serverId] of await this.remoteHosts()) {
+      this.statuses.set(sshHost, initialStatus(sshHost));
+      await this.reconcileHost(sshHost, serverId);
+    }
+  }
+
+  private async remoteHosts(): Promise<Map<string, string>> {
     const remotes = (await listManagedServers()).filter(
       (s) => s.managementKind === 'remote' && s.sshHost
     );
-    for (const server of remotes) {
-      const sshHost = server.sshHost!;
-      this.statuses.set(sshHost, initialStatus(sshHost));
-      let host: RemoteServerHost | null = null;
-      try {
-        host = await createRemoteServerHost(sshHost);
-        if (!(await isStackRunning(host))) {
-          host.dispose();
-          continue;
-        }
-        const ports = await readPersistedPorts(host);
-        if (!ports) {
-          // Running but we don't know its ports — leave it stopped; the user can
-          // restart to re-derive them rather than forward to the wrong ports.
-          host.dispose();
-          continue;
-        }
-        await host.establishNetworking(ports);
-        this.hosts.set(sshHost, host);
-        this.setStatus(sshHost, { phase: 'running', serverId: server.id });
-      } catch (error) {
-        host?.dispose();
-        log.warn(`remote-switch-server: boot reconcile failed for ${sshHost}`, { error });
+    return new Map(remotes.map((s) => [s.sshHost!, s.id]));
+  }
+
+  /** Pick a host's stack back up once its host is reachable again, so a
+   * recovered host resumes without the user restarting anything. */
+  private async onHostReachable(sshHost: string): Promise<void> {
+    if (this.busy.has(sshHost) || this.hosts.has(sshHost)) return;
+    const serverId = (await this.remoteHosts()).get(sshHost);
+    if (!serverId) return;
+    await this.reconcileHost(sshHost, serverId);
+  }
+
+  /** Adopt an already-running remote stack: re-open its forward and mark it
+   * running. Skipped while the host is blocked — the reachability manager will
+   * call back through {@link onHostReachable} when it recovers. */
+  private async reconcileHost(sshHost: string, serverId: string): Promise<void> {
+    if (hostReachabilityService.isBlocked(sshHost)) return;
+    let host: RemoteServerHost | null = null;
+    try {
+      host = await createRemoteServerHost(sshHost);
+      if (!(await isStackRunning(host))) {
+        host.dispose();
+        return;
       }
+      const ports = await readPersistedPorts(host);
+      if (!ports) {
+        // Running but we don't know its ports — leave it stopped; the user can
+        // restart to re-derive them rather than forward to the wrong ports.
+        host.dispose();
+        return;
+      }
+      await host.establishNetworking(ports);
+      this.hosts.set(sshHost, host);
+      this.setStatus(sshHost, { phase: 'running', serverId });
+    } catch (error) {
+      host?.dispose();
+      log.warn(`remote-switch-server: boot reconcile failed for ${sshHost}`, { error });
     }
   }
 
@@ -104,6 +130,7 @@ class RemoteServerService {
     if (this.busy.has(sshHost)) {
       return { kind: 'error', message: `An operation is already in progress for ${sshHost}.` };
     }
+    hostReachabilityService.requireReachable(sshHost);
     this.busy.add(sshHost);
     const abort = new AbortController();
     this.startAborts.set(sshHost, abort);
@@ -159,6 +186,7 @@ class RemoteServerService {
   async stop(sshHost: string): Promise<void> {
     if (this.busy.has(sshHost))
       throw new Error(`An operation is already in progress for ${sshHost}.`);
+    hostReachabilityService.requireReachable(sshHost);
     this.busy.add(sshHost);
     const host = this.hosts.get(sshHost) ?? (await createRemoteServerHost(sshHost));
     try {
@@ -183,6 +211,7 @@ class RemoteServerService {
   async reset(sshHost: string): Promise<void> {
     if (this.busy.has(sshHost))
       throw new Error(`An operation is already in progress for ${sshHost}.`);
+    hostReachabilityService.requireReachable(sshHost);
     this.busy.add(sshHost);
     const host = this.hosts.get(sshHost) ?? (await createRemoteServerHost(sshHost));
     try {

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const fetchMe = vi.hoisted(() => vi.fn());
 const getServer = vi.hoisted(() => vi.fn());
 const isManagedServerRunning = vi.hoisted(() => vi.fn());
+const managedServerHostBlocked = vi.hoisted(() => vi.fn((): unknown => null));
+const fetchAuthConfig = vi.hoisted(() => vi.fn());
 
 // Stub the modules the controller imports that would otherwise pull electron /
 // ssh / agent side effects at load. We only exercise getConnectionStatus.
@@ -19,6 +21,10 @@ vi.mock('@main/core/locations/location-transport', () => ({ sshConnectionIdForHo
 vi.mock('@main/core/ssh/connect/connect-agent-ssh', () => ({ ensureSshConnected: vi.fn() }));
 vi.mock('@main/core/managed-switch-server/managed-server-status', () => ({
   isManagedServerRunning,
+  managedServerHostBlocked,
+}));
+vi.mock('@main/core/remote-hosts/host-reachability-service', () => ({
+  HostUnreachableError: class HostUnreachableError extends Error {},
 }));
 vi.mock('./auth', () => ({ oidcLogin: vi.fn(), passwordLogin: vi.fn() }));
 vi.mock('./gateway-web', () => ({ openAuthenticatedGatewayPage: vi.fn() }));
@@ -28,7 +34,7 @@ vi.mock('./gateway-client', () => ({
   fetchAgentDetail: vi.fn(),
   fetchAgentRooms: vi.fn(),
   fetchAgents: vi.fn(),
-  fetchAuthConfig: vi.fn(),
+  fetchAuthConfig,
   fetchRoomRoles: vi.fn(),
   fetchRooms: vi.fn(),
   registerKnownAgent: vi.fn(),
@@ -100,5 +106,28 @@ describe('getConnectionStatus', () => {
     expect(status).toEqual({ serverId: 'srv', connected: true, user: USER });
     expect(isManagedServerRunning).not.toHaveBeenCalled();
     expect(fetchMe).toHaveBeenCalledOnce();
+  });
+});
+
+describe('gateway calls on an unreachable host', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    managedServerHostBlocked.mockReturnValue(null);
+  });
+
+  it('refuses getAuthConfig instead of fetching a gateway that cannot answer', async () => {
+    getServer.mockResolvedValue(server({ managed: true, managementKind: 'remote', sshHost: 'h' }));
+    managedServerHostBlocked.mockReturnValue({ sshHost: 'h', status: 'unreachable' });
+
+    await expect(switchServersController.getAuthConfig('srv')).rejects.toThrow();
+    expect(fetchAuthConfig).not.toHaveBeenCalled();
+  });
+
+  it('fetches the auth config normally while the host is reachable', async () => {
+    getServer.mockResolvedValue(server({ managed: true, managementKind: 'remote', sshHost: 'h' }));
+    fetchAuthConfig.mockResolvedValue({ password: true });
+
+    await expect(switchServersController.getAuthConfig('srv')).resolves.toEqual({ password: true });
+    expect(fetchAuthConfig).toHaveBeenCalledOnce();
   });
 });

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
@@ -8,7 +8,11 @@ import { writeSwitchSettings } from '@main/core/agents/write-switch-settings';
 import { appService } from '@main/core/app/service';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
 import { sshConnectionIdForHost } from '@main/core/locations/location-transport';
-import { isManagedServerRunning } from '@main/core/managed-switch-server/managed-server-status';
+import {
+  isManagedServerRunning,
+  managedServerHostBlocked,
+} from '@main/core/managed-switch-server/managed-server-status';
+import { HostUnreachableError } from '@main/core/remote-hosts/host-reachability-service';
 import { ensureSshConnected } from '@main/core/ssh/connect/connect-agent-ssh';
 import type {
   AddressingPolicy,
@@ -70,6 +74,20 @@ async function requireServer(serverId: string): Promise<SwitchServer> {
   return server;
 }
 
+/**
+ * Resolve a server and refuse to touch its gateway while the host it is managed
+ * on is unreachable. Everything the gateway serves — auth config, sign-in,
+ * dashboard pages — rides the SSH forward, so a fetch here can only produce a
+ * misleading `Could not reach http://localhost:<port>` (CHOO-1780). Fail with
+ * the modeled host state instead, which the UI already knows how to render.
+ */
+async function requireReachableServer(serverId: string): Promise<SwitchServer> {
+  const server = await requireServer(serverId);
+  const blocked = managedServerHostBlocked(server);
+  if (blocked) throw new HostUnreachableError(blocked);
+  return server;
+}
+
 export const switchServersController = createRPCController({
   listServers: (): Promise<SwitchServer[]> => listServers(),
 
@@ -105,15 +123,15 @@ export const switchServersController = createRPCController({
   setActiveServer: (serverId: string): Promise<void> => setActiveServerId(serverId),
 
   getAuthConfig: async (serverId: string): Promise<SwitchAuthConfig> =>
-    fetchAuthConfig(await requireServer(serverId)),
+    fetchAuthConfig(await requireReachableServer(serverId)),
 
   passwordLogin: async (params: PasswordLoginParams) => {
-    const server = await requireServer(params.serverId);
+    const server = await requireReachableServer(params.serverId);
     return passwordLogin(server, params.email, params.password);
   },
 
   oidcLogin: async (serverId: string): Promise<Result<true, LoginError>> =>
-    oidcLogin(await requireServer(serverId)),
+    oidcLogin(await requireReachableServer(serverId)),
 
   logout: (serverId: string): Promise<void> => deleteSessionCookie(serverId),
 
@@ -127,7 +145,7 @@ export const switchServersController = createRPCController({
    * origin.
    */
   openGatewayPage: async (params: { serverId: string; url: string }): Promise<void> => {
-    const server = await requireServer(params.serverId);
+    const server = await requireReachableServer(params.serverId);
     if (server.managed) {
       await openAuthenticatedGatewayPage(server, params.url);
     } else {

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/AddServerModal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/AddServerModal.tsx
@@ -1,6 +1,7 @@
 import { CircleCheck, Globe, HardDrive, Server, TriangleAlert } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { HostReachabilityNotice } from '@renderer/features/remote-hosts/host-reachability-notice';
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
@@ -416,7 +417,8 @@ const RemoteHostSetupStep = observer(function RemoteHostSetupStep({
   const status = sshHost ? store.statusFor(sshHost) : null;
   const logs = sshHost ? store.logsFor(sshHost) : [];
 
-  const canStart = !!sshHost && name.trim().length > 0 && dockerReady && !starting;
+  const hostBlocked = sshHost ? store.isHostBlocked(sshHost) : false;
+  const canStart = !!sshHost && name.trim().length > 0 && dockerReady && !starting && !hostBlocked;
   const primaryLabel = running ? 'Done' : status?.phase === 'error' ? 'Retry' : 'Start';
   const onPrimary = () => {
     if (running) onSuccess();
@@ -474,6 +476,8 @@ const RemoteHostSetupStep = observer(function RemoteHostSetupStep({
                 ))}
               </div>
             </Field>
+
+            {sshHost && <HostReachabilityNotice sshHost={sshHost} />}
 
             {sshHost && (
               <Field>

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/RemoteServerControls.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/RemoteServerControls.tsx
@@ -43,7 +43,10 @@ export const RemoteServerControls = observer(function RemoteServerControls({
   }, [store, sshHost]);
 
   const status = store.statusFor(sshHost);
-  const transitioning = store.isTransitioning(sshHost);
+  const hostBlocked = store.isHostBlocked(sshHost);
+  // Every lifecycle action rides the host's SSH connection, so none of them can
+  // succeed while it is down — disable rather than let them fail (CHOO-1780).
+  const transitioning = store.isTransitioning(sshHost) || hostBlocked;
   const running = store.isRunning(sshHost);
   const docker = store.dockerFor(sshHost);
   const dockerUnavailable = docker && !docker.available ? docker : null;
@@ -186,6 +189,16 @@ const ResetDialog = observer(function ResetDialog({
 });
 
 const PhaseBadge = observer(function PhaseBadge({ sshHost }: { sshHost: string }) {
+  // Never report a stack state we cannot currently observe: with the host down,
+  // `running` is a memory of the last time we could see it (CHOO-1780).
+  if (remoteServerStore.isHostBlocked(sshHost)) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-foreground-muted">
+        <span aria-hidden className="inline-block size-2 rounded-full bg-amber-500" />
+        Host unreachable
+      </span>
+    );
+  }
   const phase = remoteServerStore.phaseFor(sshHost);
   const label: Record<typeof phase, string> = {
     stopped: 'Stopped',

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/remote-server-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/remote-server-store.ts
@@ -1,6 +1,7 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 import { agentsStore } from '@renderer/features/locations/stores/agents-store';
 import { getLocationManagerStore } from '@renderer/features/locations/stores/location-selectors';
+import { hostReachabilityStore } from '@renderer/features/remote-hosts/host-reachability-store';
 import { events, rpc } from '@renderer/lib/ipc';
 import type { DockerAvailability } from '@shared/core/managed-switch-server/managed-switch-server';
 import {
@@ -44,7 +45,17 @@ export class RemoteServerStore {
     return this.statusFor(sshHost).phase;
   }
 
+  /**
+   * Whether the host this stack lives on is known-unreachable. Mirrors the
+   * main-process gate in `isManagedServerRunning` so the UI and the backend
+   * agree on one host-level state (CHOO-1780).
+   */
+  isHostBlocked(sshHost: string): boolean {
+    return hostReachabilityStore.isBlocked(sshHost);
+  }
+
   isRunning(sshHost: string): boolean {
+    if (this.isHostBlocked(sshHost)) return false;
     return this.phaseFor(sshHost) === 'running';
   }
 
@@ -62,6 +73,7 @@ export class RemoteServerStore {
   }
 
   async init(): Promise<void> {
+    void hostReachabilityStore.hydrate();
     if (!this.off) {
       this.off = events.on(remoteServerStatusChannel, (status) => {
         runInAction(() => this.statuses.set(status.sshHost, status));
@@ -95,6 +107,9 @@ export class RemoteServerStore {
   }
 
   async checkDocker(sshHost: string): Promise<void> {
+    // Probing Docker over a dead SSH forward can only yield a HostUnreachableError
+    // in the page banner; the host-unreachable surface already says it better.
+    if (this.isHostBlocked(sshHost)) return;
     try {
       const docker = await rpc.remoteSwitchServer.detectDocker(sshHost);
       runInAction(() => this.dockerByHost.set(sshHost, docker));

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -1,4 +1,5 @@
 import { makeAutoObservable, runInAction } from 'mobx';
+import { hostReachabilityStore } from '@renderer/features/remote-hosts/host-reachability-store';
 import { rpc } from '@renderer/lib/ipc';
 import type {
   ServerConnectionStatus,
@@ -34,6 +35,14 @@ export class SwitchServersStore {
 
   constructor() {
     makeAutoObservable(this);
+  }
+
+  /** Whether this server is managed on a host the reachability manager has
+   * marked unreachable — nothing it serves can be fetched until that clears. */
+  isHostBlocked(serverId: string): boolean {
+    const server = this.servers.find((s) => s.id === serverId);
+    if (!server?.managed || server.managementKind !== 'remote' || !server.sshHost) return false;
+    return hostReachabilityStore.isBlocked(server.sshHost);
   }
 
   get activeServer(): SwitchServer | null {
@@ -116,6 +125,10 @@ export class SwitchServersStore {
 
   async ensureAuthConfig(serverId: string): Promise<void> {
     if (this.authConfigs.has(serverId)) return;
+    // The gateway of a server on an unreachable host cannot answer, and the
+    // host-unreachable surface already states why — don't paint the global
+    // error banner with a doomed fetch (CHOO-1780).
+    if (this.isHostBlocked(serverId)) return;
     try {
       const config = await rpc.switchServers.getAuthConfig(serverId);
       runInAction(() => {

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
@@ -2,6 +2,8 @@ import { ExternalLink, MoreVertical, Pencil, RefreshCw, Trash2 } from 'lucide-re
 import { observer } from 'mobx-react-lite';
 import { useEffect, useState } from 'react';
 import { type GuardResult, type ViewDefinition } from '@renderer/app/view-registry';
+import { hostReachabilityStore } from '@renderer/features/remote-hosts/host-reachability-store';
+import { HostUnreachablePanel } from '@renderer/features/remote-hosts/host-unreachable-panel';
 import { Titlebar } from '@renderer/lib/components/titlebar/Titlebar';
 import { rpc } from '@renderer/lib/ipc';
 import { useNavigate, useParams } from '@renderer/lib/layout/navigation-provider';
@@ -77,6 +79,10 @@ const ServerMainPanel = observer(function ServerMainPanel() {
   const detailsVisible = !server?.managed || isManagedRunning(server);
 
   useEffect(() => {
+    void hostReachabilityStore.hydrate();
+  }, []);
+
+  useEffect(() => {
     if (!detailsVisible) return;
     void store.refreshStatus(serverId);
     void store.ensureAuthConfig(serverId);
@@ -86,6 +92,22 @@ const ServerMainPanel = observer(function ServerMainPanel() {
     return (
       <div className="relative z-10 flex min-h-0 flex-1 overflow-auto bg-background p-6">
         <p className="text-sm text-foreground-muted">This server is no longer available.</p>
+      </div>
+    );
+  }
+
+  // A remote-managed server is only as reachable as its host. While the host is
+  // blocked, everything on this page (stack status, Docker, sign-in, web app)
+  // would be a stale or doomed read, so the modeled host state replaces it
+  // outright rather than sitting under a green badge (CHOO-1780).
+  const blockedHost =
+    server.managed && server.managementKind === 'remote' && server.sshHost
+      ? hostReachabilityStore.get(server.sshHost)
+      : null;
+  if (blockedHost && hostReachabilityStore.isBlocked(blockedHost.sshHost)) {
+    return (
+      <div className="relative z-10 flex min-h-0 flex-1 overflow-auto bg-background">
+        <HostUnreachablePanel reachability={blockedHost} />
       </div>
     );
   }


### PR DESCRIPTION
Jira: [CHOO-1780](https://sandboxquantum.atlassian.net/browse/CHOO-1780) — extends the [CHOO-1682](https://sandboxquantum.atlassian.net/browse/CHOO-1682) pattern.

## Problem

CHOO-1682 made remote-host reachability first-class state owned by a central manager; remote agents already consult it. Remote **managed servers** never joined that gate. With the host down, switchdash showed:

- a stale green **● Running** card, while `remoteSwitchServer.detectDocker` threw a raw `HostUnreachableError`
- `switchServers.getAuthConfig` → `GatewayError: Could not reach http://localhost:50772` in the page-level banner
- the sign-in section spinning on *"Checking sign-in options…"* behind a **Sign in** button that could never succeed

## Approach

Reuse the existing manager and its verdict — no parallel mechanism. Reachability is **derived**, not persisted as a second phase, so there's one source of truth and recovery needs no reconciliation.

**Main**
- `remote-server-service`: `requireReachable()` before `detectDocker` / `start` / `stop` / `reset`; boot reconcile split into `reconcileHost()` which skips blocked hosts (previously a swallowed `docker compose ps` failure made an unreachable host read as *stopped*); subscribes to the manager's `change` event → `onHostReachable()` re-adopts the stack automatically.
- `isManagedServerRunning()` folds in reachability; new `managedServerHostBlocked()` exposes the record for callers reporting the host-level state.
- `switch-servers/controller`: `requireReachableServer()` guards `getAuthConfig`, `passwordLogin`, `oidcLogin`, `openGatewayPage` — they fail with the modeled `HostUnreachableError` rather than fetching a gateway that can't answer. `getConnectionStatus` inherits the gate via `isManagedServerRunning`.

**Renderer**
- `remoteServerStore.isHostBlocked()` / `isRunning()` mirror the main-process gate, so the server page and the sidebar's dormant state follow automatically; `checkDocker` no-ops while blocked.
- `switchServersStore.ensureAuthConfig` skips the doomed fetch, so nothing raw lands in the global error banner.
- Server page renders `HostUnreachablePanel` and **hides all details** while blocked; `PhaseBadge` reads **● Host unreachable**; Start/Stop/Reset/Refresh/Sign in disabled.
- `AddServerModal` gains a `HostReachabilityNotice` and a reachability term in `canStart`.

## Verification

`pnpm test` 1348 passed (175 files) · `typecheck` clean · `lint` + `format:check` clean. New coverage in `managed-server-status.test.ts` (stale-green suppression, auto-resume, suspended hosts, local unaffected) and `switch-servers/controller.test.ts` (auth-config refusal vs. normal path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1780]: https://sandboxquantum.atlassian.net/browse/CHOO-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHOO-1682]: https://sandboxquantum.atlassian.net/browse/CHOO-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ