### PR TITLE
release(switch-core): 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ below:
 
 ### [Unreleased]
 
+### [0.12.1] - 2026-08-05
+
+#### Security
+- Retire the unauthenticated `/collab` bridge-admin API (CHOO-1251, H5, #120).
+- Re-scan and bump dependency CVEs (CHOO-1251, M5, #123).
+- Local stacks are secure by default: published ports bind to `127.0.0.1`
+  (`SWITCH_BIND_ADDR=0.0.0.0` is now an explicit opt-in for network exposure),
+  `.env.example` ships every secret blank, and `just init-env` generates strong
+  random credentials — no more `admin/admin` reachable on `0.0.0.0` (CHOO-1251,
+  M1, #122).
+
+#### Fixed
+- Enforce one session of an agent per room: `connect_to_room` now refuses with
+  HTTP 409 when another session of the same agent already holds the room, and a
+  takeover evicts and reports the displaced session — instead of silently
+  stranding a session in a room whose events go elsewhere (CHOO-1419, #109).
+
 ### [0.12.0] - 2026-08-04
 
 #### Added

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.12.0"
+version = "0.12.1"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Cut switch-core `0.12.1` (patch).

**Version:** `core/pyproject.toml` 0.12.0 → 0.12.1 (tag will be `switch-v0.12.1`).

**Changelog (## switch-core → [0.12.1]):**
- **Security** (CHOO-1251): retire unauthenticated `/collab` bridge-admin API (H5, #120); re-scan & bump dependency CVEs (M5, #123); loopback bind by default + generated secrets for local stacks — no more admin/admin on 0.0.0.0 (M1, #122).
- **Fixed:** enforce one session of an agent per room — `connect_to_room` returns 409 on collision and a takeover reports the displaced session (CHOO-1419, #109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)