### PR TITLE
docs(switchdash): audit the dash/ agent docs and clear emdash-fork drift (CHOO-1860)

### DIFF
--- a/dash/AGENTS.md
+++ b/dash/AGENTS.md
@@ -525,6 +525,8 @@ pnpm run test
 - [Main process architecture](agents/architecture/main-process.md)
 - [Renderer architecture](agents/architecture/renderer.md)
 - [Shared modules](agents/architecture/shared.md)
+- [Remote execution: hosts, reachability, sidecar](agents/architecture/remote-execution.md)
+- [Switch rooms and sessions](agents/architecture/switch-rooms.md)
 - [Data model (switchdash vs. its upstream origin)](agents/architecture/data-model.md)
 - [Testing workflow](agents/workflows/testing.md)
 - [Provider integration](agents/integrations/providers.md)

--- a/dash/AGENTS.md
+++ b/dash/AGENTS.md
@@ -1,8 +1,8 @@
 # Project Overview
 
 Switchdash is a cross-platform, local-first Electron app for orchestrating multiple AI
-coding agents in parallel. Each agent runs in its own session at the project root (there
-are no Git worktrees). An agent runs either locally or — when configured remote — on an
+coding agents in parallel. Each agent runs in its own session in its location's directory
+(there are no Git worktrees). An agent runs either locally or — when configured remote — on an
 SSH host, where it runs inside tmux next to a switchdash-deployed sidecar so it keeps
 working and listening to its Switch rooms while switchdash is closed (CHOO-1059). It
 combines provider-agnostic CLI agent execution, session management,
@@ -34,10 +34,14 @@ Repo root:
 - `.claude/` - Local Claude agent settings for this checkout.
 - `agents/` - Agent-facing architecture, workflow, convention, integration, and risk docs.
 - `apps/switchdash-desktop/` - The Electron desktop app (everything below).
-- `packages/` - Shared workspace packages: core runtime, shared primitives, and plugins.
+- `packages/` - Shared workspace packages.
   - `packages/core/` - Transport-agnostic core runtime primitives.
-  - `packages/shared/` - Shared workspace primitives.
-  - `packages/plugins/` - Plugin interfaces and helpers.
+  - `packages/shared/` - Shared workspace primitives, including the `Result<T, E>` type
+    (`@switchdash/shared`).
+  - `packages/plugins/` - Plugin interfaces and helpers, and the agent provider plugins
+    under `src/agents/impl/<id>/`.
+  - `packages/switch-agent-runtime/` - The published agent runtime; sessions run a pinned
+    version of it (see "Versioned Artifacts").
 - Root config files - `pnpm-workspace.yaml`, root `package.json` with aggregate scripts,
   `.nvmrc`, `.oxfmtrc.json`, `.oxlintrc.json`.
 
@@ -45,7 +49,9 @@ Inside `apps/switchdash-desktop/`:
 
 - `build/` - Electron packaging assets; avoid edits unless working on packaging or signing.
 - `drizzle/` - Generated Drizzle SQL migrations and metadata.
-- `scripts/` - Release, verification, and build support scripts.
+- `scripts/` - Build and verification support scripts (sidecar bundle, postinstall,
+  deeplink reset, compose sync). Releasing is a GitHub Actions workflow at the repo
+  root, not a script here.
 - `src/main/` - Electron main process, RPC controllers, services, database, PTY.
 - `src/preload/` - Typed Electron preload bridge exposed to the renderer.
 - `src/renderer/` - React app organized around `app/`, `features/`, `lib/`, and tests.
@@ -183,7 +189,7 @@ pnpm run reset
   imported operation or service functions.
 - Renderer RPC calls go through `rpc` from `src/renderer/lib/ipc.ts`.
 - Feature UI lives under `src/renderer/features/<feature>/`; shared renderer
-  primitives, stores, hooks, modal infrastructure, PTY, Monaco, and UI live under
+  primitives, stores, hooks, modal infrastructure, PTY, hotkeys, and UI live under
   `src/renderer/lib/`.
 - New modals must be registered in `src/renderer/app/modal-registry.ts`.
 - New views must be registered in `src/renderer/app/view-registry.ts`.
@@ -225,12 +231,16 @@ views, modals, command providers, project state, terminals, and session workflow
 Shared IPC primitives, provider metadata, events, MCP types, skills types, and
 domain types live under `src/shared/`.
 
