### PR TITLE
fix(switchdash): point release links at the namespaced switchdash-v tag

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/updates/update-service.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/updates/update-service.ts
@@ -24,6 +24,7 @@ import {
   updateNotAvailableEvent,
   updateProgressEvent,
 } from '@shared/events/updateEvents';
+import { switchdashReleaseApiUrl } from '@shared/urls';
 import {
   FAKE_UPDATE_VERSION_ENV_VAR,
   FakeUpdateDriver,
@@ -436,18 +437,28 @@ class UpdateService implements IInitializable, IDisposable {
       const version = this.updateState.availableVersion;
       if (!version) return null;
 
-      const response = await fetch(
-        `https://api.github.com/repos/sandbox-quantum/switch/releases/tags/v${version}`
-      );
+      // The release feed is a private repo: an unauthenticated read 404s on
+      // every release, so reuse the token the update check already relies on.
+      const token = await getGithubTokenFromGhCli();
+      const response = await fetch(switchdashReleaseApiUrl(version), {
+        headers: token ? { authorization: `token ${token}` } : {},
+      });
 
-      if (response.ok) {
-        const data = (await response.json()) as { body?: string };
-        const notes = data.body || 'No release notes available';
-        this.updateState.releaseNotes = notes;
-        return notes;
+      if (!response.ok) {
+        log.warn('Could not fetch release notes', {
+          event: 'update.release_notes',
+          stage: 'fetch',
+          errorCode: `http_${response.status}`,
+          version,
+          authenticated: token !== null,
+        });
+        return null;
       }
 
-      return null;
+      const data = (await response.json()) as { body?: string };
+      const notes = data.body || 'No release notes available';
+      this.updateState.releaseNotes = notes;
+      return notes;
     } catch (error) {
       log.error('Failed to fetch release notes:', error);
       return null;

--- a/dash/apps/switchdash-desktop/src/shared/urls.test.ts
+++ b/dash/apps/switchdash-desktop/src/shared/urls.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SWITCHDASH_RELEASES_URL,
+  switchdashReleaseApiUrl,
+  switchdashReleaseTag,
+  switchdashReleaseUrl,
+} from './urls';
+
+describe('switchdashReleaseTag', () => {
+  it('namespaces the tag with the switchdash prefix', () => {
+    expect(switchdashReleaseTag('0.18.2')).toBe('switchdash-v0.18.2');
+  });
+
+  it('does not double the v when the version already carries one', () => {
+    expect(switchdashReleaseTag('v0.18.2')).toBe('switchdash-v0.18.2');
+  });
+
+  it('keeps a prerelease identifier intact', () => {
+    expect(switchdashReleaseTag('0.19.0-canary.4')).toBe('switchdash-v0.19.0-canary.4');
+  });
+});
+
+describe('switchdashReleaseUrl', () => {
+  it('links to the namespaced release tag', () => {
+    expect(switchdashReleaseUrl('0.18.2')).toBe(
+      'https://github.com/sandbox-quantum/switch/releases/tag/switchdash-v0.18.2'
+    );
+  });
+
+  it('falls back to the releases index when the version is unknown', () => {
+    expect(switchdashReleaseUrl(undefined)).toBe(SWITCHDASH_RELEASES_URL);
+  });
+});
+
+describe('switchdashReleaseApiUrl', () => {
+  it('points at the namespaced tag on the API host', () => {
+    expect(switchdashReleaseApiUrl('0.18.2')).toBe(
+      'https://api.github.com/repos/sandbox-quantum/switch/releases/tags/switchdash-v0.18.2'
+    );
+  });
+});

--- a/dash/apps/switchdash-desktop/src/shared/urls.ts
+++ b/dash/apps/switchdash-desktop/src/shared/urls.ts
@@ -1,4 +1,14 @@
 export const SWITCHDASH_RELEASES_URL = 'https://github.com/sandbox-quantum/switch/releases';
+const SWITCHDASH_RELEASES_API_URL = 'https://api.github.com/repos/sandbox-quantum/switch/releases';
+
+/**
+ * The desktop app shares its repo with switch-core, so its release tags are
+ * namespaced `switchdash-v<version>` — see .github/workflows/switchdash-release.yml,
+ * which only triggers on that prefix. A bare `v<version>` tag belongs to nothing.
+ */
+export function switchdashReleaseTag(version: string): string {
+  return `switchdash-v${version.replace(/^v/, '')}`;
+}
 
 /**
  * Release page for one specific version. Falls back to the releases index when
@@ -6,8 +16,12 @@ export const SWITCHDASH_RELEASES_URL = 'https://github.com/sandbox-quantum/switc
  */
 export function switchdashReleaseUrl(version: string | undefined): string {
   if (!version) return SWITCHDASH_RELEASES_URL;
-  const tag = version.startsWith('v') ? version : `v${version}`;
-  return `${SWITCHDASH_RELEASES_URL}/tag/${tag}`;
+  return `${SWITCHDASH_RELEASES_URL}/tag/${switchdashReleaseTag(version)}`;
+}
+
+/** GitHub API endpoint for one version's release, for reading its notes. */
+export function switchdashReleaseApiUrl(version: string): string {
+  return `${SWITCHDASH_RELEASES_API_URL}/tags/${switchdashReleaseTag(version)}`;
 }
 export const SWITCHDASH_DOCS_URL = 'https://github.com/sandbox-quantum/switch';
 export const SWITCHDASH_ISSUES_URL = 'https://github.com/sandbox-quantum/switch/issues';


### PR DESCRIPTION
## Problem

The "release notes" link in the update UI 404s:

| | |
|---|---|
| Links to | `https://github.com/sandbox-quantum/switch/releases/tag/v0.18.2` |
| Should be | `https://github.com/sandbox-quantum/switch/releases/tag/switchdash-v0.18.2` |

The desktop app shares its repo with switch-core, so its release tags are namespaced `switchdash-v<version>` — that prefix is what `switchdash-release.yml` triggers on. `switchdashReleaseUrl()` built a bare `v<version>` tag, which belongs to nothing.

Both entry points — the sidebar update module and the **settings** Update card — route through `updateStore.openReleasePage()`, so the single helper covers both.

The same mistake sat in `fetchReleaseNotes()`, which fetched `/releases/tags/v<version>`. That call also went out unauthenticated against a private repo, so the in-app notes never rendered on any version, right tag or not.

## Fix

- One `switchdashReleaseTag()` helper; `switchdashReleaseUrl()` and the new `switchdashReleaseApiUrl()` both build on it. Handles a leading `v` and keeps prerelease identifiers (`0.19.0-canary.4`) intact.
- `fetchReleaseNotes()` uses the API helper and sends the gh CLI token the update check already depends on, and `log.warn`s the status code instead of returning `null` in silence.
- Unit tests over the three helpers.

## Verification

`pnpm run typecheck` clean; `vitest --project node src/shared src/main/core/updates` → 19 files / 175 tests pass. (The full local suite can't run in this checkout — Electron's binary isn't installed, which fails 79 files unrelated to this change. CI is the gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)