### PR TITLE
fix(switchdash): opt dialogs out of the window drag region (CHOO-1953)

### DIFF
--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -55,11 +55,9 @@ export const ServersSidebarSection = observer(function ServersSidebarSection() {
     };
   }, [store]);
 
-  // Nothing registered yet — keep the sidebar uncluttered, but still expose a
-  // way to add the first server.
-  const empty = store.servers.length === 0;
-  // Offer to start a local server whenever there isn't one already, even if the
-  // user has remote servers registered.
+  // Adding a server — local or remote — is reached from the header's "+" only.
+  // A managed server still gets a placeholder row while it starts, so the list
+  // shows it before the record exists.
   const hasManagedServer = store.servers.some((s) => s.managed);
   // The selected server scopes the whole sidebar. When the list is collapsed the
   // rows are hidden, so surface the active server's name here to keep it clear
@@ -118,24 +116,6 @@ export const ServersSidebarSection = observer(function ServersSidebarSection() {
               always visible in the list — not only once it's healthy. */}
           {!hasManagedServer && localServerStore.phase !== 'stopped' && (
             <LocalServerPendingEntry onOpen={() => showAddServerModal({ mode: 'local' })} />
-          )}
-          {!hasManagedServer && localServerStore.phase === 'stopped' && (
-            <button
-              type="button"
-              onClick={() => showAddServerModal({ mode: 'local' })}
-              className="w-full px-3 py-1.5 text-left text-xs text-foreground-tertiary hover:text-foreground"
-            >
-              Start a local server…
-            </button>
-          )}
-          {empty && (
-            <button
-              type="button"
-              onClick={() => showAddServerModal({})}
-              className="w-full px-3 py-1.5 text-left text-xs text-foreground-tertiary-passive hover:text-foreground-tertiary"
-            >
-              Add a server…
-            </button>
           )}
         </SidebarMenu>
       )}

--- a/dash/apps/switchdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
@@ -109,7 +109,10 @@ export const ModalRenderer = observer(function ModalRenderer() {
             }
           }}
           className={cn(
-            'fixed left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-xl bg-background-quaternary text-sm ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            // `no-drag`: the popup portals to `document.body`, so a view's
+            // `-webkit-app-region: drag` rect stays live underneath it and would
+            // otherwise swallow pointer-down. See the DialogOverlay docblock.
+            'fixed left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-xl bg-background-quaternary text-sm ring-1 ring-foreground/10 duration-100 outline-none [-webkit-app-region:no-drag] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
             POSITION_CLASSES[displayEntry?.position ?? 'center'],
             SIZE_CLASSES[displayEntry?.size ?? 'md']
           )}

--- a/dash/apps/switchdash-desktop/src/renderer/lib/ui/dialog.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/ui/dialog.tsx
@@ -20,12 +20,22 @@ function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
+/**
+ * Draggable regions are geometric rectangles Chromium computes from layout, not
+ * something a DOM subtree inherits. Dialogs portal to `document.body`, so a view
+ * that declares `-webkit-app-region: drag` (the home panel, `page-header`,
+ * `page-layout`, `Titlebar`, `sidebar-space`) keeps its rect live *underneath* an
+ * open dialog: without an explicit opt-out, pointer-down over the dialog is taken
+ * by the window-drag handler, so text cannot be selected and clicks land as drags.
+ * The backdrop opts the whole viewport out for as long as a dialog is open, which
+ * also keeps outside-click dismissal working over those views.
+ */
 function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 isolate z-50 bg-black/30 duration-100  data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        'fixed inset-0 isolate z-50 bg-black/30 duration-100 [-webkit-app-region:no-drag] data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
         className
       )}
       {...props}
@@ -50,7 +60,10 @@ function DialogContent({
           }
         }}
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl bg-background text-sm ring-1 ring-foreground/10 duration-100 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 sm:max-w-lg',
+          // `no-drag` is repeated here rather than left to the backdrop so the
+          // popup carries the opt-out itself, even if it is ever rendered
+          // without one. See the DialogOverlay docblock.
+          'fixed top-1/2 left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl bg-background text-sm ring-1 ring-foreground/10 duration-100 outline-none [-webkit-app-region:no-drag] data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 sm:max-w-lg',
           className
         )}
         {...props}

