### PR TITLE
fix(ci): grant CLA workflow contents:read for committer lookup (CHOO-1251, H3 follow-up)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, synchronize]
 
 permissions:
+  contents: read
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
## What
Second follow-up to the H3 hardening. Smoke test after #113 confirmed the App token now mints successfully ✅, but the CLA action's next step failed:

> graphql call to get the committers details failed: Resource not accessible by integration

Dropping `contents` entirely left `GITHUB_TOKEN` unable to read commit authors for the committer-lookup GraphQL query. This restores **`contents: read`** (read-only).

The H3 intent is preserved: `GITHUB_TOKEN` still has **no write** scope beyond pull-requests/statuses, and there's **no long-lived PAT** — signature commits go through the short-lived, repo-scoped App token.

## Resulting permissions
```yaml
permissions:
  contents: read
  pull-requests: write
  statuses: write
```

## Verification
After merge I'll re-run the smoke test; expected result is the check going green (or, for an unsigned author, the bot cleanly posting the "please sign" comment — both mean it's working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)