### PR TITLE
release(claude-plugin): 0.7.7 — pin switch-agent-runtime 0.1.5

### DIFF
--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/.mcp.json
+++ b/connectors/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandbox-quantum/switch-agent-runtime@0.1.4"],
+      "args": ["-y", "@sandbox-quantum/switch-agent-runtime@0.1.5"],
       "env": {
         "SWITCH_API_ENDPOINT": "${SWITCH_API_ENDPOINT}",
         "SWITCH_API_TOKEN": "${SWITCH_API_TOKEN}",

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-rooms/switch-agent-runtime.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-rooms/switch-agent-runtime.ts
@@ -20,7 +20,7 @@ export const SWITCH_AGENT_RUNTIME_PACKAGE = '@sandbox-quantum/switch-agent-runti
  * `connectors/claude-code-plugin/.mcp.json`; `switch-agent-runtime.test.ts`
  * fails if the two drift. Bump both together when the runtime is republished.
  */
-export const SWITCH_AGENT_RUNTIME_VERSION = '0.1.4';
+export const SWITCH_AGENT_RUNTIME_VERSION = '0.1.5';
 
 /**
  * Credentials the runtime refuses to start without: it reads all three at


### PR DESCRIPTION
Moves the runtime pins onto the freshly published **switch-agent-runtime `0.1.5`** and bumps the Claude Code connector plugin so installs pick it up.

## Changes
- `connectors/claude-code-plugin/.mcp.json` — runtime pin `0.1.4 → 0.1.5`
- `connectors/claude-code-plugin/.claude-plugin/plugin.json` — plugin version `0.7.6 → 0.7.7`
- `dash/apps/switchdash-desktop/src/shared/core/switch-rooms/switch-agent-runtime.ts` — `SWITCH_AGENT_RUNTIME_VERSION` `0.1.4 → 0.1.5`

## Why the switchdash pin moves too
`switch-agent-runtime.test.ts` holds the two pins equal (the Claude `.mcp.json` pin and switchdash's `SWITCH_AGENT_RUNTIME_VERSION`) and forbids either running ahead of `packages/switch-agent-runtime/package.json` (now `0.1.5`, published). So both pins move together, off `0.1.4` onto `0.1.5`.

Runtime `0.1.5` publish run: https://github.com/sandbox-quantum/switch/actions/runs/31024249390

🤖 Generated with [Claude Code](https://claude.com/claude-code)