-agent runtime, dependencies, execution context, fs, locations (an agent's working
-dir on a host — formerly the project/workspace split), prompt library, PTY,
-resource monitor, search, secrets, sessions, settings, switch agents, terminal
-shell, terminals, updates, and view state. Stateful main-process concerns use
-singleton services; expected failures should use the `Result<T, E>` pattern from
-`src/main/lib/result.ts`.
+Main-process work is split into domain modules under `src/main/core/`: agent hooks,
+agent runtime, agents (Switch agents), app, dependencies, execution context, fs,
+locations (an agent's working dir on a host — formerly the project/workspace split),
+managed Switch server, prompt library, providers (the CLI-provider registry), PTY,
+remote hosts, resource monitor, search, secrets, sessions, settings, sidecar, SSH,
+switch rooms, switch servers, switch setup, terminal shell, terminals, updates, and
+view state. `agents` and `providers` are different things — see
+`agents/architecture/main-process.md`. Stateful main-process concerns use singleton
+services; expected failures should use the `Result<T, E>` pattern from the
+`@switchdash/shared` workspace package.
 
 ### Logging
 
@@ -304,7 +314,7 @@ pnpm run lint
 
 ## Security & Compliance
 
-- The project is licensed under Apache-2.0; see `LICENSE.md`.
+- The project is licensed under Apache-2.0; see `LICENSE` at the repo root.
 - Do not commit secrets, tokens, private keys, app databases, logs, build artifacts,
   or generated dependency folders.
 - Application secrets are stored through encrypted app secret services and Electron
@@ -451,7 +461,8 @@ pnpm run test
   display metadata, and a mirror of each provider's argv shape. The mirror is
   descriptive: nothing reads it at spawn time, so change the plugin first and update the
   mirror to match. `provider-argv-parity.test.ts` pins Codex's.
-- Provider detection lives in `src/main/core/dependencies/dependency-manager.ts`.
+- Provider detection lives in `src/main/core/dependencies/` (`dependency-managers.ts`,
+  `registry.ts`), with remote detection in `remote-dependency-manager.ts`.
 - Provider PTY behavior and env passthrough live under `src/main/core/pty/`.
 - Provider event hooks and plugins live under `src/main/core/agent-hooks/`.
 - Modal definitions are centralized in `src/renderer/app/modal-registry.ts`.
@@ -502,7 +513,7 @@ pnpm run test
 - Path aliases are defined in `tsconfig.json` and mirrored in `electron.vite.config.ts`:
   `@/*`, `@renderer/*`, `@main/*`, `@shared/*`, and `@root/*`.
 - Versioned JSON column schemas are defined in `src/shared/` using
-  `defineVersionedSchema()` from `src/shared/lib/versioned-schema.ts` and wired to
+  `defineVersionedSchema()` from `src/shared/lib/versioned-schema/versioned-schema.ts` and wired to
   Drizzle via `versionedJsonColumn()` from `src/main/db/versioned-column.ts`.
   See `agents/conventions/versioned-schemas.md` for the full guide.
 
@@ -527,5 +538,5 @@ pnpm run test
 - [Database risk notes](agents/risky-areas/database.md)
 - [PTY risk notes](agents/risky-areas/pty.md)
 - [Updater risk notes](agents/risky-areas/updater.md)
-- [Contributing guide](CONTRIBUTING.md)
+- [Contributing guide](../CONTRIBUTING.md) (repo root)
 - [Project README](README.md)

--- a/dash/agents/README.md
+++ b/dash/agents/README.md
@@ -8,6 +8,11 @@ This directory is the system of record for agent-facing repo guidance. Keep topi
 2. `architecture/overview.md`
 3. the task-specific page for the area you are changing
 
+If the change touches remote hosts or Switch rooms, read
+`architecture/remote-execution.md` and `architecture/switch-rooms.md` too — switchdash
+runs agents on SSH hosts as well as locally, and the remote path is a separate
+implementation.
+
 ## Directory Layout
 
 - `architecture/`

--- a/dash/agents/architecture/data-model.md
+++ b/dash/agents/architecture/data-model.md
@@ -6,10 +6,10 @@ project (repo) holds several sessions (originally one per git worktree), each se
 holds conversations with a coding agent and one or more terminals, all running in an
 abstracted *workspace* (worktree / SSH / remote).
 
-switchdash is being reworked to manage **local Switch agent sessions** instead:
-multiple agents living in a directory, each tied to one provider, each with its
-own runs. This page is the system of record for how the switchdash model
-diverges from that upstream model and how the abstractions map across.
+switchdash manages **Switch agent sessions** instead: multiple agents living in a
+directory, each tied to one provider, each with its own runs. This page is the system
+of record for how the switchdash model diverges from that upstream model and how the
+abstractions map across.
 
 The schema is defined in `apps/switchdash-desktop/src/main/db/schema.ts`.
 
@@ -17,24 +17,41 @@ The schema is defined in `apps/switchdash-desktop/src/main/db/schema.ts`.
 
 | switchdash | upstream equivalent | What it is |
 |---|---|---|
-| **project** | `project` | A directory on disk (repo root). Unchanged in spirit. |
+| **location** | `project` + `workspace` | A working directory on a host — local, or on an SSH host. Replaces both the upstream project *and* the workspace abstraction; the table is `locations`. |
 | **agent** | *(none)* — new | A Switch agent identity bound to one provider. **Many agents per directory.** Carries the optional Switch identity (`switchAgentId`, `apiEndpoint`) detected from `.claude/settings.local.json`. |
 | **provider** | `agent` | The CLI agent kind (claude, codex, gemini, …). Upstream called this an "agent"; here it's a *provider*, referenced by an agent via `providerId`. It stays a static code registry, not a table. |
 | **session** | `conversation` | One instantiation/run of an agent. The unit shown under an agent in the sidebar. |
 | *(folded into session)* | `terminal` | A session is 1:1 with its terminal, so the terminal's `shellId` lives on the session; there is no `terminals` table. |
 | **message** | `message` | A message in a session (was keyed by `conversationId`, now `sessionId`). |
-| *(removed)* | `session` (worktree-era) | The upstream parallel-run grouping. Removed — switchdash runs every session in the project root, so the grouping layer is gone. |
+| *(removed)* | `session` (worktree-era) | The upstream parallel-run grouping. Removed — switchdash runs every session in the location's directory, so the grouping layer is gone. |
 | *(removed)* | `workspace` | The upstream execution-location abstraction (worktree / SSH / BYOI remote). Removed — see below. |
+
+### Tables with no upstream equivalent
+
+These carry the Switch- and remote-specific state that upstream had no concept of:
+
+| Table | What it is |
+|---|---|
+| `switch_servers` | A Switch server switchdash talks to, managed or external. |
+| `remote_hosts` | An SSH host (keyed by its `~/.ssh/config` alias) that can run agents. |
+| `remote_host_reachability` | The last observed reachability of a host. Separate from the host record so a probe result never masquerades as configuration — see the reachability note below. |
+| `remote_host_setup_plans` | A host's onboarding plan (CHOO-1809). See "Remote host setup". |
+| `location_settings` | Per-location DB-backed settings (distinct from `.switchdash.json`). |
+| `session_room_connections` | The Switch room a session is attending (0..1). |
+| `kv`, `app_secrets` | Generic key/value state and encrypted secrets. |
 
 ## Resulting hierarchy
 
 ```
-project   (directory on disk)
-  └─ agent     (Switch identity; one provider each; many per dir)
+location  (a working directory, local or on an SSH host)
+  └─ agent     (Switch identity; one provider each; many per location)
        └─ session   (a run/instantiation; was "conversation")
             ├─ message
             └─ session_room_connection   (0..1 — the Switch room it is attending)
 ```
+
+A location that lives on an SSH host references a `remote_hosts` row; that host carries
+its own reachability and setup-plan rows alongside, not inside, the location hierarchy.
 
 A session's room connection is a row keyed by `session_id` with
 `ON DELETE CASCADE`, so it cannot outlive the session (or the agent above it).
@@ -51,7 +68,12 @@ agents whose Switch server had been destroyed.
   runs in the project root directory."* A workspace was therefore just "the
   project directory" plus lifecycle scripts. We dropped the table (and
   `project.repositoryWorkspaceId` / `session.workspaceId`) and keep lifecycle
-  scripts / fs access as a service hung off the project directory.
+  scripts / fs access as a service hung off the location's directory.
+
+  **What survived of it is the host split, not the table.** "Where a session runs" is
+  still a real question — it is now answered by the location's host (local or SSH) and
+  by the `execution-context` / `agent-runtime` provider pairs, rather than by a
+  `workspace` row. Dropping the table did not make switchdash local-only.
 - **The worktree-era `session` grouping.** With no worktrees, a session was a
   near-empty wrapper around a single conversation. We collapsed it: the upstream
   `conversation` becomes switchdash's `session`.
@@ -63,7 +85,14 @@ agents whose Switch server had been destroyed.
 
 ## Naming note (code)
 
-The upstream "agent" concept (the provider registry and its tooling) is being renamed
-from `agents/` to `providers/` across `src/main/core/` and `src/shared/core/`, so
-that the name **agent** is free for the new Switch-agent concept. The Switch-agent
-domain absorbs the former `switch-agents/detect.ts` directory detector.
+This rename has **landed**. The upstream "agent" concept (the provider registry and its
+tooling) is now `providers/` in both `src/main/core/` and `src/shared/core/`, and the name
+**agent** belongs to the Switch-agent concept. The Switch-agent domain absorbed the former
+`switch-agents/detect.ts` directory detector, which is now `core/agents/detect.ts`.
+
+So in current code:
+
+- `core/agents/` — Switch agents (create, onboard, detect, remote discovery)
+- `core/providers/` — the CLI-provider registry, payload builder, plugin registry
+
+Both directories exist and mean different things. `core/switch-agents/` no longer exists.

--- a/dash/agents/architecture/main-process.md
+++ b/dash/agents/architecture/main-process.md
@@ -6,44 +6,61 @@ The main process is organized into domain modules under `src/main/core/`. Each d
 
 ## Domain Modules (`src/main/core/`)
 
