### PR TITLE
docs(legal): drop "open source" claim from repo docs (CHOO-1251, H1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ The target architecture is documented in `docs/`.
 
 ## Switchdash
 
-`dash/` is a local-first desktop app (Electron; an open-source fork, upstream
+`dash/` is a local-first desktop app (Electron; a fork, upstream
 attribution in `dash/NOTICE`) for managing the local AI coding-agent sessions that
 participate in Switch. The upstream app is built around coding workflows
 (projects → sessions → conversations); switchdash is being reworked

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 </div>
 
-Agent Switch is the open-source workplace for AI agents: they join rooms with
+Agent Switch is the workplace for AI agents: they join rooms with
 your team, chat where you chat, take on tasks, and work under rules you set.
 
 - 🤝 **Multi-agent, multi-human** — shared rooms where whole teams of people and agents work together, not 1:1 chatbot sessions.

--- a/dash/AGENTS.md
+++ b/dash/AGENTS.md
@@ -8,7 +8,7 @@ working and listening to its Switch rooms while switchdash is closed (CHOO-1059)
 combines provider-agnostic CLI agent execution, session management,
 terminal sessions, MCP and skills, and packaging for desktop releases.
 
-Switchdash is an open-source fork; upstream attribution is recorded in `NOTICE`. The
+Switchdash is a fork; upstream attribution is recorded in `NOTICE`. The
 product is fully rebranded to switchdash: packages (`@switchdash/*`), the app directory
 (`apps/switchdash-desktop/`), the user-data directory, the per-project config file
 (`.switchdash.json`), the macOS app id (`com.switchdash.*`), release artifact names

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,7 +95,7 @@ flowchart LR
 
 ### The desktop app (switchdash)
 
-`dash/` is a local-first Electron desktop app (an open-source fork; see
+`dash/` is a local-first Electron desktop app (a fork; see
 `dash/NOTICE`) for managing the local coding-agent sessions that participate in
 Switch — which rooms an agent belongs to, its config, and session scheduling
 (e.g. auto-starting a session when a Slack user addresses an agent that has no


### PR DESCRIPTION
## What

Removes the "open source" claim from the repo's documentation. Agent Switch ships under **Apache-2.0 + Commons Clause**, which is *not* an OSI-approved open-source license, so calling the project (or switchdash) "open source" is inaccurate.

Per direction from the collaborating dev, the claim is **removed** rather than replaced with a "source-available" label — the docs no longer characterize the distribution model, they just state the license factually.

## Changes
- **`README.md`** — tagline: "the ~~open-source~~ workplace for AI agents".
- **`docs/ARCHITECTURE.md`**, **`CLAUDE.md`**, **`dash/AGENTS.md`** — switchdash fork descriptors: "an ~~open-source~~ fork" → "a fork". Upstream emdash attribution in `dash/NOTICE` is unchanged.

The README/CONTRIBUTING License sections already state the license factually (Apache-2.0 + Commons Clause, no "open source"), so no change was needed there.

## Context
Addresses the **H1** finding from the INFOSEC-499 security review (docs/labeling portion). The separate legal question in H1 — layering Commons Clause on top of the emdash (third-party) Apache-2.0 grant — is **out of scope for this PR** and is being handled with Legal (CHOO-1252/1253).

## Out of code (for a human)
- GitHub repo **topics** / website / badges that say "open source" are repo settings, not files — flip those separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)