### PR TITLE
release(switchdash): 0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,15 @@ below:
 
 ### [Unreleased]
 
+### [0.18.2] - 2026-08-05
+
+#### Fixed
+- Client side of one-session-per-room enforcement: a session whose room the
+  server takes away (or refuses with HTTP 409 because another session of the
+  agent holds it) is now reported as roomless and is not reconnected under a
+  room it no longer attends — the remote-session reconciler and sidecar no
+  longer strand two sessions in one room (CHOO-1419, #109).
+
 ### [0.18.1] - 2026-08-05
 
 #### Changed

--- a/dash/apps/switchdash-desktop/package.json
+++ b/dash/apps/switchdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchdash/switchdash-desktop",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",


### PR DESCRIPTION
Cut switchdash `0.18.2` (patch).

**Version:** `dash/apps/switchdash-desktop/package.json` 0.18.1 → 0.18.2 (tag will be `switchdash-v0.18.2`).

**Changelog (## switchdash → [0.18.2]):**
- **Fixed:** client side of one-session-per-room enforcement — a session whose room the server takes away (or refuses, HTTP 409) is reported roomless and not reconnected under a room it no longer attends; the reconciler and sidecar no longer strand two sessions in one room (CHOO-1419, #109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)