-- **agent-hooks** — HTTP hook server for agent callbacks, event enrichment, OS notifications, hook/plugin config writer, workspace/trust services
-- **agents** — Agent payload builder, plugin registry, plugin filesystem
+Two names in this list are easy to misread, because one of them changed meaning:
+
+- **agents** is the *Switch agent* domain — an agent identity bound to a provider. It is
+  **not** the CLI-tool registry.
+- **providers** is the CLI-tool registry (claude, codex, …). Upstream called that concept
+  an "agent"; it was renamed to free the name for the Switch-agent concept above.
+
+- **agent-hooks** — HTTP hook server for agent callbacks, event enrichment, OS notifications, hook config writer (`hook-config-service.ts`), per-tool trust services (`claude-trust-service.ts`, `cursor-trust-service.ts`, `dir-trust-service.ts`)
+- **agent-runtime** — How a session is actually launched and supervised: launch profiles, the runtime supervisor, and `impl/` backends — `local-agent-runtime.ts` (local spawn) and `ssh-agent-runtime.ts` (remote), plus sidecar launch/HTTP and keystroke injection
+- **agents** — The Switch-agent domain: create/rename/delete, directory detection (`detect.ts`), onboarding, remote agent discovery and reconciliation, Switch credential/settings files
 - **app** — App lifecycle service and controller
-- **conversations** — Conversation CRUD and session start
-- **dependencies** — CLI agent detection, probing, install runner, version/update services
-- **execution-context** — Execution context resolution for agent runs
+- **dependencies** — CLI agent detection, probing, install runner, version/update services, and their remote counterparts (`remote-dependency-manager.ts`, `ssh-install-runner.ts`)
+- **execution-context** — Where a command runs: `local-execution-context.ts` vs `ssh-execution-context.ts`
 - **fs** — Filesystem operations with provider pattern (`impl/local-fs.ts`)
-- **projects** — Project management with provider pattern (`impl/local-project-provider.ts`), project settings, CRUD operations
+- **locations** — An agent's working directory on a host. Replaces the upstream project/workspace split; provider pattern plus lifecycle scripts
+- **managed-switch-server** — A switchdash-managed Switch server deployed via Docker Compose
 - **prompt-library** — Prompt library service and controller
+- **providers** — CLI-provider plugin registry (`plugin-registry.ts`), agent payload builder, plugin filesystem, argv parity test
 - **pty** — PTY lifecycle (`local-pty.ts`), session registry, env setup, spawn utilities
+- **remote-hosts** — SSH host records, reachability probing (`host-reachability-service.ts`), and host setup
 - **resource-monitor** — System resource monitoring
-- **runtime** — Runtime service wiring
 - **search** — Search service
 - **secrets** — Encrypted app secret storage
 - **sessions** — Session CRUD (create, delete, rename, provision)
 - **settings** — App settings service and schema, provider settings (separate controller)
-- **shared** — Shared main-process utilities
-- **switch-agents** — Switch agent integration
+- **shared** — Shared main-process utilities (OAuth flow)
+- **sidecar** — Desktop-side view of the remote sidecar: diagnostics and health verdicts. The sidecar implementation itself is `src/sidecar/`
+- **ssh** — SSH config, connection, lifecycle, and transport
+- **switch-rooms** — Room connections, the auto-session watcher, prompt injection sinks, Switch credentials, notification polling
+- **switch-servers** — Switch server records, gateway client, auth, room creation
+- **switch-setup** — First-run Switch setup, local and remote (`remote-switch-setup.ts`)
 - **terminal-shell** — Terminal shell availability and detection
 - **terminals** — Terminal lifecycle with provider pattern (`impl/local-terminal-provider.ts`), lifecycle scripts
 - **updates** — Auto-update service
-- **utils** — Cross-domain main-process helpers
+- **utils** — Cross-domain main-process helpers (exec, TTL cache, compensation)
 - **view-state** — Persisted view/UI state
-- **workspaces** — Workspace (project-root working directory) management
 
 ## Other Main Process Areas
 
-- `src/main/app/` — Menu, protocol handler, window creation
-- `src/main/lib/` — Logger, events, result type, updater error
-- `src/main/db/` — Database schema and initialization
+- `src/main/app/` — Menu, protocol handler, deeplinks, window creation, app identity
+- `src/main/lib/` — Logger and file logger, log context (`AsyncLocalStorage`) and enrichment, events, rate limiter, retry, semver
+- `src/main/db/` — Database schema, client, initialization, versioned columns
 - `src/main/utils/` — Shell environment, shell escaping, child process env, external links
-- `src/main/core/agent-hooks/` — Hook server, event enrichment, OS notifications, hook/plugin config writer
+- `src/sidecar/` — The headless remote sidecar. Not part of `src/main/`, but it re-implements
+  much of what the main process does for a session; see the sidecar section of `AGENTS.md`.
+
+The `Result<T, E>` type is **not** in `src/main/lib/`. It lives in the `@switchdash/shared`
+workspace package (`packages/shared/src/result.ts`) and is imported as
+`import { ok, err, type Result } from '@switchdash/shared'`.
 
 ## IPC / RPC Structure
 
 - All domain controllers are assembled into a typed RPC router in `src/main/rpc.ts`.
-- RPC primitives live in `src/shared/ipc/rpc.ts` (`createRPCRouter`, `createRPCController`, `createRPCClient`).
-- Event primitives live in `src/shared/ipc/events.ts`.
+- RPC primitives live in `src/shared/lib/ipc/rpc.ts` (`createRPCRouter`, `createRPCController`, `createRPCClient`).
+- Event primitives live in `src/shared/lib/ipc/events.ts`.
 - The preload bridge (`src/preload/index.ts`) exposes only `invoke`, `eventSend`, `eventOn`, and `getPathForFile`; there are no other manual IPC handlers.
 
 ## When Editing Here

--- a/dash/agents/architecture/overview.md
+++ b/dash/agents/architecture/overview.md
@@ -8,6 +8,7 @@ All paths are relative to `apps/switchdash-desktop/`.
 - `src/preload/`: Electron preload bridge — exposes typed `invoke`, `eventSend`, `eventOn` to renderer
 - `src/renderer/`: React UI — app shell (`app/`), feature areas (`features/`), shared infrastructure (`lib/`), typed RPC client
 - `src/shared/`: Agent provider registry, IPC primitives (RPC + events), shared domain types under `src/shared/core/`
+- `src/sidecar/`: The headless on-host sidecar that keeps a remote session running while switchdash is closed. Not an Electron process — see `remote-execution.md`
 
 ## Boot Sequence
 
@@ -29,3 +30,5 @@ All paths are relative to `apps/switchdash-desktop/`.
 - Main process details: `main-process.md`
 - Renderer details: `renderer.md`
 - Shared modules and provider registry: `shared.md`
+- Remote hosts, reachability, and the sidecar: `remote-execution.md`
+- Switch rooms and session binding: `switch-rooms.md`