--- a/dash/apps/switchdash-desktop/src/renderer/tests/browser/modal-drag-region.test.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/tests/browser/modal-drag-region.test.tsx
@@ -1,0 +1,84 @@
+import { act, type ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ModalRenderer } from '@renderer/lib/modal/modal-renderer';
+import { modalStore } from '@renderer/lib/modal/modal-store';
+import { Dialog, DialogContent } from '@renderer/lib/ui/dialog';
+
+/**
+ * Draggable regions are geometric rectangles Chromium derives from layout, not
+ * an inherited DOM property. Dialogs portal to `document.body`, so the drag rect
+ * a view declares (the home panel since CHOO-1430, plus `page-header`,
+ * `page-layout`, `Titlebar` and `sidebar-space`) stays live underneath an open
+ * dialog and takes its pointer-down events: the window moves and form text
+ * cannot be selected (CHOO-1953).
+ *
+ * Only Electron acts on a drag region, so — as in `home-drag-region.test.tsx` —
+ * these assertions are on the markup rather than on behaviour. They exist to
+ * catch a restyle or refactor silently dropping the opt-out again.
+ */
+
+const NO_DRAG = '[-webkit-app-region:no-drag]';
+
+let container: HTMLDivElement | null = null;
+
+async function render(node: ReactNode): Promise<void> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => root.render(node));
+}
+
+// `unsavedChangesModal` stands in for any registry modal: the assertions are on
+// the chrome ModalRenderer wraps around the content, not on the content itself,
+// and this one renders from its props alone — no query client or store to stub.
+async function renderRegistryModal(): Promise<void> {
+  modalStore.setModal('unsavedChangesModal', {
+    fileName: 'test.txt',
+    onSuccess: () => {},
+    onClose: () => {},
+  });
+  await render(<ModalRenderer />);
+}
+
+afterEach(() => {
+  modalStore.closeModal();
+  container?.remove();
+  container = null;
+});
+
+describe('modal drag region', () => {
+  it('opts the registry modal popup out of the drag region', async () => {
+    await renderRegistryModal();
+
+    // The popup portals out of `container`, so query the document.
+    const popup = document.querySelector('[data-slot="dialog-content"]');
+
+    expect(popup).not.toBeNull();
+    expect(popup?.className).toContain(NO_DRAG);
+  });
+
+  it('opts the backdrop out so outside clicks dismiss rather than drag', async () => {
+    await renderRegistryModal();
+
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]');
+
+    expect(overlay).not.toBeNull();
+    expect(overlay?.className).toContain(NO_DRAG);
+  });
+
+  it('opts the standalone DialogContent out too', async () => {
+    await render(
+      <Dialog open>
+        <DialogContent>
+          <p>Test</p>
+        </DialogContent>
+      </Dialog>
+    );
+
+    const popup = document.querySelector('[data-slot="dialog-content"]');
+
+    expect(popup).not.toBeNull();
+    expect(popup?.className).toContain(NO_DRAG);
+  });
+});


### PR DESCRIPTION
Two changes, both on the switchdash renderer. The first is CHOO-1953 proper; the second is a UI cleanup the collaborating dev asked to fold into the same PR.

---

# 1. Dialogs are inside the window drag region (CHOO-1953)

## Problem

