### PR TITLE
ci(switchdash): ship Linux x64 builds again, and build platforms in parallel (CHOO-1905)

### DIFF
--- a/.github/workflows/switchdash-release.yml
+++ b/.github/workflows/switchdash-release.yml
@@ -4,11 +4,9 @@ name: switchdash release
 # (private) repo, so anyone with repo-read access can install it without building
 # from source. Release assets inherit the repo's read access — no separate ACL.
 #
-# macOS (arm64) is signed + notarized. Linux (x64) is temporarily disabled
-# (CHOO-1339): the .deb target fails without an author email in the app
-# package.json; re-enabling with proper maintainer metadata is a follow-up.
-# Windows is not built yet (needs an Authenticode / Azure Trusted Signing
-# identity — tracked as a follow-up).
+# macOS (arm64) is signed + notarized. Linux (x64) builds AppImage, deb and rpm,
+# unsigned. Windows is not built yet (needs an Authenticode / Azure Trusted
+# Signing identity — tracked as a follow-up).
 #
 # Trigger by pushing a tag like `switchdash-v1.1.34` (the version after
 # `switchdash-v` MUST match apps/switchdash-desktop/package.json `version`).
@@ -137,9 +135,6 @@ jobs:
   build-linux:
     name: Build & release (Linux x64)
     runs-on: ubuntu-latest
-    # Disabled (CHOO-1339): the .deb target fails without an author email in the
-    # app package.json. Re-enable once maintainer metadata is added (follow-up).
-    if: false
     # On tag runs, upload into the Release the macOS job creates — depend on it so
     # the Release exists before we upload. Linux is unsigned, so no cert secrets.
     needs: build-macos