--- a/dash/agents/architecture/remote-execution.md
+++ b/dash/agents/architecture/remote-execution.md
@@ -1,0 +1,105 @@
+# Remote Execution: Hosts, Reachability, and the Sidecar
+
+All paths are relative to `apps/switchdash-desktop/` unless noted.
+
+**Switchdash is not local-only.** An agent runs either on the local machine or on an SSH
+host. That choice reaches almost every layer — execution context, agent runtime,
+dependency detection, PTY — so a change that only handles the local case is a change that
+silently does less on a remote host. This page is the map of the remote half.
+
+## The pieces
+
+| Concern | Where |
+|---|---|
+| SSH host records, keyed by `~/.ssh/config` alias | `src/main/core/remote-hosts/`, table `remote_hosts` |
+| Reachability state machine | `remote-hosts/host-reachability-service.ts`, `src/shared/core/remote-hosts/reachability.ts`, table `remote_host_reachability` |
+| SSH config, connection, transport | `src/main/core/ssh/` |
+| Where a command runs | `src/main/core/execution-context/` — `local-execution-context.ts` / `ssh-execution-context.ts` |
+| How a session is launched | `src/main/core/agent-runtime/impl/` — `local-agent-runtime.ts` / `ssh-agent-runtime.ts` |
+| Remote dependency detection and install | `dependencies/remote-dependency-manager.ts`, `dependencies/ssh-install-runner.ts` |
+| The on-host sidecar | `src/sidecar/` (implementation), `src/main/core/sidecar/` (desktop-side diagnostics) |
+| A switchdash-managed Switch server | `src/main/core/managed-switch-server/` |
+| Renderer surfaces | `src/renderer/features/remote-hosts/` |
+
+## Reachability is a state machine, not a boolean (CHOO-1682)
+
+Before it existed, "can we reach host X?" was answered independently by every caller — the
+pooled connection's in-memory state, an on-demand `testConnection`, or just attempting the
+work and interpreting the ssh2 error. That produced unbounded retry loops against dead
+hosts and raw transport errors in the UI. Now there is **one per-host state** that every
+host-dependent path consults up front:
+
+- `unknown` — never probed this run. **Work is allowed through**; the first attempt is what
+  establishes reachability.
+- `reachable` — a probe or live connection succeeded.
+- `unreachable` — probes failing. Background work pauses; a bounded backoff probe keeps
+  checking so recovery is automatic.
+- `suspended` — **authentication** failed. Retrying a rejected key never self-heals, so
+  there is no automatic probing; the user must fix auth and retry explicitly.
+
+The backoff is `1s, 5s, 15s, 30s, 60s, 300s` (capped and repeated). Early steps are tight
+because the common cause is a credential the user is actively re-establishing (VPN,
+`aws sso login`); the long tail keeps a genuinely dead host from costing anything. A manual
+retry short-circuits the schedule.
+
+**When adding a host-dependent path, gate it on reachability rather than discovering the
+failure yourself.** The distinction between `unreachable` and `suspended` is the point: one
+is worth retrying automatically and the other is not.
+
+### Never report "fine" for something you did not observe
+
+A check that could not run is **not** a passing check. Collapsing "couldn't determine" into
+"satisfied" is the stale-green bug (CHOO-1780) — the UI claims a host is ready, the user
+acts on it, and the failure surfaces somewhere less obvious. Keep `unknown` as a
+first-class answer all the way to the surface.
+
+## Host setup is a persisted plan (CHOO-1809)
+
+> This section describes `feature-request/remote-host-onboarding-rewrite`. If you are
+> reading it on a checkout where `src/main/core/remote-hosts/setup/` does not exist, that
+> branch has not merged yet.
+
+Onboarding a host used to be a single boolean — a row existed or it didn't — with every
+prerequisite probed independently by whichever component happened to render. There was no
+notion of *where a host got to*, so nothing could be resumed or ordered, and a failure
+halfway through left no record.
+
+A **setup plan** is that missing object: an ordered list of steps, persisted per host in
+`remote_host_setup_plans`, answering "what still needs to happen on this host, and what
+went wrong last time?".
+
+- Model: `src/shared/core/remote-hosts/setup.ts`, `host-status.ts`
+- Main: `src/main/core/remote-hosts/setup/` — `plan-builder.ts`, `host-setup-runner.ts`,
+  `host-setup-service.ts`, `setup-plan-store.ts`, `step-outcomes.ts`
+- Renderer: `src/renderer/features/remote-hosts/setup/`, `host-readiness.ts`
+
+Two properties worth preserving:
+
+- **Nothing advances the plan on its own.** Each step runs when the user asks for that
+  step; the ordering is guidance, not automation. There is deliberately no
+  run-everything button.
+- **A check outcome is richer than a boolean** — `satisfied`, `missing`, `not-running`,
+  `wrong-version`, `unknown`. `not-running` matters because `docker` being on `PATH` tells
+  you nothing about whether `dockerd` is up, and running an installer over a stopped
+  service would misreport the cause.
+
+## The sidecar
+
+A remote agent runs inside tmux next to a switchdash-deployed **sidecar**, so it keeps
+working and listening to its Switch rooms while switchdash is closed (CHOO-1059).
+
+`src/sidecar/` is a second, headless implementation of what the desktop does for a
+session — it starts sessions, keeps them connected to their room, and injects messages into
+their pane — with no Electron, no database and no renderer.
+
+**Read the sidecar section of `AGENTS.md` before changing session launch behaviour.** It
+lists the desktop/sidecar pairs that must stay in step, and the sharpest edge: anything
+reaching a session through its **environment** is built separately on each side.
+
+## When editing here
+
+- Check the reachability state before adding a host-dependent code path.
+- Ask whether a change to local session launch needs the same change in `src/sidecar/`.
+- Remote dependency detection and install are separate implementations from the local
+  ones — see `dependencies/remote-dependency-manager.ts`.
+- See `agents/architecture/switch-rooms.md` for how a session binds to a Switch room.

--- a/dash/agents/architecture/renderer.md
+++ b/dash/agents/architecture/renderer.md
@@ -12,17 +12,22 @@ All paths are relative to `apps/switchdash-desktop/`.
 
 ## App Shell (`src/renderer/app/`)
 
-- `workspace.tsx`, `home-view.tsx`, `welcome.tsx` — shell and top-level views
+- `workspace.tsx`, `home-view.tsx` — shell and top-level views
 - `modal-registry.ts` — central modal registry; all modals are registered here
 - `view-registry.ts` — central view registry; all views are registered here
 - `app-menu-events.tsx` — native app menu event wiring
 
 ## Feature Areas (`src/renderer/features/`)
 
-- `sessions/` — session experience: `conversations/`, `terminals/`, `create-session-modal/`,
-  `components/`, `hooks/`, and `stores/` (MobX session stores and `session-selectors.ts`)
-- `projects/` — project management and settings panel; `stores/` holds
-  project stores and `project-selectors.ts`
+- `sessions/` — session experience: `create-session-modal/`, `components/`, `hooks/`,
+  and `stores/` (MobX session stores and `session-selectors.ts`)
+- `locations/` — an agent's working directory on a host, and its settings panel; `stores/`
+  holds location stores and `location-selectors.ts`
+- `remote-hosts/` — SSH hosts: the host list and detail views, reachability notices, and
+  host setup
+- `switch-rooms/` — Switch room membership and the inline bridge pane
+  (`room-embed-layer.tsx`)
+- `switch-servers/` — Switch server connections, including a switchdash-managed server
 - `sidebar/` — app sidebar
 - `settings/` — settings view
 - `command-palette/` — command palette
@@ -33,10 +38,14 @@ All paths are relative to `apps/switchdash-desktop/`.
 - `modal/` — modal provider, renderer, store, and close-guard infrastructure
 - `layout/` — layout, navigation, and panel drag providers
 - `commands/` — command registry (`registry.ts`) and view-level `commandProvider` hooks
+- `hotkeys/` — global hotkey handling
 - `pty/` — frontend PTY sessions, pool provider, panes, prompt injection
