### PR TITLE
fix(ci): restore actions:write for CLA re-run on pull_request_target (CHOO-1251, H3 follow-up)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, synchronize]
 
 permissions:
+  actions: write
   contents: read
   pull-requests: write
   statuses: write


### PR DESCRIPTION
## What
Third and final follow-up to the H3 hardening. The smoke test after #115 got all the way to **"All contributors have signed ✅"** (so committer lookup + token mint both work), then the job failed with:

> Resource not accessible by integration

### Root cause (from reading the pinned action source)
The "CLA Assistant" check *is* the workflow job's own status — there's no separate commit-status call. After confirming signatures, `setupClaCheck()` calls `reRunLastWorkFlowIfRequired()`, which on **`pull_request_target`** events (only plain `pull_request` is skipped) uses the `GITHUB_TOKEN` octokit to call `actions.listRepoWorkflows` → `listWorkflowRuns` → `reRunWorkflow`. All of those need the **`actions`** permission. With it dropped, the call throws and the job (hence the check) goes red — even when everyone has already signed.

This is a feature of the action: re-running the previous failed CLA run so its check flips green after someone signs.

## Fix
Restore `actions: write`. Final permissions:
```yaml
permissions:
  actions: write
  contents: read
  pull-requests: write
  statuses: write
```

### H3 wins still intact
`actions: write` here lives only on the **ephemeral `GITHUB_TOKEN`** (dies with the job — not a long-lived, exfiltratable credential). The meaningful H3 hardening stands:
- ✅ Long-lived repo-scoped **PAT removed** → short-lived, repo-scoped **App token**
- ✅ Third-party action **SHA-pinned** (was a mutable tag)
- ✅ `contents` is **read-only** on `GITHUB_TOKEN` (writes go through the App token)
- ✅ Signer **allowlist narrowed** from `*[bot]`

The reviewer's suggested drop of `actions: write` was simply too aggressive for this action's re-run behavior.

## Verification
Smoke-tested end-to-end after each fix; this restores the one permission the re-run path needs. I'll run a final smoke test after merge to confirm the check goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)