### PR TITLE
fix(switchdash): let the onboarding page drag the window (CHOO-1430)

### DIFF
--- a/dash/apps/switchdash-desktop/src/renderer/app/home-view.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/app/home-view.tsx
@@ -25,8 +25,12 @@ export function HomeMainPanel() {
   const isDark = effectiveTheme === 'emdark';
 
   return (
+    // Home registers no TitlebarSlot, so without a drag region here the whole
+    // main pane is dead for moving the window and only the sidebar's
+    // SidebarSpace strip drags it. The surface is empty, so it is all drag —
+    // any interactive control added below must opt out with `no-drag`.
     <motion.div
-      className="flex h-full flex-col overflow-y-auto bg-background text-foreground"
+      className="flex h-full flex-col overflow-y-auto bg-background text-foreground [-webkit-app-region:drag]"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5, ease: 'easeOut' }}
@@ -41,7 +45,7 @@ export function HomeMainPanel() {
             />
           </div>
         </div>
-        <div className="mx-auto mt-8 flex w-full max-w-md flex-col gap-1">
+        <div className="mx-auto mt-8 flex w-full max-w-md flex-col gap-1 [-webkit-app-region:no-drag]">
           {LOCATION_ACTIONS.map((action, i) => (
             <HomeLocationAction
               key={action.label}

--- a/dash/apps/switchdash-desktop/src/renderer/tests/browser/home-drag-region.test.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/tests/browser/home-drag-region.test.tsx
@@ -1,0 +1,81 @@
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type * as HomeView from '@renderer/app/home-view';
+import type * as ThemeProvider from '@renderer/lib/providers/theme-provider';
+
+/**
+ * The home view is the one screen that registers no `TitlebarSlot`, so it has
+ * no `Titlebar` supplying a `-webkit-app-region: drag` strip. Without a drag
+ * region of its own the frameless window can only be moved by grabbing the
+ * sidebar's top strip (CHOO-1430).
+ *
+ * Electron is the only place a drag region actually does anything, so these
+ * assertions are on the markup rather than on behaviour: they exist to catch a
+ * restyle or refactor silently dropping the utility classes again.
+ */
+
+let ThemeContext: typeof ThemeProvider.ThemeContext;
+let HomeMainPanel: typeof HomeView.HomeMainPanel;
+let container: HTMLDivElement | null = null;
+
+beforeAll(async () => {
+  // `lib/ipc` reads the preload bridge at module scope and the home view pulls
+  // it in transitively, so the bridge has to exist before the import runs.
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      invoke: async () => undefined,
+      eventSend: () => {},
+      eventOn: () => () => {},
+    },
+  });
+  ({ HomeMainPanel } = await import('@renderer/app/home-view'));
+  // The real ThemeProvider resolves the theme over RPC; the panel only reads
+  // `effectiveTheme` to pick logo colours, so feed the context directly.
+  ({ ThemeContext } = await import('@renderer/lib/providers/theme-provider'));
+});
+
+async function renderHome(): Promise<HTMLDivElement> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () =>
+    root.render(
+      <ThemeContext.Provider
+        value={{
+          theme: null,
+          setTheme: () => {},
+          toggleTheme: () => {},
+          effectiveTheme: 'emlight',
+        }}
+      >
+        <HomeMainPanel />
+      </ThemeContext.Provider>
+    )
+  );
+  return container;
+}
+
+afterEach(() => {
+  container?.remove();
+  container = null;
+});
+
+describe('home view drag region', () => {
+  it('makes the whole onboarding surface draggable', async () => {
+    const el = await renderHome();
+    const surface = el.firstElementChild;
+
+    expect(surface).not.toBeNull();
+    expect(surface?.className).toContain('[-webkit-app-region:drag]');
+  });
+
+  it('opts the action list out so its buttons stay clickable', async () => {
+    const el = await renderHome();
+    const action = el.querySelector('button[aria-label="Add Switch agent"]');
+
+    expect(action).not.toBeNull();
+    expect(action?.closest('[class*="[-webkit-app-region:no-drag]"]')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes [CHOO-1430](https://sandboxquantum.atlassian.net/browse/CHOO-1430).

## The bug

On the switchdash empty/onboarding page the frameless window could only be moved by grabbing the **top of the left sidebar**. The whole main pane — including the top-right, where you instinctively reach — was dead.

## Root cause

Not quite what the ticket guessed. It is not a stray `no-drag` or an element intercepting the region.

`app/view-registry.ts` declared `homeView` as `{ MainPanel: HomeMainPanel }` with **no `TitlebarSlot`**. `lib/layout/navigation-provider.tsx:66` defaults a missing slot to `() => null`, so `WorkspaceContentLayout` rendered nothing above the home panel. Every other view (`locations`, `sessions`, `switch-rooms`, `switch-servers`) registers a slot that renders `Titlebar`, which carries the `h-10 [-webkit-app-region:drag]` strip.

That left `features/sidebar/sidebar-space.tsx` as the only drag region on screen — exactly the reported symptom.

(Settings also has no `TitlebarSlot` but is unaffected: it gets its drag region from page padding — `PageSidebarMenu`'s `py-10` and `PageHeader`'s sticky `pt-10`, both marked `drag` with their interactive children marked `no-drag`.)

## The fix

The onboarding surface is empty by design, so rather than reinstating titlebar chrome on the one page that deliberately has none, the whole panel becomes the drag region:

- `HomeMainPanel` root → `[-webkit-app-region:drag]`
- the action-list wrapper → `[-webkit-app-region:no-drag]`, so the "Add Switch agent" button keeps receiving clicks

Two lines of Tailwind, no new components, no layout shift, no visual change.

## Tests

`src/renderer/tests/browser/home-drag-region.test.tsx` asserts the drag region is present and that the action list opts out. Electron is the only place a drag region does anything, so these are markup assertions — their job is to catch a restyle silently dropping the classes again. Verified they bite: removing either class fails the suite.

## Verification

- `typecheck` ✅ · `lint` ✅ · `format:check` ✅ · `vitest --project browser` 18/18 ✅
- `vitest --project node` reports 38 failed files, **identical to the untouched baseline** (confirmed by stashing and re-running). All trace to missing native binaries (`electron`, `pty.node`) in the sandbox, unrelated to this change.

## ⚠️ Needs a human check in a running build

Drag-region hit-testing only exists in real Electron, so this could not be verified from a terminal. Please confirm on the onboarding page:

1. Dragging from the **top-right** of the main pane moves the window.
2. The **"Add Switch agent"** row still clicks and opens the modal, and hover/arrow-key selection still works.
3. Nothing else on the page feels swallowed.

One known edge case worth a glance: the drag region sits on the scroll container, so in a very short window (where the page actually overflows) dragging the scrollbar thumb may move the window instead of scrolling. Mouse wheel is unaffected.

## Out of scope

- `SettingsTitlebar` (`features/settings/settings-view.tsx:42`) is defined but never registered — dead code.
- `lib/components/titlebar/Titlebar.tsx:23` claims Linux has no native frame, but `main/app/window.ts` only sets `titleBarStyle: 'hiddenInset'` on `darwin` and never sets `frame: false`. The comment looks stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1430]: https://sandboxquantum.atlassian.net/browse/CHOO-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