### PR TITLE
fix(migrations): unique revision id for the default-bridge migration (unblocks deploy)

### DIFF
--- a/core/switch_core/migrations/versions/b3f36489c258_default_collaboration_bridge.py
+++ b/core/switch_core/migrations/versions/b3f36489c258_default_collaboration_bridge.py
@@ -14,7 +14,7 @@ Existing instances are left without a default on purpose — adopting one is
 promoting an arbitrary existing bridge here could start routing rooms to a
 Slack workspace the operator never nominated.
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: b3f36489c258
 Revises: d5e6f7a8b9c0
 Create Date: 2026-07-28 00:00:00.000000
 
@@ -26,7 +26,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
+revision: str = "b3f36489c258"
 down_revision: str | None = "d5e6f7a8b9c0"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None


### PR DESCRIPTION
## Problem

`main` cannot be deployed. The pre-upgrade migration job fails:

```
Cycle is detected in revisions (2fdce59aecd2, 93bb75c91fa4, a1b2c3d4e5f6, ...)
Revision a1b2c3d4e5f6 is present more than once
```

The migration added in #84 (CHOO-1674) declared `revision = "a1b2c3d4e5f6"` — an id **already held** by the long-standing `a1b2c3d4e5f6_add_server_connectors.py`.

That duplicate creates the cycle. The original `a1b2c3d4e5f6` is an *ancestor* of `d5e6f7a8b9c0`, so the new file declaring `a1b2c3d4e5f6 -> d5e6f7a8b9c0` closes the loop:

```
a1b2c3d4e5f6 -> b2c3d4e5f6a7 -> 2fdce59aecd2 -> 93bb75c91fa4 -> ... -> d5e6f7a8b9c0 -> a1b2c3d4e5f6
```

Walking the graph, `main` currently has **zero heads** — the formal signature of a cycle.

## Fix

Only the **id** was wrong. `d5e6f7a8b9c0` was genuinely the head when the migration was written, so the chaining is correct. Re-id to `b3f36489c258` (verified unique) and rename the file to match.

Nothing referenced the new id — the only in-tree references to `a1b2c3d4e5f6` are in `b2c3d4e5f6a7_unify_api_keys.py`, which correctly points at the *original* migration and is left untouched.

**No data impact:** no deployed environment ever ran this migration — it failed at graph-load time, before any DDL.

## Verification

```
$ uv run alembic heads
b3f36489c258 (head)
```

Single head, no cycle error. Full graph walk: 41 revisions, one root (`dad29005a7f7`), one head, no dangling `down_revision`s, chain length 41 == revision count (acyclic).

## Follow-up (not in this PR)

CI did not catch this — the Backend job passed on #84 because tests never run `alembic upgrade head` against the full graph. A migration-graph check in CI (`alembic heads` asserting exactly one head) would have blocked the merge. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)