### PR TITLE
fix(ci): drop actions:write from CLA app-token request (CHOO-1251, H3 follow-up)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,6 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-statuses: write
-          permission-actions: write
 
       - name: CLA Assistant
         if: >-


### PR DESCRIPTION
## What
Follow-up to the H3 hardening (#111). The live smoke test showed `create-github-app-token` failing with:

> 422 — The permissions requested are not granted to this installation.

The dedicated **Switch CLA Assistant** app is installed with **Contents / Pull requests / Commit statuses = write** (as set up), but the workflow additionally requested `permission-actions: write`, which the app wasn't granted → the token mint fails.

`actions: write` isn't needed by the CLA action (it persists signatures, comments on the PR, and sets the commit status). This drops that one line so the requested token scope matches the app's granted permissions.

## Verification
After merge I'll re-run a throwaway-PR smoke test to confirm the token mints and the CLA check runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)