--- a/.github/workflows/switchdash-release.yml
+++ b/.github/workflows/switchdash-release.yml
@@ -115,7 +115,15 @@ jobs:
           # auto-update.
           shopt -s nullglob
           assets=(release/*.dmg release/*.zip release/*.blockmap release/latest-mac.yml)
-          notes="switchdash desktop app $version (macOS arm64). Install: download the .dmg, open it, drag Switchdash to Applications. This build is signed and notarized with SandboxAQ's Developer ID — it opens without a Gatekeeper bypass. In-app updates require a GitHub login via the gh CLI (gh auth login)."
+          # Covers both platforms: the Linux job attaches its assets to this same
+          # Release a few minutes later.
+          notes="switchdash desktop app $version — macOS arm64 and Linux x64.
+
+          **macOS (arm64):** download the .dmg, open it, drag Switchdash to Applications. Signed and notarized with SandboxAQ's Developer ID — it opens without a Gatekeeper bypass.
+
+          **Linux (x64):** download the .AppImage (\`chmod +x\` then run), the .deb (\`sudo apt install ./<file>.deb\`) or the .rpm (\`sudo dnf install ./<file>.rpm\`). Linux builds are unsigned.
+
+          In-app updates require a GitHub login via the gh CLI (\`gh auth login\`)."
           gh release create "$GITHUB_REF_NAME" "${assets[@]}" \
             --repo "$GITHUB_REPOSITORY" \
             --title "switchdash $version" \

--- a/.github/workflows/switchdash-release.yml
+++ b/.github/workflows/switchdash-release.yml
@@ -32,9 +32,51 @@ defaults:
     working-directory: dash
 
 jobs:
+  # Creates the (assetless) Release up front so the platform jobs can run
+  # concurrently and each upload into it, rather than chaining Linux behind macOS
+  # purely to wait for the Release to exist.
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify tag matches package.json version
+        run: |
+          tag_version="${GITHUB_REF_NAME#switchdash-v}"
+          pkg_version="$(node -p "require('./apps/switchdash-desktop/package.json').version")"
+          echo "tag=$tag_version package.json=$pkg_version"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag version ($tag_version) does not match apps/switchdash-desktop/package.json version ($pkg_version). Bump package.json and re-tag."
+            exit 1
+          fi
+
+      - name: Create the Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#switchdash-v}"
+          notes="switchdash desktop app $version — macOS arm64 and Linux x64.
+
+          **macOS (arm64):** download the .dmg, open it, drag Switchdash to Applications. Signed and notarized with SandboxAQ's Developer ID — it opens without a Gatekeeper bypass.
+
+          **Linux (x64):** download the .AppImage (\`chmod +x\` then run), the .deb (\`sudo apt install ./<file>.deb\`) or the .rpm (\`sudo dnf install ./<file>.rpm\`). Linux builds are unsigned.
+
+          In-app updates require a GitHub login via the gh CLI (\`gh auth login\`)."
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "switchdash $version" \
+            --latest=false \
+            --notes "$notes"
+
   build-macos:
     name: Build & release (macOS arm64)
     runs-on: macos-14
+    # Runs on dispatch too, where create-release is skipped rather than run.
+    needs: create-release
+    if: ${{ !cancelled() && needs.create-release.result != 'failure' }}
     # Surface the cert/key secrets through env so step-level `if:` can gate on
     # them — the `secrets` context is not allowed in `if:` expressions.
     env:
@@ -102,33 +144,21 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: pnpm exec electron-builder --mac --publish never --config electron-builder.config.ts
 
-      - name: Create GitHub Release
+      - name: Upload to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         working-directory: dash/apps/switchdash-desktop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version="${GITHUB_REF_NAME#switchdash-v}"
           # Upload the installable artifacts (.dmg, .zip) AND the channel manifest
           # (latest-mac.yml) + blockmaps — electron-updater needs the manifest to
           # detect/download updates, so a dmg-only release would silently break
           # auto-update.
           shopt -s nullglob
           assets=(release/*.dmg release/*.zip release/*.blockmap release/latest-mac.yml)
-          # Covers both platforms: the Linux job attaches its assets to this same
-          # Release a few minutes later.
-          notes="switchdash desktop app $version — macOS arm64 and Linux x64.
-
-          **macOS (arm64):** download the .dmg, open it, drag Switchdash to Applications. Signed and notarized with SandboxAQ's Developer ID — it opens without a Gatekeeper bypass.
-
-          **Linux (x64):** download the .AppImage (\`chmod +x\` then run), the .deb (\`sudo apt install ./<file>.deb\`) or the .rpm (\`sudo dnf install ./<file>.rpm\`). Linux builds are unsigned.
-
-          In-app updates require a GitHub login via the gh CLI (\`gh auth login\`)."
-          gh release create "$GITHUB_REF_NAME" "${assets[@]}" \
+          gh release upload "$GITHUB_REF_NAME" "${assets[@]}" \
             --repo "$GITHUB_REPOSITORY" \
-            --title "switchdash $version" \
-            --latest=false \
-            --notes "$notes"
+            --clobber
 
       - name: Upload build artifacts (dispatch runs, no Release)
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -143,9 +173,10 @@ jobs:
   build-linux:
     name: Build & release (Linux x64)
     runs-on: ubuntu-latest
-    # On tag runs, upload into the Release the macOS job creates — depend on it so
-    # the Release exists before we upload. Linux is unsigned, so no cert secrets.
-    needs: build-macos
+    # Waits only for the Release to exist, not for the macOS build — the two
+    # platform jobs are independent. Linux is unsigned, so no cert secrets.
+    needs: create-release
+    if: ${{ !cancelled() && needs.create-release.result != 'failure' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -197,9 +228,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # The Release is created by the macOS job (needs: build-macos). Attach the
-          # Linux installers + the electron-updater channel manifest (latest-linux.yml)
-          # so auto-update works on Linux too.
+          # Attach the Linux installers + the electron-updater channel manifest
+          # (latest-linux.yml) so auto-update works on Linux too.
           shopt -s nullglob
           assets=(release/*.AppImage release/*.deb release/*.rpm release/*.blockmap release/latest-linux.yml)
           gh release upload "$GITHUB_REF_NAME" "${assets[@]}" \

--- a/dash/apps/switchdash-desktop/electron-builder.canary.config.ts
+++ b/dash/apps/switchdash-desktop/electron-builder.canary.config.ts
@@ -12,6 +12,11 @@ const config: Configuration = {
   appId: APP_ID,
   productName: PRODUCT_NAME,
   executableName: PRODUCT_NAME,
+  // Canary-specific desktop entry name so it never collides with the stable
+  // channel's (see the base config for what desktopName does).
+  extraMetadata: {
+    desktopName: `${APP_NAME_LOWER}.desktop`,
+  },
   // Claim the switchdash:// scheme so the OS routes deeplinks to the app (see
   // the base config for details).
   protocols: [
@@ -67,6 +72,10 @@ const config: Configuration = {
   linux: {
     category: 'Development',
     executableName: APP_NAME_LOWER,
+    // Same fpm requirement as the stable channel — deb/rpm cannot package
+    // without it.
+    maintainer: 'Louis Amaudruz <louis.amaudruz@sandboxaq.com>',
+    syncDesktopName: true,
     target: [
       { target: 'AppImage', arch: ['x64'] },
       { target: 'deb', arch: ['x64'] },

--- a/dash/apps/switchdash-desktop/electron-builder.config.ts
+++ b/dash/apps/switchdash-desktop/electron-builder.config.ts
@@ -113,6 +113,9 @@ const config: Configuration = {
   },
   linux: {
     category: 'Development',
+    // fpm requires a maintainer for the .deb and .rpm targets; without it the
+    // packaging step aborts before writing any Linux artifact.
+    maintainer: 'Louis Amaudruz <louis.amaudruz@sandboxaq.com>',
     target: [
       { target: 'AppImage', arch: ['x64'] },
       { target: 'deb', arch: ['x64'] },

--- a/dash/apps/switchdash-desktop/electron-builder.config.ts
+++ b/dash/apps/switchdash-desktop/electron-builder.config.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import type { AfterPackContext, Configuration } from 'electron-builder';
 import {
   APP_ID,
+  APP_NAME_LOWER,
   ARTIFACT_PREFIX,
   PRODUCT_NAME,
   RELEASE_REPO_NAME,
@@ -51,6 +52,13 @@ const config: Configuration = {
   appId: APP_ID,
   productName: PRODUCT_NAME,
   executableName: PRODUCT_NAME,
+  // Electron reads `desktopName` from the packaged package.json and uses it as the
+  // Linux app_id / WM_CLASS. Paired with linux.syncDesktopName, the installed
+  // .desktop entry gets the same basename, so desktop environments can associate a
+  // running window with its launcher (pinning, one dock entry, correct icon).
+  extraMetadata: {
+    desktopName: `${APP_NAME_LOWER}.desktop`,
+  },
   // Claim the switchdash:// URL scheme so the OS routes deeplinks (from Slack /
   // Mattermost messages) to this app. On macOS this writes CFBundleURLTypes
   // into Info.plist — the canonical registration; the runtime
@@ -116,6 +124,7 @@ const config: Configuration = {
     // fpm requires a maintainer for the .deb and .rpm targets; without it the
     // packaging step aborts before writing any Linux artifact.
     maintainer: 'Louis Amaudruz <louis.amaudruz@sandboxaq.com>',
+    syncDesktopName: true,
     target: [
       { target: 'AppImage', arch: ['x64'] },
       { target: 'deb', arch: ['x64'] },

--- a/dash/docs/INSTALL.md
+++ b/dash/docs/INSTALL.md
@@ -5,7 +5,8 @@ repository** (`sandbox-quantum/switch`). The repo is private, so the release
 downloads are automatically limited to people with repo-read access — there is
 no separate sign-up or allowlist. No need to build from source.
 
-> Builds are currently **macOS arm64** (Apple Silicon) only.
+> Builds are currently **macOS arm64** (Apple Silicon) and **Linux x64**.
+> Windows is not built yet.
 
 ## Download
 
@@ -17,7 +18,8 @@ no separate sign-up or allowlist. No need to build from source.
    page.
 3. Find the latest release titled **`switchdash <version>`** (tag
    `switchdash-v<version>`).
-4. Under **Assets**, download the `.dmg` file.
+4. Under **Assets**, download the file for your platform — `.dmg` on macOS, or
+   one of `.AppImage` / `.deb` / `.rpm` on Linux.
 
 If you don't have repo access the assets return a 404 — ask in the Switch
 Workforce hub to be added as a repo reader.
@@ -28,10 +30,15 @@ Workforce hub to be added as a repo reader.
 # Latest switchdash release (requires `gh auth login` with repo access):
 gh release list --repo sandbox-quantum/switch | grep switchdash-v
 
-# Download the .dmg from a specific release:
+# Download the installer from a specific release (macOS):
 gh release download switchdash-v<version> \
   --repo sandbox-quantum/switch \
   --pattern '*.dmg'
+
+# Linux — pick the format your distro uses:
+gh release download switchdash-v<version> \
+  --repo sandbox-quantum/switch \
+  --pattern '*.AppImage'   # or '*.deb' / '*.rpm'
 ```
 
 > A plain `curl` of the asset URL will **not** work — private-repo release
@@ -57,6 +64,33 @@ Gatekeeper blocks the first launch. Clear it once, either way:
   ```
 
 After that, launch switchdash normally.
+
+## Install (Linux x64)
+
+Linux builds are **unsigned**. Pick the format your distro uses:
+
+- **AppImage** — no install step; make it executable and run it:
+
+  ```bash
+  chmod +x switchdash-x86_64.AppImage
+  ./switchdash-x86_64.AppImage
+  ```
+
+- **Debian / Ubuntu** (`.deb`):
+
+  ```bash
+  sudo apt install ./switchdash-amd64.deb
+  ```
+
+- **Fedora / RHEL** (`.rpm`):
+
+  ```bash
+  sudo dnf install ./switchdash-x86_64.rpm
+  ```
+
+> The app does not yet set a `desktopName`, so desktop environments may not
+> associate its windows with the installed `.desktop` entry (the icon can appear
+> as a duplicate or generic entry in the taskbar). Tracked under CHOO-1905.
 
 ## Updating
 


### PR DESCRIPTION
## What

Re-enables the Linux x64 job in `switchdash-release.yml` so tagged releases ship Linux artifacts (AppImage, deb, rpm) alongside the macOS `.dmg`, fixes the desktop-entry association that made installed builds behave like an unpackaged app, and runs the two platform builds concurrently.

First slice of the **CHOO-1905** Linux umbrella — packaging and release plumbing only, no app-code platform work.

## Why

CHOO-1339 hit `⨯ Please specify author 'email' in the application package.json — It is required to set Linux .deb package maintainer.` on the `switchdash-v0.8.8` tag run ([napoleon run 29419957566](https://github.com/sandbox-quantum/napoleon/actions/runs/29419957566)) and responded by gating the job with `if: false` to keep releases green. That was never followed up, so we currently ship **no Linux artifact at all**.

In that run the AppImage built fine and the job died at the deb target — so **rpm never executed** and was unverified, not known-good.

## Changes

**Linux packaging**
- `electron-builder.config.ts` — set `linux.maintainer`. Scoped to the `linux` block rather than adding `author.email`, so the address governs Linux packaging only instead of becoming the app's global author identity.
- `switchdash-release.yml` — removed `if: false` from `build-linux`; rewrote the header comment that still described Linux as disabled.

**Desktop entry association**
- Electron derives its Linux `app_id` / WM_CLASS from `desktopName` in the *packaged* `package.json`. Without it the running window carries an identifier matching no installed `.desktop` entry, so desktop environments show a second anonymous launcher entry, pinning doesn't stick, and the window falls back to a generic icon.
- `extraMetadata.desktopName` carries the value into the packaged manifest (what Electron reads at runtime); `linux.syncDesktopName` names the installed entry to match.
- Applied to **both** channels with distinct basenames (`switchdash.desktop` / `switchdash-canary.desktop`). `package.json` is shared between channels, so setting it in only one place would have made canary windows associate with the *stable* launcher. The canary config was also missing `linux.maintainer` entirely — the same failure mode this PR fixes for stable.

**Parallel release builds**
- `build-linux` previously had `needs: build-macos`, but not for anything macOS produced — it was only waiting for the GitHub Release to exist, since the macOS job called `gh release create`.
- A small tag-only `create-release` job now creates the assetless Release; both platform jobs depend on that and upload into it with `gh release upload --clobber`. Measured: macOS ~5m10s + Linux ~6m11s sequential (~11m25s) → ~6m11s parallel, roughly **5 minutes saved per release**.
- The `if: ${{ !cancelled() && needs.create-release.result != 'failure' }}` on both build jobs is load-bearing: `create-release` is tag-gated, and a *skipped* dependency would otherwise skip both builds on every `workflow_dispatch` run.

**Docs**
- `dash/docs/INSTALL.md` — dropped the "macOS arm64 only" claim, added per-format Linux install instructions.
- Generated release notes covered macOS only ("download the .dmg"); they now describe both platforms.

## Verification

Ran the workflow via `workflow_dispatch` on this branch — it uploads artifacts instead of touching a Release, so builds are proven without cutting a release.

[Run 30914753720](https://github.com/sandbox-quantum/switch/actions/runs/30914753720) — success, all three Linux targets, and the `desktopName is not set` warning went 3 → 0:

- `switchdash-x86_64.AppImage`
- `switchdash-amd64.deb` ← the target that used to fail
- `switchdash-x86_64.rpm` ← never previously executed

Unpacked the resulting `.deb` to confirm the fix rather than relying on exit codes:

- `/usr/share/applications/switchdash.desktop` (was `Switchdash.desktop`) with `StartupWMClass=switchdash`
- `app.asar` → `package.json` contains `"desktopName": "switchdash.desktop"`, so the runtime `app_id` matches the installed entry
- deb control → `Maintainer: Louis Amaudruz <louis.amaudruz@sandboxaq.com>`, `Package: switchdash`

[Run 30915888379](https://github.com/sandbox-quantum/switch/actions/runs/30915888379) — macOS and Linux started 6 seconds apart (concurrent), with `create-release` correctly skipped on dispatch and neither build job skipped along with it.

### Not verifiable before merge

Every `gh release` step is gated behind `startsWith(github.ref, 'refs/tags/')`, so **the create-then-upload sequence cannot be exercised by a dispatch run** and stays unproven until the first real tag. This was already true of the Linux upload; this PR extends it to the macOS upload, which was previously proven as `gh release create`.

## Deliberately out of scope

Folded into CHOO-1905 as follow-ups:

- `linux.icon` — builds currently fall back to generated icons.
- Creating the Release as a `--draft` and publishing only after both jobs succeed. Nicer (no half-populated release, and a failed Linux job wouldn't leave notes promising Linux downloads) but `gh release upload` resolves drafts differently, and it shouldn't be bet on untested.
- Stable sets `executableName: PRODUCT_NAME` → `Switchdash`, installing to `/opt/Switchdash/Switchdash`; canary deliberately lowercases it. Lowercase is the Linux convention, but changing it moves install paths and icon names.
- `process.platform` branching in app code, tray/notifications, credential storage, Linux auto-update.

## Cross-platform note

Sibling umbrella CHOO-1468 (Windows) touches the same workflow header comment and the same supported-platform line in `INSTALL.md`. That branch will want a rebase rather than a parallel edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)