-- `editor/` — Monaco editor integration
+- `updates/` — in-app update surfaces
 - `stores/` — cross-feature stores (navigation, dependencies, resource monitor, ...)
 - `providers/`, `hooks/`, `components/`, `ui/`, `theme/` — shared providers, hooks, and UI primitives
+
+There is no `editor/` directory. Monaco is still a dependency, but the only integration
+left in the renderer is `lib/components/monaco-keyboard-bridge.tsx`.
 
 ## Tests
 

--- a/dash/agents/architecture/shared.md
+++ b/dash/agents/architecture/shared.md
@@ -6,18 +6,27 @@
   lives in `packages/plugins/src/agents/impl/<id>/index.ts`):
   - `src/shared/core/providers/agent-provider-registry.ts`
 - IPC primitives:
-  - `src/shared/ipc/rpc.ts` — typed RPC router, controller, and client
-  - `src/shared/ipc/events.ts` — typed event emitter
+  - `src/shared/lib/ipc/rpc.ts` — typed RPC router, controller, and client
+  - `src/shared/lib/ipc/events.ts` — typed event emitter
 - Typed event definitions:
-  - `src/shared/events/` — `appEvents.ts`, `browserEvents.ts`, `resourceEvents.ts`, `updateEvents.ts`
+  - `src/shared/events/` — `appEvents.ts`, `browserEvents.ts`, `resourceEvents.ts`,
+    `updateEvents.ts`, `sidecarEvents.ts`, `switchSetupEvents.ts`,
+    `localSwitchServerEvents.ts`, `remoteSwitchServerEvents.ts`
   - additional domain events colocated under `src/shared/core/` — e.g.
-    `core/agents/agentEvents.ts`, `core/conversations/conversationEvents.ts`,
-    `core/fs/fsEvents.ts`, `core/projects/projectEvents.ts`, `core/sessions/sessionEvents.ts`
+    `core/providers/agentEvents.ts`, `core/fs/fsEvents.ts`,
+    `core/locations/locationEvents.ts`, `core/sessions/sessionEvents.ts`,
+    `core/switch-rooms/switchRoomEvents.ts`, `core/ssh/sshEvents.ts`,
+    `core/pty/ptyEvents.ts`
 - Domain type modules (under `src/shared/core/`):
-  - `agents/`, `conversations/`, `fs/`, `projects/`, `project-settings/`, `pty/`,
-    `sessions/`, `terminals/`, `workspaces/`
+  - `agents/`, `fs/`, `location-settings/`, `locations/`, `managed-switch-server/`,
+    `mcp/`, `providers/`, `pty/`, `remote-hosts/`, `sessions/`, `skills/`, `ssh/`,
+    `switch-rooms/`, `switch-servers/`, `switch-setup/`, `terminals/`
 - App settings types:
   - `src/shared/core/app-settings.ts`
+
+Note the `agents/` vs `providers/` split here, which mirrors `src/main/core/`:
+`core/agents/` is the Switch-agent concept, `core/providers/` is the CLI-provider
+registry and payload types.
 
 ## Path Aliases
 

--- a/dash/agents/architecture/switch-rooms.md
+++ b/dash/agents/architecture/switch-rooms.md
@@ -1,0 +1,86 @@
+# Switch Rooms and Sessions
+
+All paths are relative to `apps/switchdash-desktop/`.
+
+Switchdash exists to manage Switch agents, and a Switch agent's work happens in **rooms**.
+A session can be *attending* a room: it receives the room's events and can post back into
+it. This page covers that binding, how a session is started in response to room activity,
+and how a room's conversation is shown in the app.
+
+## Where it lives
+
+| Concern | Where |
+|---|---|
+| Room connection, credentials, event stream | `src/main/core/switch-rooms/` |
+| Room/session binding | table `session_room_connections`, `session-room-store.ts` |
+| Auto-start a session from room activity | `switch-rooms/auto-session-watcher.ts` |
+| Prompt injection into a live TUI | `switch-rooms/injection-sink.ts`, `tmux-injection-sink.ts` |
+| Switch servers (managed or external) | `src/main/core/switch-servers/`, `managed-switch-server/` |
+| Renderer | `src/renderer/features/switch-rooms/`, `features/switch-servers/` |
+| Shared types | `src/shared/core/switch-rooms/` |
+
+## A session attends at most one room
+
+The binding is a `session_room_connections` row keyed by `session_id` with
+`ON DELETE CASCADE`, so it cannot outlive the session (or the agent above it).
+
+This is worth knowing because of what it replaced: the binding used to be a JSON blob in
+`app_settings`, which referenced nothing and therefore survived both. Switchdash would
+restore sessions on every launch for agents whose Switch server had been destroyed. If you
+are tempted to persist session-adjacent state somewhere convenient, that is the bug to
+remember.
+
+## Auto-sessions
+
+`auto-session-watcher.ts` watches for room activity addressed to an agent that has no live
+session, and starts one. This is why an agent can be addressed from Slack or Mattermost and
+simply respond, without anyone opening switchdash first.
+
+**The sidecar has its own implementation of this watcher**
+(`src/sidecar/notification-watcher.ts`). They are two implementations of one behaviour, and
+neither follows the other — see the sidecar table in `AGENTS.md`.
+
+## Prompt injection
+
+Some providers cannot be handed a new prompt through an API once their TUI is running, so
+switchdash types it in. `InjectionSink` abstracts the transport:
+
+- **Local** — write straight to the agent's PTY via node-pty.
+- **Remote** — the sidecar performs `tmux send-keys` into the agent's tmux pane.
+
+`acquire` returns null when the target is not ready to receive input (e.g. the PTY is not
+live yet); callers defer and retry rather than dropping the injection.
+
+## The inline bridge pane (CHOO-1674)
+
+A room's conversation can be rendered **inside** switchdash in a `<webview>`, rather than
+sending the user out to a browser. `src/shared/core/switch-rooms/room-embed.ts` resolves
+one of two answers:
+
+- `kind: 'inline'` — a `<webview>` on a partition that already has the Mattermost session
+  cookie installed, with `chromeless` asking the guest preload
+  (`src/preload/mattermost-guest.ts`) to hide the global header and sidebars.
+- **Deeplink** — the room is bridged somewhere we cannot embed (Slack, or a Mattermost we
+  hold no credentials for). The app offers the deeplink **instead of pretending** it can
+  show the conversation.
+
+Two things not to rediscover:
+
+- **Only managed servers can be embedded.** Mattermost embedding needs a port we chose and
+  credentials we hold; an external server's Mattermost is somebody else's deployment.
+- **Mattermost's `/_popout/` route does not work for this.** It looks like the supported
+  way to embed a single channel, but it requires the desktop app's `window.opener` token
+  handshake — under an Electron user agent the web app ignores our session cookie and
+  bounces to a login page. The ordinary channel URL is loaded and the surrounding chrome
+  hidden instead. The decision sits behind one resolved value so swapping strategies later
+  touches that module and nothing else.
+
+`room-embed-layer.tsx` keeps at most `MAX_LIVE_EMBEDS` (4) live webviews once visited —
+each is a real renderer process, so this trades memory for instant switching and drops the
+oldest beyond a handful.
+
+## When editing here
+
+- Changing session startup? Check whether `src/sidecar/` needs the same change.
+- Changing what reaches a session's environment? Both sides build that separately.
+- See `agents/architecture/remote-execution.md` for hosts, reachability, and the sidecar.

