### PR TITLE
release(switchdash): 0.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ below:
 
 ### [Unreleased]
 
+### [0.18.3] - 2026-08-06
+
 #### Added
 - The Codex connector plugin now ships the Switch MCP server itself
   (`mcpServers` + `env_vars` name-forwarding), so Codex can be used with Switch
@@ -204,6 +206,12 @@ below:
 - Codex runtime status reports tool calls ("Running tool …") instead of sitting
   on "Working on it…" for a whole turn; no tool hook was registered for Codex,
   so nothing could ever produce an activity update (CHOO-1935).
+- In-app release links resolve again: the sidebar update indicator and the
+  Settings Update card pointed at `.../releases/tag/v<version>`, which is not a
+  real tag (the app is tagged `switchdash-v<version>`), so the user hit a 404;
+  the release-notes fetch had the same broken tag and now also authenticates
+  with the gh CLI token so it can read the private release feed instead of
+  silently returning nothing (#134).
 
 #### Changed
 - The per-agent Codex profile carries only model, reasoning effort and

--- a/dash/apps/switchdash-desktop/package.json
+++ b/dash/apps/switchdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchdash/switchdash-desktop",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",


### PR DESCRIPTION
Cut switchdash `0.18.3` (patch) from latest main.

**Version:** `dash/apps/switchdash-desktop/package.json` 0.18.2 → 0.18.3 (tag will be `switchdash-v0.18.3`).

**Changelog (## switchdash → [0.18.3]):**
- **Added:** Codex connector plugin ships the Switch MCP server itself — Codex works with Switch outside switchdash, tools auto-approved (CHOO-1935, #126).
- **Fixed:** bypass-permissions applied to existing sessions again (CHOO-1935, #126); Codex runtime status reports tool calls (CHOO-1935, #126); in-app release links point at the `switchdash-v` tag and the notes fetch authenticates against the private feed (#134).
- **Changed:** per-agent Codex profile carries only model/effort/instructions; none set → no profile (CHOO-1935, #126).

🤖 Generated with [Claude Code](https://claude.com/claude-code)