On the switchdash empty state, clicking the add/connect-server modal **drags the whole window**, and text in the form cannot be selected. Reported on `v0.18.0` ([CHOO-1953](https://sandboxquantum.atlassian.net/browse/CHOO-1953)).

## Root cause

Electron/Chromium draggable regions are **geometric rectangles computed from layout — not a property a DOM subtree inherits.**

[CHOO-1430](https://sandboxquantum.atlassian.net/browse/CHOO-1430) (`6aea585`, #106) fixed "window not draggable from the top-right" by putting `-webkit-app-region: drag` on the **entire** `HomeMainPanel` root, opting only the action list out.

The modal does not render inside that div — `ModalRenderer` portals via Base UI to `document.body`, a DOM **sibling** of `#root`. So it can neither inherit from nor subtract from the panel's drag rect. It paints on top of a live drag rectangle, and since neither the popup nor the backdrop declared `no-drag`, pointer-down over it was consumed by the window-drag handler.

Region collection is DOM-order based and the portal node comes after `#root`, so a `no-drag` there wins cleanly.

## Fix

Opt the shared dialog chrome out explicitly, rather than narrowing the home panel's region:

- **`lib/ui/dialog.tsx`** — `[-webkit-app-region:no-drag]` on `DialogOverlay` (the shared backdrop, used by both modal paths) and on the standalone `DialogContent` popup.
- **`lib/modal/modal-renderer.tsx`** — same on the registry `DialogPrimitive.Popup`.

The backdrop opts the whole viewport out for as long as a dialog is open, which additionally keeps **outside-click dismissal** working over a drag region (previously it dragged the window instead of dismissing). The popups repeat the opt-out so they carry the guarantee even if ever rendered without a backdrop.

Trade-off, chosen deliberately with the dev: while a dialog is open the window cannot be dragged at all. The alternative — leaving the backdrop draggable — keeps window repositioning during a long form but leaves outside-click dismissal broken over any drag region.

## Why this does not reintroduce CHOO-1430

**`home-view.tsx` is not touched.** The empty state keeps its full-pane drag region and stays draggable from the top-right whenever no dialog is open — exactly the CHOO-1430 scenario. Its regression test `tests/browser/home-drag-region.test.tsx` is **unmodified and still passes**.

Considered and rejected: narrowing home's drag region to a top strip. It would fix only home, leave the bug live over every other view, and force rewriting the CHOO-1430 guard.

## Scope

Because the fix is on shared dialog chrome, it also fixes this for the other 16 registry modals over `page-header`, `page-layout`, `Titlebar` and `sidebar-space`, which all declare drag rects and posed the identical hazard.

## Testing

New `tests/browser/modal-drag-region.test.tsx` (3 cases: registry popup, backdrop, standalone `DialogContent`).

- **Guarded the guard** — stripped the `no-drag` classes back out and re-ran: all 3 new tests fail. Restored: all 3 pass. The assertions are markup-level (only Electron acts on a drag region), so this check matters.
- Manually confirmed fixed in a real Electron window by the reporter.

---

# 2. Drop the two servers-sidebar text actions

At the dev's request, remove **"Start a local server…"** and **"Add a server…"** from the `SERVERS` sidebar section.

**No capability is lost.** Both were duplicates of the section header's always-present `+` button (`aria-label="Add server"`), which opens the same `addServerModal` chooser — and that chooser reaches both paths: "Run a server on this computer" (the local start) and "Connect to an existing server". The two text rows were additionally *gated* (`empty`, and `!hasManagedServer && phase === 'stopped'`) where the `+` is not, so they were strictly narrower entry points.

Checked before removing: there is no command-palette, menu, or keyboard entry point for either action, so the `+` and the add-agent modal's zero-servers path are what remain. The `LocalServerPendingEntry` placeholder stays — it reports state rather than offering an action.

---

## Verification (both changes)

- Full browser suite: **25/25 pass**, including the unmodified CHOO-1430 test.
- `node` + `main-db` projects: **1780/1780 pass**.
- `typecheck`, `format`, app `lint`: clean.

## Pre-existing issues on the base commit (`dd19430`), not from this PR

- `packages/plugins/src/agents/impl/codex/hooks.test.ts:274` — oxlint `require-array-sort-compare` **error**, so root `pnpm run lint` is already red on `main`. Verified by stashing this work and re-running. Deliberately left out of scope.
- `src/sidecar/sidecar-runtime.test.ts:259` — `await-thenable` warning.

No version bumps needed: renderer-only, none of the four independently-versioned artifacts are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1953]: https://sandboxquantum.atlassian.net/browse/CHOO-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHOO-1430]: https://sandboxquantum.atlassian.net/browse/CHOO-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