--- a/dash/agents/conventions/ipc.md
+++ b/dash/agents/conventions/ipc.md
@@ -32,7 +32,9 @@ when a browser/Electron primitive cannot fit the RPC/event path.
 
 ## Event System
 
-Typed events use `createEventEmitter` from `src/shared/ipc/events.ts`. Event type definitions live in `src/shared/events/`.
+Typed events use `createEventEmitter` from `src/shared/lib/ipc/events.ts`. Event type
+definitions live in `src/shared/events/`, with domain events colocated under
+`src/shared/core/<domain>/`.
 
 ## Rules
 

--- a/dash/agents/conventions/main-patterns.md
+++ b/dash/agents/conventions/main-patterns.md
@@ -23,7 +23,7 @@ Controllers are assembled into the router in `src/main/rpc.ts`:
 ```ts
 export const rpcRouter = createRPCRouter({
   sessions: sessionController,
-  projects: projectController,
+  locations: locationsController,
   // ...
 });
 ```
@@ -60,21 +60,35 @@ Some domains expose a provider interface with a single local backend, leaving ro
 additional backends without changing call sites:
 
 ```
-src/main/core/projects/
-├── project-provider.ts            # Interface
-├── create-project-provider.ts     # Factory
-└── project-manager.ts             # Orchestrates the provider
+src/main/core/locations/
+├── location-provider.ts           # Interface
+├── create-location-provider.ts    # Factory
+└── location-manager.ts            # Orchestrates the provider
 ```
 
-Used in: projects, filesystem (`fs/impl/local-fs.ts`), terminals (`terminals/impl/local-terminal-provider.ts`).
-Switchdash is local-only — these providers currently have local implementations only.
+Used in: locations, filesystem (`fs/impl/local-fs.ts`), terminals (`terminals/impl/local-terminal-provider.ts`).
 
-## Result Type (`src/main/lib/result.ts`)
+**Switchdash is not local-only, and this is the pattern that carries the difference.**
+An agent runs either locally or on an SSH host, so the backend behind an interface is a
+real choice rather than a placeholder for one:
 
-Explicit error handling via discriminated union:
+- `execution-context` has `local-execution-context.ts` **and** `ssh-execution-context.ts`
+- `agent-runtime/impl/` has `local-agent-runtime.ts` **and** `ssh-agent-runtime.ts`
+- `dependencies` has local detection **and** `remote-dependency-manager.ts` /
+  `ssh-install-runner.ts`
+
+`fs` and `terminals` do currently have only a local implementation. When adding a backend,
+check whether the remote path needs one too — and see the sidecar section of `AGENTS.md`,
+because a remote session is served by `src/sidecar/`, which is a second implementation that
+will not follow your change automatically.
+
+## Result Type (`@switchdash/shared`)
+
+Explicit error handling via discriminated union. The type lives in the shared workspace
+package (`packages/shared/src/result.ts`), not in `src/main/lib/`:
 
 ```ts
-import { ok, err, type Result } from '../lib/result';
+import { ok, err, type Result } from '@switchdash/shared';
 
 async function doSomething(): Promise<Result<Data, SomeError>> {
   if (problem) return err({ type: 'not_found' as const });

--- a/dash/agents/conventions/renderer-patterns.md
+++ b/dash/agents/conventions/renderer-patterns.md
@@ -21,7 +21,7 @@ All modals use a registry-based system. Only one modal can be active at a time.
 
 ```tsx
 const { showModal } = useModalContext();
