### PR TITLE
fix(ci): gate dispatch-from-branch on secret-bearing workflows (CHOO-1251, H4)

### DIFF
--- a/.github/workflows/container_security.yml
+++ b/.github/workflows/container_security.yml
@@ -36,8 +36,10 @@ permissions:
 
 jobs:
   scan-all:
-    # Scheduled / manual full sweep -> standing VULNMGMT tickets.
-    if: ${{ github.event_name != 'pull_request' }}
+    # Scheduled full sweep -> standing VULNMGMT tickets, or a manual dispatch
+    # from main. A workflow_dispatch from an arbitrary branch is skipped so the
+    # Jira machine-user token can't be exercised from unreviewed branch code.
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -32,6 +32,10 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Runs on the weekly schedule (always on the default branch) or a manual
+    # dispatch from main. A workflow_dispatch from an arbitrary branch is skipped
+    # so the PR-bot App credentials can't be exercised from unreviewed branch code.
+    if: ${{ github.event_name == 'schedule' || github.ref == 'refs/heads/main' }}
     env:
       # Gate the App-token step without referencing a missing secret in an `if:`.
       BOT_CLIENT_ID: ${{ secrets.AUTOFIX_PR_BOT_CLIENT_ID }}

--- a/.github/workflows/socket_cve_fix.yml
+++ b/.github/workflows/socket_cve_fix.yml
@@ -14,6 +14,11 @@ permissions:
 jobs:
   socket-fix:
     runs-on: ubuntu-latest
+    # Runs on the monthly/weekly schedule (always on the default branch) or a
+    # manual dispatch from main. A workflow_dispatch from an arbitrary branch is
+    # skipped so the Socket key and PR-bot App credentials can't be exercised
+    # from unreviewed branch code.
+    if: ${{ github.event_name == 'schedule' || github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/switch-agent-runtime-publish.yml
+++ b/.github/workflows/switch-agent-runtime-publish.yml
@@ -39,6 +39,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Publish only from a matching tag or from main. A workflow_dispatch from an
+    # arbitrary branch would otherwise publish whatever that branch's
+    # package.json says into the real @sandbox-quantum namespace, bypassing the
+    # tag-vs-version guard below (which only runs on the tag path).
+    if: ${{ startsWith(github.ref, 'refs/tags/switch-agent-runtime-v') || github.ref == 'refs/heads/main' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/switchdash-release.yml
+++ b/.github/workflows/switchdash-release.yml
@@ -74,9 +74,15 @@ jobs:
   build-macos:
     name: Build & release (macOS arm64)
     runs-on: macos-14
-    # Runs on dispatch too, where create-release is skipped rather than run.
+    # The Apple Developer ID signing secrets live in the `release` environment
+    # (required reviewers + branch policy), so a run must be approved and can
+    # only come from main or a tag — a workflow_dispatch from an arbitrary
+    # branch cannot reach the org signing identity.
+    environment: release
+    # Runs on dispatch too (from main), where create-release is skipped rather
+    # than run. Restricted to main / tags so a feature-branch dispatch is skipped.
     needs: create-release
-    if: ${{ !cancelled() && needs.create-release.result != 'failure' }}
+    if: ${{ !cancelled() && needs.create-release.result != 'failure' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main') }}
     # Surface the cert/key secrets through env so step-level `if:` can gate on
     # them — the `secrets` context is not allowed in `if:` expressions.
     env:


### PR DESCRIPTION
## What
Addresses the **H4** finding from INFOSEC-499: `workflow_dispatch` runs against *any* branch the actor can push, and the repo has no protected environments — so several secret-bearing jobs could be run from an arbitrary, unreviewed branch with org credentials in scope.

> Scope note: this is a **write-access / compromised-account** risk (dispatch requires write access; the public can't reach it), but the Apple signing identity makes it worth closing as defense-in-depth.

## Changes (workflow code)
- **`switchdash-release.yml`** — `build-macos` now runs in a **`release` environment** (required reviewers + branch policy) and only on a **tag or `main`**. The org Apple Developer ID signing identity is now behind human approval and unreachable from a branch dispatch.
- **`switch-agent-runtime-publish.yml`** — `publish` only runs from a `switch-agent-runtime-v*` tag or `main`, so a branch dispatch can't publish an arbitrary `package.json` version into `@sandbox-quantum` (which bypassed the tag-vs-version guard).
- **`socket_cve_fix.yml`** & **`renovate.yml`** — run only on `schedule` or from `main`; the Socket key + PR-bot App credentials can't be exercised from a branch dispatch.
- **`container_security.yml`** — `scan-all` runs only on `schedule` or a `main` dispatch; the Jira machine-user token can't be exercised from a branch dispatch.

## Design note — why only Apple secrets move to an environment
The reviewer suggested moving Apple **and** Socket **and** Jira secrets to a protected environment. Apple secrets are used only by `switchdash-release` (human-initiated), so they get the full **environment + required-reviewers** treatment.

The Socket / Jira / PR-bot secrets are **shared**: `SOCKET_KEY`/`AUTOFIX_PR_BOT_*` with `renovate.yml`, and `SBT_MACHINE_USER_*` with `renovate_jira.yml` — and `renovate_jira` consumes the Jira creds on **`pull_request`** events (ref = `refs/pull/*`). A main-only environment would **block that legitimate consumer**. So those keep repo-secret scope and are protected by **ref-gating** instead, which gives the same "no arbitrary-branch dispatch → secrets" guarantee without breaking renovate automation.

## ⚠️ Admin steps required before this fully takes effect
The `release` environment must be created (I can't do this from code):
1. **Settings → Environments → New environment** → name it **`release`**.
2. **Required reviewers** → add yourself / trusted maintainers.
3. **Deployment branches and tags** → *Selected* → add `main` and tag pattern `switchdash-v*`.
4. **Environment secrets** → add the five Apple secrets there, then **delete them from repo secrets**: `APPLE_API_KEY_P8`, `APPLE_CSC_LINK`, `APPLE_CSC_KEY_PASSWORD`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`.

Note: after this, **releases will pause for a reviewer to approve** the macOS signing job — that's the intended control.

## Behavior changes to be aware of
- Can no longer `workflow_dispatch` a **signed macOS build** or an **npm publish** from a feature branch — only from `main` (or a tag). Unsigned Linux dispatch builds are unaffected.
- Scheduled jobs are unaffected (they always run on the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)