### PR TITLE
release(switchdash): 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,16 @@ below:
 
 ### [Unreleased]
 
+### [0.18.1] - 2026-08-05
+
+#### Changed
+- Bundled Switch agent runtime bumped to 0.1.5 (#127).
+
+#### Fixed
+- A session's Switch connection id is now derived deterministically, so a
+  supervisor/sidecar restart no longer strands a remote session with a stale
+  connection id (CHOO-1931, #125).
+
 ### [0.18.0] - 2026-08-04
 
 #### Added

--- a/dash/apps/switchdash-desktop/package.json
+++ b/dash/apps/switchdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchdash/switchdash-desktop",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",


### PR DESCRIPTION
Cuts the **switchdash 0.18.1** patch release.

## Changes
- `dash/apps/switchdash-desktop/package.json` — version `0.18.0 → 0.18.1`
- `CHANGELOG.md` — `## switchdash` `[Unreleased]` cut to `[0.18.1] - 2026-08-05`

## Changelog for 0.18.1
- **Changed** — Bundled Switch agent runtime bumped to 0.1.5 (#127).
- **Fixed** — A session's Switch connection id is now derived deterministically, so a supervisor/sidecar restart no longer strands a remote session with a stale connection id (CHOO-1931, #125).

Once merged, tagging `switchdash-v0.18.1` triggers the release build. Note the macOS build is gated on approval in the `release` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)