-showModal('myModal', { projectId: '123', onSuccess: (result) => {...} });
+showModal('myModal', { locationId: '123', onSuccess: (result) => {...} });
 ```
 
 **Rules:**
@@ -60,7 +60,7 @@ Views use a registry + parameterized navigation pattern.
 
 **Rules:**
 - Historical output comes from the main-process ring buffer; do not add renderer-side buffering
-- `sessionId` format: `makePtySessionId(projectId, scopeId, leafId)` from
+- `sessionId` format: `makePtySessionId(locationId, scopeId, leafId)` from
   `src/shared/core/pty/ptySessionId.ts` — deterministic
 - Panel drag pauses resizing to avoid jank (`src/renderer/lib/layout/panel-drag-store.ts`)
 
@@ -93,6 +93,6 @@ For state that must survive React unmounts or be shared across unrelated compone
 
 - **`useSyncExternalStore`-compatible stores** — e.g., `panelDragStore` in `src/renderer/lib/layout/`
 - **Cross-feature stores** — `src/renderer/lib/stores/` (navigation, dependencies, resource monitor, ...)
-- **MobX session and project stores** — `src/renderer/features/sessions/stores/` and
-  `src/renderer/features/projects/stores/`; access them through selectors
-  (`session-selectors.ts`, `project-selectors.ts`) and session view hooks, never directly
+- **MobX session and location stores** — `src/renderer/features/sessions/stores/` and
+  `src/renderer/features/locations/stores/`; access them through selectors
+  (`session-selectors.ts`, `location-selectors.ts`) and session view hooks, never directly

--- a/dash/agents/conventions/versioned-schemas.md
+++ b/dash/agents/conventions/versioned-schemas.md
@@ -219,8 +219,14 @@ For Drizzle column helpers, use the exported `parseVersionedColumn` and
 
 ## All migrated columns
 
+These are the columns currently bound with `versionedJsonColumn()` in
+`src/main/db/schema.ts`:
+
 | Column | Schema file | Versioning |
 |--------|-------------|------------|
-| `workspaces.config` | `src/shared/core/workspaces/workspace-config.ts` | v1 → v2 → v3 (versioned from start) |
-| `workspaces.data` | `src/shared/core/workspaces/workspace-provider-data.ts` | unversioned (v0) |
-| `conversations.config` | `src/shared/core/conversations/conversation-config.ts` | unversioned (v0) |
+| `agents.provider_config` | `src/shared/core/agents/agent-provider-config.ts` | v1 (versioned from start) |
+| `sessions.config` | `src/shared/core/sessions/session-config.ts` | unversioned (v0) |
+
+The `workspaces.*` and `conversations.config` columns this table used to list are gone —
+both tables were dropped when the location/session model replaced the upstream
+project/workspace/conversation model. See `agents/architecture/data-model.md`.

--- a/dash/agents/integrations/mcp.md
+++ b/dash/agents/integrations/mcp.md
@@ -9,7 +9,7 @@ small set of shared types and a static catalog.
 - `src/shared/core/mcp/types.ts` — canonical MCP server entry types (e.g. `RawServerEntry`)
 - `src/shared/core/mcp/catalog.ts` — static catalog of known MCP servers and their
   credential keys (`catalogData`)
-- `src/main/core/agents/agent-payload-builder.ts` — includes MCP capability data in the
+- `src/main/core/providers/agent-payload-builder.ts` — includes MCP capability data in the
   payload handed to an agent based on provider capabilities
 
 ## Current Behavior

--- a/dash/agents/risky-areas/database.md
+++ b/dash/agents/risky-areas/database.md
@@ -130,9 +130,8 @@ guidance.
 
 | Column | Schema file |
 |--------|-------------|
-| `workspaces.config` | `src/shared/core/workspaces/workspace-config.ts` |
-| `workspaces.data` | `src/shared/core/workspaces/workspace-provider-data.ts` |
-| `conversations.config` | `src/shared/core/conversations/conversation-config.ts` |
+| `agents.provider_config` | `src/shared/core/agents/agent-provider-config.ts` |
+| `sessions.config` | `src/shared/core/sessions/session-config.ts` |
 
 ### Snapshot columns and raw SQL
 

--- a/dash/agents/risky-areas/updater.md
+++ b/dash/agents/risky-areas/updater.md
@@ -4,14 +4,17 @@
 
 - `src/main/core/updates/update-service.ts`
 - `src/main/core/updates/controller.ts`
+- `src/main/core/updates/github-token.ts` — the updater's `gh` CLI token
+- `src/main/core/updates/dev-harness.ts` — `SWITCHDASH_FAKE_UPDATE` replay
 - `build/`
 - `package.json`
 - `electron-builder.config.ts`
 - `electron-builder.canary.config.ts`
-- `scripts/release/build.ts`
-- `scripts/release/notarize-mac.ts`
-- `scripts/release/rebuild-native.ts`
-- `scripts/release/finalize-release.ts`
+- `.github/workflows/switchdash-release.yml` — the release pipeline (repo root, **not** under `dash/`)
+
+There is no `scripts/release/` directory. Releasing is done by the GitHub Actions
+workflow above, which calls `electron-builder` directly; the packaging, notarization and
+finalize steps are workflow jobs rather than TypeScript entry points.
 
 ## Rules
 
@@ -21,20 +24,44 @@
 
 ## Update Feed / Publishing Strategy
 
-The stable release pipeline publishes to **GitHub Releases** (primary feed) and **Cloudflare R2** (legacy/migration feed) in parallel. Both feeds are served from the same single build.
+The release pipeline publishes to **GitHub Releases** only. The Cloudflare R2 feed that
+ran alongside it during the migration is gone: neither electron-builder config has a
+`generic` publish block, and there is no R2 upload step.
 
-### Two feeds, one build
+### One feed
 
-electron-builder emits channel manifests named by the **first** publish provider's `channel`:
+electron-builder emits channel manifests named by the publish provider's `channel`:
 
-- Stable: `provider: github` has no explicit channel → defaults to `latest` → emits `latest*.yml`.
-- Canary: `provider: github` sets `channel: 'canary'` → emits `canary*.yml`.
+- Stable: `provider: github` (`releaseType: 'release'`) has no explicit channel → defaults to `latest` → emits `latest*.yml`.
+- Canary: `provider: github` (`releaseType: 'draft'`) sets `channel: 'canary'` → emits `canary*.yml`.
 
-The R2 feed uses different channel names (`v1-stable`, `v1-canary`) that pre-date the GitHub migration. Rather than running a second packaging pass, `scripts/release/build.ts` calls `duplicateChannelManifests()` after the electron-builder step to copy `latest*.yml → v1-stable*.yml` (or `canary*.yml → v1-canary*.yml`). The duplicated manifests are then uploaded to both the GitHub draft release and R2, so every client cohort sees a consistent manifest for its feed.
+The release repo is `sandbox-quantum/switch`, private, so the updater uses
+electron-updater's authenticated GitHub provider.
 
-### Guard: `upload-r2.ts` hard-fails on missing channel manifest
+### Draft until every platform has uploaded
 
-`scripts/release/upload-r2.ts` asserts that at least one `${channel}*.yml` file exists before uploading. If `duplicateChannelManifests` did not run or produced no output, the R2 upload step fails immediately with a clear message rather than silently uploading only binaries. A stale channel manifest (frozen at a previous version) combined with newer binaries would cause sha512 checksum failures on client download.
+The workflow does **not** let electron-builder publish (`--publish never`). Instead:
+
+1. `create-release` opens the GitHub Release as a **draft**. A draft is invisible to
+   electron-updater — `/releases/latest` skips drafts — so no client can see a
+   half-uploaded release.
+2. Each platform job builds, then `gh release upload`s its installers **and** its
+   electron-updater channel manifest.
+3. `publish-release` runs last. It **verifies every expected channel manifest is
+   present** and refuses to publish if any is missing, leaving the release a draft with
+   an error naming what's absent.
+
+That last step is the guard worth knowing about: binaries published against a stale or
+missing channel manifest produce sha512 checksum failures on client download, so the
+pipeline would rather stay a draft than publish an inconsistent release.
+
+### `UPDATE_CHANNEL` is a log label, not a feed selector
+
+`UPDATE_CHANNEL` (`src/shared/app-identity.ts`) is `'v1-stable'` / `'v1-canary'` — naming
+inherited from the retired R2 bucket. It is passed **only** to `log.info` calls in
+`update-service.ts` for diagnostics. It is **not** passed to `autoUpdater.channel` and not
+used to build a feed URL. Do not wire it into feed selection on the assumption that a
+constant named "channel" must be one.
 
 ### Update channels on GitHub
 
@@ -43,24 +70,17 @@ The app does **not** override `autoUpdater.channel`; the GitHub provider resolve
 - **Stable** (`allowPrerelease=false`): resolves to `latest`, fetches `latest*.yml` from the newest non-prerelease GitHub release.
 - **Canary** (`allowPrerelease=true`): resolves the target release tag from the Atom feed by matching the semver prerelease identifier of the installed version (`canary`) against each entry. Once a `-canary.N` tag is found it fetches `canary*.yml` from that release, as defined by `channel: 'canary'` in `electron-builder.canary.config.ts`.
 
-The `UPDATE_CHANNEL` / `v1-stable` / `v1-canary` naming applies **only** to the flat R2 bucket (via the `generic` publish block's `channel`). It is kept as a log label in `update-service.ts` for diagnostics but is not passed to `autoUpdater.channel`.
-
-### R2 decommission path
-
-R2 uploads continue until all clients are confirmed to have migrated to the GitHub-backed feed. At that point:
-
-1. Remove the `provider: generic` block from `electron-builder.config.ts` and `electron-builder.canary.config.ts`.
-2. Remove the `upload-r2.ts` call and `duplicateChannelManifests` call from `build.ts`.
-3. Decommission the R2 bucket.
-
 - Canary publishes to GitHub as prereleases. `ALLOW_PRERELEASE` in `update-service.ts` is driven by `IS_CANARY` so canary clients accept prerelease versions automatically.
-- The `finalize-release.ts` script runs after all three platform builds complete to flip the draft GitHub release to published. Until that job finishes the release remains a draft and is invisible to electron-updater clients on the GitHub feed.
+- The `publish-release` workflow job runs after all platform builds complete to flip the draft GitHub release to published. Until that job finishes the release remains a draft and is invisible to electron-updater clients.
 
-## Release Scripts Library Usage
+## Authenticating the updater
 
-- `scripts/release/build.ts` — uses `electron-builder`'s programmatic `build()` API (no CLI spawn)
-- `scripts/release/rebuild-native.ts` — uses `@electron/rebuild`'s `rebuild()` API (no CLI spawn)
-- `scripts/release/notarize-mac.ts` — uses `@electron/notarize`'s `notarize()` API for DMG submission + auto-staple; system spawns are kept only for `.app` bundle stapling and Gatekeeper verification
+The release repo is private, so a plain feed fetch 404s. `github-token.ts` sources a token
+from the user's `gh` CLI and it is handed to `autoUpdater.setFeedURL(...)` rather than
+exported as `GH_TOKEN`. That is deliberate and worth preserving: switchdash's environment
+is inherited by every child process it spawns — including `gh` itself, which prefers
+`GH_TOKEN` over its keyring — so a token parked there outlives the login it came from and
+shadows the next one until the app restarts.
 
 ## Current Notes
 

--- a/dash/agents/workflows/testing.md
+++ b/dash/agents/workflows/testing.md
@@ -23,12 +23,14 @@ pnpm run test
 
 - Vitest config is in `vitest.config.ts` (separate from the build config in `electron.vite.config.ts`).
 - Five test projects:
-  - `node` — `src/**/*.test.ts` excluding `_*` dirs, browser tests, migration tests, `*.db.test.ts`, and `src/main/db/legacy-port/**/*.test.ts`
-  - `main-db` — `src/main/core/**/*.db.test.ts` and `src/main/db/legacy-port/**/*.test.ts` against real SQLite
+  - `node` — `src/**/*.test.ts` excluding `_*` dirs, browser tests, migration tests, and `*.db.test.ts` under `src/main/core/` and `src/main/db/`
+  - `main-db` — `src/main/core/**/*.db.test.ts` and `src/main/db/**/*.db.test.ts` against real SQLite
   - `fixtures` — fixture generator, run via `pnpm run db:fixtures`
   - `migrations` — `src/main/db/tests/migrations/**`, run via `pnpm run test:migrations`
   - `browser` — `src/renderer/tests/browser/**/*.test.{ts,tsx}` via Playwright
 - `pnpm run test` runs the `node`, `main-db`, `migrations`, and `browser` projects.
+- Both project globs still mention `src/main/db/legacy-port/`, which no longer exists. The
+  globs are harmless but match nothing — do not go looking for that directory.
 - Tests use per-file `vi.mock()` setup.
 - Integration-style tests create temporary project directories in `os.tmpdir()`.
 


### PR DESCRIPTION
Audit of the agent-facing docs under `dash/` — `AGENTS.md` (→ `CLAUDE.md`) and the
`dash/agents/**` tree — against the actual code.

Jira: [CHOO-1860](https://sandboxquantum.atlassian.net/browse/CHOO-1860)

> [!IMPORTANT]
> **Merge after CHOO-1809** (`feature-request/remote-host-onboarding-rewrite`).
> One section of `remote-execution.md` documents the persisted host setup plan, which
> only exists on that branch. It is explicitly marked as such, so a reader on `main` is
> told why those paths are absent — but the ordering is still the intended one.

## Why this needed doing

These files are what a coding agent reads *before* touching the app. A wrong claim here
does not merely mislead a human who would sanity-check it — it gets **followed**. So every
statement was checked against code rather than rewritten from what sounded right.

Method: extracted all path-like tokens from the docs and resolved each against the real
tree, then hand-checked every module inventory and every semantic claim. Things that were
still correct were deliberately left alone (see below).

## Root cause

Almost all the drift is **one rename that never propagated**:

- `project` / `workspace` → **`location`** (a working directory on a host)
- upstream's `agents/` (the CLI-tool registry) → **`providers/`**, freeing `agents/` for
  the Switch-agent concept

`data-model.md` described both as *future* work. Both had shipped. Every downstream page
still described the pre-rename tree.

## The drift found

**Dead paths**
- `renderer.md` — `welcome.tsx`, deleted in #96
- `updater.md` — the entire `scripts/release/` tree (`build.ts`, `notarize-mac.ts`, `rebuild-native.ts`, `finalize-release.ts`, `upload-r2.ts`). **The directory does not exist.**
- `src/shared/ipc/*` → `src/shared/lib/ipc/*`
- `src/main/lib/result.ts` → moved out of the app into `packages/shared` (`@switchdash/shared`)
- `src/shared/lib/versioned-schema.ts` → now a directory
- `dependency-manager.ts` → `dependency-managers.ts`
- `core/agents/agent-payload-builder.ts` → `core/providers/agent-payload-builder.ts`
- `agentEvents.ts` → `core/providers/`; `conversationEvents.ts` gone; `projectEvents.ts` → `locationEvents.ts`
- `workspace-config.ts`, `workspace-provider-data.ts`, `conversation-config.ts` — all gone
- `features/projects/`, `project-selectors.ts` → `locations/`, `location-selectors.ts`
- `LICENSE.md` → `LICENSE`; `CONTRIBUTING.md` linked relative to `dash/`, but it is at the repo root

**Stale inventories**
- `main-process.md` — worst case: **5 domains listed that no longer exist**, **10 that exist and were unlisted** (`agent-runtime`, `locations`, `managed-switch-server`, `providers`, `remote-hosts`, `sidecar`, `ssh`, `switch-rooms`, `switch-servers`, `switch-setup`)
- `shared.md` — 4 dead, 11 missing, plus 4 unlisted event modules
- `renderer.md` — `projects/` dead; `locations/`, `remote-hosts/`, `switch-rooms/`, `switch-servers/` missing
- `AGENTS.md` — `packages/switch-agent-runtime` unlisted, despite being referenced elsewhere in the same file

**Wrong claims, not just wrong paths**
- `main-patterns.md`: **"Switchdash is local-only."** Flatly false — remote SSH hosts, tmux and the sidecar are core. The most dangerous line in the set.
- `updater.md`: ~35 lines describing a dual-feed GitHub + Cloudflare R2 pipeline. No `generic` publish block in either electron-builder config, no R2 upload, no `duplicateChannelManifests`.
- `data-model.md`: mapped `project` as a live table; it is `locations`. Six tables missing entirely.
- `renderer-patterns.md`: `makePtySessionId(projectId, …)` — the parameter is `locationId`.
- `AGENTS.md`: a paragraph that **began mid-sentence**, its lead-in lost in an edit.

**Gaps** — nothing in `agents/` covered remote hosts, reachability, the sidecar, Switch rooms, or the bridge pane.

## What was left alone

Verified as still correct and deliberately untouched: the provider list (31, matches
`AGENT_PROVIDER_IDS` exactly), the five vitest projects, the preload surface, the
`.switchdash.json` keys, the path aliases, all 11 store-selector helper names, and
`AGENTS.md`'s sidecar / versioned-artifacts / logging sections.

One claim I nearly "fixed" and should not have: `UPDATE_CHANNEL` really is only a log
label. The R2 half of that sentence was stale, the `autoUpdater.channel` half was right.

## Divergences preserved rather than deleted

Where switchdash departs from upstream, the departure is the useful information:

- `editor/` — the directory is gone, but Monaco is still a dependency with a keyboard bridge in `lib/components/`. Deleting the line would have implied Monaco was removed.
- The `workspaces` table — kept the history of why it was dropped, and added that **the host split survived even though the table did not**. That is precisely what "local-only" got wrong.
- The channel-manifest guard — `upload-r2.ts` is gone, but the guard concept lives on as the workflow's refuse-to-publish step. Documented in its new home.

## Related finding, not fixed here

`electron-builder.canary.config.ts` has a code comment pointing at
`scripts/release/lib/version.ts`, which no longer exists. Left alone — this ticket is
scoped to `dash/` docs.

## Testing

Markdown only; no source files touched, so the TS gate is unaffected. Verified 0 broken
relative links, and every remaining unresolved path reference is intentional (a
deliberate "this no longer exists" mention, or a CHOO-1809 path flagged as such).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1860]: https://sandboxquantum.atlassian.net/browse/CHOO-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