### PR TITLE
feat(bridges): make the runtime indicator follow the latest message (CHOO-1104)

### DIFF
--- a/core/switch_core/bridges/agent/api/handlers.py
+++ b/core/switch_core/bridges/agent/api/handlers.py
@@ -607,6 +607,7 @@ async def set_runtime_state(
             deeplink_url=req.deeplink_url,
             detail=req.detail,
             control_capabilities=req.control_capabilities,
+            anchor_event_id=req.anchor_event_id,
         )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e

--- a/core/switch_core/bridges/agent/api/handlers.py
+++ b/core/switch_core/bridges/agent/api/handlers.py
@@ -788,14 +788,24 @@ async def connection_beat(
     still make calls but is receiving nothing must be told, not left believing
     it is connected.
     """
+    # A cursor above the buffer's head belongs to a previous life of this
+    # process: the buffer is in memory, so a restart resets the sequence while
+    # the client keeps beating the number it had reached. Both consumers below
+    # only ever move a cursor forward, so adopting it undoes the rewind the
+    # stream performs on resume — the connection then skips every event up to
+    # the stale value and confirms events it was never delivered. Clamp it here,
+    # where the untrusted value enters, rather than in either consumer.
+    head = protocol.event_buffer.head(agent.id)
+    cursor = min(req.cursor, head)
+
     try:
-        conn = protocol.connections.beat(agent.id, req.connection_id, req.cursor)
+        conn = protocol.connections.beat(agent.id, req.connection_id, cursor)
     except NoStreamAttachedError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except UnknownConnectionError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
-    protocol.event_buffer.confirm(agent.id, conn.id, req.cursor)
+    protocol.event_buffer.confirm(agent.id, conn.id, cursor)
     return {"ok": True, "rooms": sorted(conn.rooms), "cursor": conn.cursor}
 
 

--- a/core/switch_core/bridges/agent/api/schemas.py
+++ b/core/switch_core/bridges/agent/api/schemas.py
@@ -145,6 +145,12 @@ class RuntimeStateRequest(BaseModel):
     # turn, when it was in a thread, so the bridge surfaces the state in that
     # thread. Omit / null when the agent was addressed at the conversation root.
     thread_id: str | None = None
+    # Message id of the latest message the connector has actually delivered to
+    # the agent's session. The bridge repositions the runtime indicator when
+    # this changes, so it only ever moves on evidence the agent has the
+    # message — not merely because one arrived. Report the same value on a
+    # periodic refresh; only a genuine change moves the indicator.
+    anchor_event_id: str | None = None
     # A `switchdash://session?…` deeplink switchdash builds so the bridged
     # working / awaiting-input message can link back to its session. Relayed
     # verbatim to the channel; null for connectors that don't manage a UI.

--- a/core/switch_core/bridges/agent/operations/definitions.py
+++ b/core/switch_core/bridges/agent/operations/definitions.py
@@ -97,6 +97,48 @@ def claim_room_on_caller_connection(
     return evicted.id
 
 
+async def bind_room_for_connectionless_caller(
+    protocol: ProtocolService,
+    *,
+    agent_id: str,
+    connection_id: str,
+    room_id: str,
+    connection_model: str,
+) -> bool:
+    """Record the room binding row, for callers that have no connection.
+
+    The row is how an MCP transport session resolves its room, and the only
+    way it can. A connection carries its own rooms, so writing the row for one
+    records a binding nothing reads — and the row has no liveness check and no
+    expiry, so it outlives the connection it was written for and keeps
+    answering room-scoped calls afterwards. A connection that reopens without
+    re-claiming its room then reads as connected on the send path while
+    delivery, which consults the connection, has nothing: the agent posts into
+    a room it is no longer receiving from, invisibly from either side.
+
+    Returns whether a row was written.
+    """
+    if protocol.connections.get(connection_id) is not None:
+        return False
+
+    # session_passive agents have no poll loop, so the row exists only to bind
+    # the MCP transport to a room — lifecycle="explicit". always_on and
+    # session_addressable agents also receive heartbeat upserts; we mark the row
+    # "heartbeat" so the poll path's on-conflict update doesn't need to
+    # special-case it.
+    lifecycle = "explicit" if connection_model == "session_passive" else "heartbeat"
+    async with protocol.session_factory() as db:
+        await protocol.agent_session_store.set_connected_room(
+            db,
+            agent_id=agent_id,
+            room_id=room_id,
+            transport_session_id=connection_id,
+            lifecycle=lifecycle,
+        )
+        await db.commit()
+    return True
+
+
 @operation
 async def list_rooms(include_archived: bool = False) -> list[dict[str, Any]]:
     """List rooms this agent is assigned to.
@@ -117,10 +159,17 @@ async def list_rooms(include_archived: bool = False) -> list[dict[str, Any]]:
     connected_room_id: str | None = None
     key = session_key()
     if key:
-        async with protocol.session_factory() as db:
-            row = await protocol.agent_session_store.get_connected_room(db, key)
-        if row is not None:
-            _, connected_room_id = row
+        # Ask the live connection first and the binding row only for callers
+        # that have none, matching how require_connected_room resolves it — a
+        # connection carries its own rooms and no row is written for it.
+        connection = protocol.connections.get(key)
+        if connection is not None and len(connection.rooms) == 1:
+            connected_room_id = next(iter(connection.rooms))
+        elif connection is None:
+            async with protocol.session_factory() as db:
+                row = await protocol.agent_session_store.get_connected_room(db, key)
+            if row is not None:
+                _, connected_room_id = row
     rooms = await protocol.list_rooms(agent_id, include_archived=include_archived)
 
     return [
@@ -218,27 +267,17 @@ async def connect_to_room(
     key = session_key()
     if not key:
         raise ValueError("MCP session has no session id; cannot connect to room")
-    # session_passive agents have no poll loop, so the row exists only to
-    # bind the MCP transport to a room — lifecycle="explicit". always_on and
-    # session_addressable agents also receive heartbeat upserts; we mark the
-    # row "heartbeat" so the poll path's on-conflict update doesn't need to
-    # special-case it.
-    lifecycle = (
-        "explicit" if profile.connection_model == "session_passive" else "heartbeat"
-    )
     evicted_connection_id = claim_room_on_caller_connection(
         protocol, agent_id, key, room.id
     )
 
-    async with protocol.session_factory() as db:
-        await protocol.agent_session_store.set_connected_room(
-            db,
-            agent_id=agent_id,
-            room_id=room.id,
-            transport_session_id=key,
-            lifecycle=lifecycle,
-        )
-        await db.commit()
+    await bind_room_for_connectionless_caller(
+        protocol,
+        agent_id=agent_id,
+        connection_id=key,
+        room_id=room.id,
+        connection_model=profile.connection_model,
+    )
 
     return {
         "agent_id": agent_id,

--- a/core/switch_core/bridges/agent/protocol/service.py
+++ b/core/switch_core/bridges/agent/protocol/service.py
@@ -1001,6 +1001,7 @@ class ProtocolService:
         deeplink_url: str | None = None,
         detail: str | None = None,
         control_capabilities: dict[str, bool] | None = None,
+        anchor_event_id: str | None = None,
     ) -> None:
         """Record and broadcast an agent's runtime state in a room.
 
@@ -1016,6 +1017,13 @@ class ProtocolService:
         `detail` is a short activity line for the running turn (e.g. "Editing
         foo.py"); like `thread_id` it is transient and rides the event only —
         the bridge surfaces it in place on the live working message.
+
+        `anchor_event_id` is the latest message the reporting connector has
+        actually handed to the agent's session. The bridge repositions the
+        indicator when it changes, so position follows what the agent has
+        genuinely been given rather than what merely arrived in the room. Also
+        transient routing — reported on every refresh, and only a change moves
+        anything.
 
         The `switchdash://` deeplink is rewritten to a gateway HTTP redirect when
         `GATEWAY_PUBLIC_URL` is configured, so the "Open in SwitchDash" link is
@@ -1055,6 +1063,7 @@ class ProtocolService:
             thread_id=thread_id,
             deeplink_url=deeplink_url,
             detail=detail,
+            anchor_event_id=anchor_event_id,
         )
 
     async def _emit_runtime_state(
@@ -1069,6 +1078,7 @@ class ProtocolService:
         thread_id: str | None,
         deeplink_url: str | None = None,
         detail: str | None = None,
+        anchor_event_id: str | None = None,
     ) -> None:
         client = self.client_lifecycle.get_by_agent_id(agent_id)
         if client is None or client.nio_client is None:
@@ -1088,6 +1098,7 @@ class ProtocolService:
                 "thread_id": thread_id,
                 "deeplink_url": deeplink_url,
                 "detail": detail,
+                "anchor_event_id": anchor_event_id,
             },
         )
 

--- a/core/switch_core/bridges/agent/protocol/service.py
+++ b/core/switch_core/bridges/agent/protocol/service.py
@@ -2039,12 +2039,20 @@ class ProtocolService:
             """Return (present_here, session_room_name) for a lease."""
             if lease.transport_session_id is None:
                 return False, None
-            conn = await self.agent_session_store.get_connected_room(
-                session, lease.transport_session_id
-            )
-            if conn is None:
-                return False, None
-            conn_room_id = conn[1]
+            # A live connection knows its own rooms and has no binding row; the
+            # row is only there for callers that predate connections.
+            connection = self.connections.get(lease.transport_session_id)
+            if connection is not None:
+                if len(connection.rooms) != 1:
+                    return False, None
+                conn_room_id = next(iter(connection.rooms))
+            else:
+                conn = await self.agent_session_store.get_connected_room(
+                    session, lease.transport_session_id
+                )
+                if conn is None:
+                    return False, None
+                conn_room_id = conn[1]
             if conn_room_id == room_id:
                 return True, None
             if conn_room_id not in room_name_cache:

--- a/core/switch_core/bridges/collaboration/adapter.py
+++ b/core/switch_core/bridges/collaboration/adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
@@ -53,6 +54,9 @@ class CollaborationAdapter(ABC):
         # typing-indicator default leaves them empty.
         self._working_msg: dict[tuple[str, str], LiveRuntimeIndicator] = {}
         self._input_pings: dict[tuple[str, str], list[str]] = {}
+        # One lock per (channel_id, agent_name). Every mutation of the entries
+        # above happens under it — see _runtime_lock.
+        self._runtime_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
     def set_max_attachment_bytes(self, max_bytes: int) -> None:
         self._max_attachment_bytes = max_bytes
@@ -178,7 +182,54 @@ class CollaborationAdapter(ABC):
         self, channel_id: str, sender_name: str, is_typing: bool
     ) -> None: ...
 
+    def _runtime_lock(self, channel_id: str, agent_name: str) -> asyncio.Lock:
+        """The lock serialising runtime-indicator work for one agent in one
+        channel.
+
+        The indicator is mutated from two independent places — the periodic
+        activity refresh and a reposition triggered by new traffic — and each
+        reads the tracked message, awaits a platform call, then writes it back.
+        Left to interleave, the later write restores a superseded message ref:
+        the entry then names a message that has just been deleted while the one
+        actually on screen is referenced by nothing, so the end-of-turn clear
+        cannot remove it and it stays in the channel for good.
+        """
+        return self._runtime_locks.setdefault((channel_id, agent_name), asyncio.Lock())
+
     async def apply_runtime_state(
+        self,
+        channel_id: str,
+        agent_name: str,
+        state: str,
+        *,
+        notify_user: str | None,
+        thread_root_id: str | None,
+        deeplink_url: str | None = None,
+        detail: str | None = None,
+    ) -> None:
+        """Serialise against any other runtime-indicator work for this agent,
+        then apply the state. Adapters override ``_apply_runtime_state``."""
+        async with self._runtime_lock(channel_id, agent_name):
+            await self._apply_runtime_state(
+                channel_id,
+                agent_name,
+                state,
+                notify_user=notify_user,
+                thread_root_id=thread_root_id,
+                deeplink_url=deeplink_url,
+                detail=detail,
+            )
+
+    async def reposition_runtime_state(
+        self, channel_id: str, agent_name: str, thread_root_id: str | None
+    ) -> None:
+        """Serialise against any other runtime-indicator work for this agent,
+        then move the indicator. Adapters override
+        ``_reposition_runtime_state``."""
+        async with self._runtime_lock(channel_id, agent_name):
+            await self._reposition_runtime_state(channel_id, agent_name, thread_root_id)
+
+    async def _apply_runtime_state(
         self,
         channel_id: str,
         agent_name: str,
@@ -229,7 +280,7 @@ class CollaborationAdapter(ABC):
             if posted_channel == channel_id
         ]
 
-    async def reposition_runtime_state(
+    async def _reposition_runtime_state(
         self, channel_id: str, agent_name: str, thread_root_id: str | None
     ) -> None:
         """Move the agent's live runtime indicator to follow the latest message.
@@ -244,6 +295,9 @@ class CollaborationAdapter(ABC):
         the indicator lands — so it follows the agent between threads (and back
         out to the channel root) rather than being stranded in whichever thread
         the turn happened to start in.
+
+        Runs under the agent's runtime lock, so the tracked indicator cannot be
+        cleared or refreshed part-way through.
 
         Adapters that render runtime state as a typing indicator have nothing
         positional to move, so the default does nothing.
@@ -261,14 +315,6 @@ class CollaborationAdapter(ABC):
                 agent_name,
                 channel_id,
             )
-            return
-
-        if self._working_msg.get(key) is not live:
-            # The turn ended (or another move landed) while this post was in
-            # flight, so whoever cleared it has already removed the message this
-            # one replaces. Nothing will ever clear the replacement, so take it
-            # back down rather than strand it in the channel.
-            await self._remove_runtime_indicator(channel_id, ref)
             return
 
         self._working_msg[key] = replace(

--- a/core/switch_core/bridges/collaboration/adapter.py
+++ b/core/switch_core/bridges/collaboration/adapter.py
@@ -229,14 +229,21 @@ class CollaborationAdapter(ABC):
             if posted_channel == channel_id
         ]
 
-    async def reposition_runtime_state(self, channel_id: str, agent_name: str) -> None:
-        """Move the agent's live runtime indicator to the foot of the channel.
+    async def reposition_runtime_state(
+        self, channel_id: str, agent_name: str, thread_root_id: str | None
+    ) -> None:
+        """Move the agent's live runtime indicator to follow the latest message.
 
         Called when a message the agent is party to has just crossed the bridge,
         so the indicator no longer sits below the conversation it belongs to.
         The replacement is posted *before* the original is removed: the
         indicator is therefore never briefly absent, and a failed repost leaves
         the original in place rather than clearing it.
+
+        ``thread_root_id`` is the thread that message belonged to, and is where
+        the indicator lands — so it follows the agent between threads (and back
+        out to the channel root) rather than being stranded in whichever thread
+        the turn happened to start in.
 
         Adapters that render runtime state as a typing indicator have nothing
         positional to move, so the default does nothing.
@@ -246,9 +253,7 @@ class CollaborationAdapter(ABC):
         if live is None:
             return
 
-        ref = await self.send_message(
-            channel_id, agent_name, live.body, live.thread_root_id
-        )
+        ref = await self.send_message(channel_id, agent_name, live.body, thread_root_id)
         if ref is None:
             logger.warning(
                 "Could not repost the runtime indicator for %s in %s; leaving it "
@@ -258,7 +263,9 @@ class CollaborationAdapter(ABC):
             )
             return
 
-        self._working_msg[key] = replace(live, message_ref=ref)
+        self._working_msg[key] = replace(
+            live, message_ref=ref, thread_root_id=thread_root_id
+        )
         await self._remove_runtime_indicator(channel_id, live.message_ref)
 
     async def _remove_runtime_indicator(

--- a/core/switch_core/bridges/collaboration/adapter.py
+++ b/core/switch_core/bridges/collaboration/adapter.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
 
 from switch_core.bridges.collaboration.models import (
     ChannelType,
@@ -12,6 +14,23 @@ from switch_core.bridges.collaboration.models import (
     InboundUserJoin,
     OutboundAttachment,
 )
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LiveRuntimeIndicator:
+    """The runtime status message currently posted for one agent in one channel.
+
+    ``body`` and ``thread_root_id`` are retained so the indicator can be
+    reposted verbatim, in the same thread, when it is moved to follow newer
+    traffic — a move has no access to the ``detail``/``deeplink_url`` the body
+    was originally rendered from.
+    """
+
+    message_ref: str
+    body: str
+    thread_root_id: str | None
 
 
 class CollaborationAdapter(ABC):
@@ -28,6 +47,12 @@ class CollaborationAdapter(ABC):
         # size against this before downloading so an oversize file is rejected
         # loudly instead of being pulled down and discarded.
         self._max_attachment_bytes = 20 * 1024 * 1024
+        # (channel_id, agent_name) -> the agent's live "working on it…" runtime
+        # indicator, and the operator pings posted alongside it. Adapters that
+        # render runtime state as a persistent message maintain these; the
+        # typing-indicator default leaves them empty.
+        self._working_msg: dict[tuple[str, str], LiveRuntimeIndicator] = {}
+        self._input_pings: dict[tuple[str, str], list[str]] = {}
 
     def set_max_attachment_bytes(self, max_bytes: int) -> None:
         self._max_attachment_bytes = max_bytes
@@ -192,6 +217,59 @@ class CollaborationAdapter(ABC):
             )
         else:
             await self.send_typing(channel_id, agent_name, False)
+
+    def agents_with_live_runtime_state(self, channel_id: str) -> list[str]:
+        """Agents with a runtime indicator currently posted in this channel.
+
+        Cheap and synchronous so a caller can skip the work of deciding whether
+        a message warrants a move when there is nothing to move."""
+        return [
+            agent_name
+            for (posted_channel, agent_name) in self._working_msg
+            if posted_channel == channel_id
+        ]
+
+    async def reposition_runtime_state(self, channel_id: str, agent_name: str) -> None:
+        """Move the agent's live runtime indicator to the foot of the channel.
+
+        Called when a message the agent is party to has just crossed the bridge,
+        so the indicator no longer sits below the conversation it belongs to.
+        The replacement is posted *before* the original is removed: the
+        indicator is therefore never briefly absent, and a failed repost leaves
+        the original in place rather than clearing it.
+
+        Adapters that render runtime state as a typing indicator have nothing
+        positional to move, so the default does nothing.
+        """
+        key = (channel_id, agent_name)
+        live = self._working_msg.get(key)
+        if live is None:
+            return
+
+        ref = await self.send_message(
+            channel_id, agent_name, live.body, live.thread_root_id
+        )
+        if ref is None:
+            logger.warning(
+                "Could not repost the runtime indicator for %s in %s; leaving it "
+                "at its current position",
+                agent_name,
+                channel_id,
+            )
+            return
+
+        self._working_msg[key] = replace(live, message_ref=ref)
+        await self._remove_runtime_indicator(channel_id, live.message_ref)
+
+    async def _remove_runtime_indicator(
+        self, channel_id: str, message_ref: str
+    ) -> None:
+        """Delete a superseded runtime indicator.
+
+        Separate from ``delete_message`` so an adapter whose delete raises can
+        keep a failed cleanup from tearing down the turn — the worst case is a
+        duplicate indicator, which is visible, rather than a broken turn."""
+        await self.delete_message(channel_id, message_ref)
 
     @staticmethod
     def _deeplink_suffix(deeplink_url: str | None) -> str:

--- a/core/switch_core/bridges/collaboration/adapter.py
+++ b/core/switch_core/bridges/collaboration/adapter.py
@@ -263,6 +263,14 @@ class CollaborationAdapter(ABC):
             )
             return
 
+        if self._working_msg.get(key) is not live:
+            # The turn ended (or another move landed) while this post was in
+            # flight, so whoever cleared it has already removed the message this
+            # one replaces. Nothing will ever clear the replacement, so take it
+            # back down rather than strand it in the channel.
+            await self._remove_runtime_indicator(channel_id, ref)
+            return
+
         self._working_msg[key] = replace(
             live, message_ref=ref, thread_root_id=thread_root_id
         )

--- a/core/switch_core/bridges/collaboration/bridge_core.py
+++ b/core/switch_core/bridges/collaboration/bridge_core.py
@@ -146,8 +146,10 @@ class BridgeCore:
         self._outbound_groups: dict[str, _PendingOutboundGroup] = {}
         self._outbound_group_timers: dict[str, asyncio.TimerHandle] = {}
         # (channel_id, agent_name) whose runtime indicator is due to be moved
-        # below newly-arrived traffic. See _schedule_indicator_move.
+        # below newly-arrived traffic, and the thread each should land in.
+        # See _schedule_indicator_move.
         self._indicator_move_timers: dict[tuple[str, str], asyncio.TimerHandle] = {}
+        self._indicator_move_targets: dict[tuple[str, str], str | None] = {}
 
     @property
     def adapter(self) -> CollaborationAdapter:
@@ -448,6 +450,7 @@ class BridgeCore:
                 channel_type=msg.channel_type,
                 content=content,
                 mention_target=mention_target,
+                thread_root_id=msg.root_id,
             )
             return
 
@@ -500,6 +503,7 @@ class BridgeCore:
             channel_type=msg.channel_type,
             content=content,
             mention_target=mention_target,
+            thread_root_id=msg.root_id,
         )
 
     async def _handle_inbound_command(self, cmd: InboundCommand) -> None:
@@ -1016,7 +1020,9 @@ class BridgeCore:
             )
 
         if sender_name is not None:
-            await self._move_indicator_for_sender(channel_id, sender_name)
+            await self._move_indicator_for_sender(
+                channel_id, sender_name, thread_root_ref
+            )
 
     async def _outbound_thread_root_ref(
         self, event_content: dict[str, object], channel_id: str
@@ -1166,7 +1172,7 @@ class BridgeCore:
                 external_post_id=message_ref,
             )
 
-        await self._move_indicator_for_sender(channel_id, sender_name)
+        await self._move_indicator_for_sender(channel_id, sender_name, thread_root_ref)
 
     def _schedule_outbound_group_flush(
         self,
@@ -1250,7 +1256,7 @@ class BridgeCore:
                 external_post_id=message_ref,
             )
 
-        await self._move_indicator_for_sender(channel_id, sender_name)
+        await self._move_indicator_for_sender(channel_id, sender_name, thread_root_ref)
 
     async def _download_matrix_media(
         self, client: ClientBase[Any], mxc: str | None, filename: str
@@ -1355,11 +1361,11 @@ class BridgeCore:
     # ── Runtime-indicator positioning ─────────────────────────────────────────
 
     async def _move_indicator_for_sender(
-        self, channel_id: str, agent_name: str
+        self, channel_id: str, agent_name: str, thread_root_id: str | None
     ) -> None:
         """Follow a message the agent itself just posted."""
         if agent_name in self._adapter.agents_with_live_runtime_state(channel_id):
-            self._schedule_indicator_move(channel_id, agent_name)
+            self._schedule_indicator_move(channel_id, agent_name, thread_root_id)
 
     async def _move_indicators_for_addressees(
         self,
@@ -1369,6 +1375,7 @@ class BridgeCore:
         channel_type: ChannelType,
         content: str,
         mention_target: str | None,
+        thread_root_id: str | None,
     ) -> None:
         """Follow an inbound message, for each addressed agent working here.
 
@@ -1381,7 +1388,7 @@ class BridgeCore:
         # Every message in a 1:1 room addresses the agent, with no mention.
         if channel_type == "direct":
             for agent_name in live:
-                self._schedule_indicator_move(channel_id, agent_name)
+                self._schedule_indicator_move(channel_id, agent_name, thread_root_id)
             return
 
         stripped = strip_emphasis(content)
@@ -1400,7 +1407,7 @@ class BridgeCore:
             )
 
         for agent_name in addressed:
-            self._schedule_indicator_move(channel_id, agent_name)
+            self._schedule_indicator_move(channel_id, agent_name, thread_root_id)
 
     async def _live_agents_addressed_by_alias(
         self, room_id: str, content: str, candidates: list[str]
@@ -1431,15 +1438,23 @@ class BridgeCore:
                     matched.add(name)
         return matched
 
-    def _schedule_indicator_move(self, channel_id: str, agent_name: str) -> None:
+    def _schedule_indicator_move(
+        self, channel_id: str, agent_name: str, thread_root_id: str | None
+    ) -> None:
         """Queue a move of this agent's runtime indicator, coalescing bursts.
 
         Messages arriving while a move is already queued are absorbed into it,
         so a rapid exchange costs one delete-and-repost rather than one per
         message. The delay is deliberately not extended by later messages —
         a sustained conversation would otherwise starve the move indefinitely.
+
+        ``thread_root_id`` is the thread the triggering message belongs to, and
+        the one the indicator will land in. A coalesced burst keeps the most
+        recent one, so the indicator follows the conversation's latest thread
+        rather than the one that opened the window.
         """
         key = (channel_id, agent_name)
+        self._indicator_move_targets[key] = thread_root_id
         if key in self._indicator_move_timers:
             return
 
@@ -1451,9 +1466,12 @@ class BridgeCore:
 
     async def _run_indicator_move(self, key: tuple[str, str]) -> None:
         self._indicator_move_timers.pop(key, None)
+        thread_root_id = self._indicator_move_targets.pop(key, None)
         channel_id, agent_name = key
         try:
-            await self._adapter.reposition_runtime_state(channel_id, agent_name)
+            await self._adapter.reposition_runtime_state(
+                channel_id, agent_name, thread_root_id
+            )
         except Exception:
             # The indicator is cosmetic; a platform failure here must not take
             # down the bridge callback that happened to trigger it.

--- a/core/switch_core/bridges/collaboration/bridge_core.py
+++ b/core/switch_core/bridges/collaboration/bridge_core.py
@@ -31,11 +31,7 @@ from switch_core.bridges.collaboration.models import (
 )
 from switch_core.clients.admin_messages import ADMIN_MARKER, AdminMessageType
 from switch_core.clients.client_base import ClientBase, ClientConfig
-from switch_core.clients.mentions import (
-    mention_regex,
-    strip_emphasis,
-    unique_mention_tokens,
-)
+from switch_core.clients.mentions import mention_regex, strip_emphasis
 from switch_core.db.models import BridgeMessageMap, ExternalUser
 from switch_core.db.stores.agent_store import AgentStore
 from switch_core.db.stores.bridge_message_map_store import BridgeMessageMapStore
@@ -150,6 +146,9 @@ class BridgeCore:
         # See _schedule_indicator_move.
         self._indicator_move_timers: dict[tuple[str, str], asyncio.TimerHandle] = {}
         self._indicator_move_targets: dict[tuple[str, str], str | None] = {}
+        # (channel_id, agent_name) -> the last message the agent reported having
+        # been handed. Cleared when its turn ends. See _follow_reported_anchor.
+        self._reported_anchors: dict[tuple[str, str], str] = {}
 
     @property
     def adapter(self) -> CollaborationAdapter:
@@ -444,14 +443,6 @@ class BridgeCore:
                     matrix_event_id=event_id,
                     external_post_id=msg.message_ref,
                 )
-            await self._move_indicators_for_addressees(
-                channel_id=msg.channel_id,
-                room_id=room_id,
-                channel_type=msg.channel_type,
-                content=content,
-                mention_target=mention_target,
-                thread_root_id=msg.root_id,
-            )
             return
 
         # Caption convention: the text rides as the caption on the first
@@ -496,15 +487,6 @@ class BridgeCore:
                 matrix_event_id=first_event_id,
                 external_post_id=msg.message_ref,
             )
-
-        await self._move_indicators_for_addressees(
-            channel_id=msg.channel_id,
-            room_id=room_id,
-            channel_type=msg.channel_type,
-            content=content,
-            mention_target=mention_target,
-            thread_root_id=msg.root_id,
-        )
 
     async def _handle_inbound_command(self, cmd: InboundCommand) -> None:
         room_ids = self._channel_to_room.get(cmd.channel_id)
@@ -1330,6 +1312,48 @@ class BridgeCore:
             deeplink_url=event.deeplink_url,
             detail=event.detail,
         )
+        await self._follow_reported_anchor(
+            channel_id,
+            event.agent_name,
+            event.state,
+            event.anchor_event_id,
+            thread_root_ref,
+        )
+
+    async def _follow_reported_anchor(
+        self,
+        channel_id: str,
+        agent_name: str,
+        state: str,
+        anchor_event_id: str | None,
+        thread_root_ref: str | None,
+    ) -> None:
+        """Move the indicator when the agent reports it has been handed a
+        newer message than the one it was last positioned against.
+
+        Position follows what the agent has actually received, not what merely
+        arrived in the room — a message the agent has not been given yet must
+        not make the indicator look like the agent has seen it. The periodic
+        activity refresh repeats the current anchor, so it never moves anything.
+        """
+        key = (channel_id, agent_name)
+        if state != "working":
+            self._reported_anchors.pop(key, None)
+            return
+        if anchor_event_id is None:
+            return
+
+        if self._reported_anchors.get(key) == anchor_event_id:
+            return
+        previous = self._reported_anchors.get(key)
+        self._reported_anchors[key] = anchor_event_id
+        if previous is None:
+            # First anchor of the turn — the indicator was only just posted
+            # against it, so there is nothing to move.
+            return
+
+        self._indicator_move_targets[key] = thread_root_ref
+        await self._run_indicator_move(key)
 
     # ── Protection sync ──────────────────────────────────────────────────────
 
@@ -1366,77 +1390,6 @@ class BridgeCore:
         """Follow a message the agent itself just posted."""
         if agent_name in self._adapter.agents_with_live_runtime_state(channel_id):
             self._schedule_indicator_move(channel_id, agent_name, thread_root_id)
-
-    async def _move_indicators_for_addressees(
-        self,
-        *,
-        channel_id: str,
-        room_id: str,
-        channel_type: ChannelType,
-        content: str,
-        mention_target: str | None,
-        thread_root_id: str | None,
-    ) -> None:
-        """Follow an inbound message, for each addressed agent working here.
-
-        Only agents the message actually addresses move: unrelated chatter in a
-        busy channel leaves a working agent's indicator where it is."""
-        live = self._adapter.agents_with_live_runtime_state(channel_id)
-        if not live:
-            return
-
-        # Every message in a 1:1 room addresses the agent, with no mention.
-        if channel_type == "direct":
-            for agent_name in live:
-                self._schedule_indicator_move(channel_id, agent_name, thread_root_id)
-            return
-
-        stripped = strip_emphasis(content)
-        addressed = {
-            agent_name
-            for agent_name in live
-            if mention_regex(agent_name).search(stripped) is not None
-        }
-        if mention_target is not None and mention_target in live:
-            addressed.add(mention_target)
-
-        unmatched = [name for name in live if name not in addressed]
-        if unmatched:
-            addressed.update(
-                await self._live_agents_addressed_by_alias(room_id, content, unmatched)
-            )
-
-        for agent_name in addressed:
-            self._schedule_indicator_move(channel_id, agent_name, thread_root_id)
-
-    async def _live_agents_addressed_by_alias(
-        self, room_id: str, content: str, candidates: list[str]
-    ) -> set[str]:
-        """Of `candidates`, those addressed by their room alias rather than name.
-
-        An alias is room-scoped, so it cannot be matched from the message text
-        alone. Only consulted when a plain-name match has already failed for the
-        agent, keeping this off the path of the common case."""
-        tokens = unique_mention_tokens(content)
-        if not tokens:
-            return set()
-
-        by_name = {name.lower(): name for name in candidates}
-        matched: set[str] = set()
-        async with self._session_factory() as session:
-            for token in tokens:
-                agent_id = await self._room_store.get_agent_id_by_alias(
-                    session, room_id, token
-                )
-                if agent_id is None:
-                    continue
-                agent = await self._agent_store.get(session, agent_id)
-                if agent is None:
-                    continue
-                name = by_name.get(agent.name.lower())
-                if name is not None:
-                    matched.add(name)
-        return matched
 
     def _schedule_indicator_move(
         self, channel_id: str, agent_name: str, thread_root_id: str | None

--- a/core/switch_core/bridges/collaboration/bridge_core.py
+++ b/core/switch_core/bridges/collaboration/bridge_core.py
@@ -1418,7 +1418,12 @@ class BridgeCore:
         )
 
     async def _run_indicator_move(self, key: tuple[str, str]) -> None:
-        self._indicator_move_timers.pop(key, None)
+        # An anchor-driven move runs immediately rather than through the timer,
+        # so a coalescing window opened by outbound traffic may still be
+        # pending; it would otherwise fire a second, redundant move.
+        timer = self._indicator_move_timers.pop(key, None)
+        if timer is not None:
+            timer.cancel()
         thread_root_id = self._indicator_move_targets.pop(key, None)
         channel_id, agent_name = key
         try:

--- a/core/switch_core/bridges/collaboration/bridge_core.py
+++ b/core/switch_core/bridges/collaboration/bridge_core.py
@@ -31,7 +31,11 @@ from switch_core.bridges.collaboration.models import (
 )
 from switch_core.clients.admin_messages import ADMIN_MARKER, AdminMessageType
 from switch_core.clients.client_base import ClientBase, ClientConfig
-from switch_core.clients.mentions import mention_regex, strip_emphasis
+from switch_core.clients.mentions import (
+    mention_regex,
+    strip_emphasis,
+    unique_mention_tokens,
+)
 from switch_core.db.models import BridgeMessageMap, ExternalUser
 from switch_core.db.stores.agent_store import AgentStore
 from switch_core.db.stores.bridge_message_map_store import BridgeMessageMapStore
@@ -62,6 +66,11 @@ class _PendingOutboundGroup:
     caption: str | None = None
     first_event_id: str | None = None
 
+
+# How long a queued runtime-indicator move waits before it runs, so a burst of
+# messages to the same agent costs one move rather than one per message. Short
+# enough that the indicator still reads as following the conversation.
+_INDICATOR_MOVE_DELAY_SECONDS = 1.0
 
 _LOBBY_DEPRECATION_NOTICE = (
     "👋 This isn't where you talk to agents — direct messages to the Switch "
@@ -136,6 +145,9 @@ class BridgeCore:
         # never completes cannot leak.
         self._outbound_groups: dict[str, _PendingOutboundGroup] = {}
         self._outbound_group_timers: dict[str, asyncio.TimerHandle] = {}
+        # (channel_id, agent_name) whose runtime indicator is due to be moved
+        # below newly-arrived traffic. See _schedule_indicator_move.
+        self._indicator_move_timers: dict[tuple[str, str], asyncio.TimerHandle] = {}
 
     @property
     def adapter(self) -> CollaborationAdapter:
@@ -430,6 +442,13 @@ class BridgeCore:
                     matrix_event_id=event_id,
                     external_post_id=msg.message_ref,
                 )
+            await self._move_indicators_for_addressees(
+                channel_id=msg.channel_id,
+                room_id=room_id,
+                channel_type=msg.channel_type,
+                content=content,
+                mention_target=mention_target,
+            )
             return
 
         # Caption convention: the text rides as the caption on the first
@@ -474,6 +493,14 @@ class BridgeCore:
                 matrix_event_id=first_event_id,
                 external_post_id=msg.message_ref,
             )
+
+        await self._move_indicators_for_addressees(
+            channel_id=msg.channel_id,
+            room_id=room_id,
+            channel_type=msg.channel_type,
+            content=content,
+            mention_target=mention_target,
+        )
 
     async def _handle_inbound_command(self, cmd: InboundCommand) -> None:
         room_ids = self._channel_to_room.get(cmd.channel_id)
@@ -988,6 +1015,9 @@ class BridgeCore:
                 external_post_id=message_ref,
             )
 
+        if sender_name is not None:
+            await self._move_indicator_for_sender(channel_id, sender_name)
+
     async def _outbound_thread_root_ref(
         self, event_content: dict[str, object], channel_id: str
     ) -> str | None:
@@ -1136,6 +1166,8 @@ class BridgeCore:
                 external_post_id=message_ref,
             )
 
+        await self._move_indicator_for_sender(channel_id, sender_name)
+
     def _schedule_outbound_group_flush(
         self,
         group_id: str,
@@ -1217,6 +1249,8 @@ class BridgeCore:
                 matrix_event_id=pending.first_event_id,
                 external_post_id=message_ref,
             )
+
+        await self._move_indicator_for_sender(channel_id, sender_name)
 
     async def _download_matrix_media(
         self, client: ClientBase[Any], mxc: str | None, filename: str
@@ -1317,6 +1351,117 @@ class BridgeCore:
         else:
             translated = self._adapter.translate_outbound(new_content)
             await self._adapter.update_message(channel_id, message_ref, translated)
+
+    # ── Runtime-indicator positioning ─────────────────────────────────────────
+
+    async def _move_indicator_for_sender(
+        self, channel_id: str, agent_name: str
+    ) -> None:
+        """Follow a message the agent itself just posted."""
+        if agent_name in self._adapter.agents_with_live_runtime_state(channel_id):
+            self._schedule_indicator_move(channel_id, agent_name)
+
+    async def _move_indicators_for_addressees(
+        self,
+        *,
+        channel_id: str,
+        room_id: str,
+        channel_type: ChannelType,
+        content: str,
+        mention_target: str | None,
+    ) -> None:
+        """Follow an inbound message, for each addressed agent working here.
+
+        Only agents the message actually addresses move: unrelated chatter in a
+        busy channel leaves a working agent's indicator where it is."""
+        live = self._adapter.agents_with_live_runtime_state(channel_id)
+        if not live:
+            return
+
+        # Every message in a 1:1 room addresses the agent, with no mention.
+        if channel_type == "direct":
+            for agent_name in live:
+                self._schedule_indicator_move(channel_id, agent_name)
+            return
+
+        stripped = strip_emphasis(content)
+        addressed = {
+            agent_name
+            for agent_name in live
+            if mention_regex(agent_name).search(stripped) is not None
+        }
+        if mention_target is not None and mention_target in live:
+            addressed.add(mention_target)
+
+        unmatched = [name for name in live if name not in addressed]
+        if unmatched:
+            addressed.update(
+                await self._live_agents_addressed_by_alias(room_id, content, unmatched)
+            )
+
+        for agent_name in addressed:
+            self._schedule_indicator_move(channel_id, agent_name)
+
+    async def _live_agents_addressed_by_alias(
+        self, room_id: str, content: str, candidates: list[str]
+    ) -> set[str]:
+        """Of `candidates`, those addressed by their room alias rather than name.
+
+        An alias is room-scoped, so it cannot be matched from the message text
+        alone. Only consulted when a plain-name match has already failed for the
+        agent, keeping this off the path of the common case."""
+        tokens = unique_mention_tokens(content)
+        if not tokens:
+            return set()
+
+        by_name = {name.lower(): name for name in candidates}
+        matched: set[str] = set()
+        async with self._session_factory() as session:
+            for token in tokens:
+                agent_id = await self._room_store.get_agent_id_by_alias(
+                    session, room_id, token
+                )
+                if agent_id is None:
+                    continue
+                agent = await self._agent_store.get(session, agent_id)
+                if agent is None:
+                    continue
+                name = by_name.get(agent.name.lower())
+                if name is not None:
+                    matched.add(name)
+        return matched
+
+    def _schedule_indicator_move(self, channel_id: str, agent_name: str) -> None:
+        """Queue a move of this agent's runtime indicator, coalescing bursts.
+
+        Messages arriving while a move is already queued are absorbed into it,
+        so a rapid exchange costs one delete-and-repost rather than one per
+        message. The delay is deliberately not extended by later messages —
+        a sustained conversation would otherwise starve the move indefinitely.
+        """
+        key = (channel_id, agent_name)
+        if key in self._indicator_move_timers:
+            return
+
+        loop = asyncio.get_running_loop()
+        self._indicator_move_timers[key] = loop.call_later(
+            _INDICATOR_MOVE_DELAY_SECONDS,
+            lambda: asyncio.ensure_future(self._run_indicator_move(key)),
+        )
+
+    async def _run_indicator_move(self, key: tuple[str, str]) -> None:
+        self._indicator_move_timers.pop(key, None)
+        channel_id, agent_name = key
+        try:
+            await self._adapter.reposition_runtime_state(channel_id, agent_name)
+        except Exception:
+            # The indicator is cosmetic; a platform failure here must not take
+            # down the bridge callback that happened to trigger it.
+            logger.exception(
+                "[BRIDGE-OUT] failed to move the runtime indicator for %s in %s",
+                agent_name,
+                channel_id,
+            )
 
     # ── Message-map helpers ───────────────────────────────────────────────────
 

--- a/core/switch_core/bridges/collaboration/discord/adapter.py
+++ b/core/switch_core/bridges/collaboration/discord/adapter.py
@@ -6,11 +6,15 @@ import logging
 import re
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
+from dataclasses import replace
 from typing import Any
 
 import discord
 
-from switch_core.bridges.collaboration.adapter import CollaborationAdapter
+from switch_core.bridges.collaboration.adapter import (
+    CollaborationAdapter,
+    LiveRuntimeIndicator,
+)
 from switch_core.bridges.collaboration.models import (
     Attachment,
     AttachmentFailure,
@@ -69,15 +73,9 @@ class DiscordAdapter(CollaborationAdapter):
         # Discord user id ↔ username caches, for mention translation both ways.
         self._user_names: dict[int, str] = {}
         self._username_to_id: dict[str, int] = {}
-        # (channel_id, agent_name) -> message ref of the agent's live "working
-        # on it…" runtime-state message, so it can be deleted when the agent
-        # stops working. Webhook messages delete cleanly on Discord, so a
-        # persistent message is preferable to the one-shot typing indicator.
-        self._working_msg: dict[tuple[str, str], str] = {}
-        # (channel_id, agent_name) -> refs of the live "needs your input" pings,
-        # kept so they can be removed when the turn ends. The working indicator
-        # stays up alongside these — the agent is mid-turn, just paused.
-        self._input_pings: dict[tuple[str, str], list[str]] = {}
+        # Webhook messages delete cleanly on Discord, so runtime state renders
+        # as a persistent message (see the base class's _working_msg) rather
+        # than the one-shot typing indicator.
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
 
@@ -455,11 +453,14 @@ class DiscordAdapter(CollaborationAdapter):
             body = self._working_body(detail, deeplink_url)
             existing = self._working_msg.get(key)
             if existing is not None:
-                await self.update_message(channel_id, existing, body)
+                await self.update_message(channel_id, existing.message_ref, body)
+                self._working_msg[key] = replace(existing, body=body)
                 return
             ref = await self.send_message(channel_id, agent_name, body, thread_root_id)
             if ref is not None:
-                self._working_msg[key] = ref
+                self._working_msg[key] = LiveRuntimeIndicator(
+                    message_ref=ref, body=body, thread_root_id=thread_root_id
+                )
         elif state == "awaiting-input":
             ref = await self._ping_operator(
                 channel_id, agent_name, notify_user, thread_root_id, deeplink_url
@@ -471,9 +472,9 @@ class DiscordAdapter(CollaborationAdapter):
             await self._clear_input_pings(channel_id, agent_name)
 
     async def _clear_working(self, channel_id: str, agent_name: str) -> None:
-        ref = self._working_msg.pop((channel_id, agent_name), None)
-        if ref is not None:
-            await self.delete_message(channel_id, ref)
+        live = self._working_msg.pop((channel_id, agent_name), None)
+        if live is not None:
+            await self.delete_message(channel_id, live.message_ref)
 
     async def _clear_input_pings(self, channel_id: str, agent_name: str) -> None:
         refs = self._input_pings.pop((channel_id, agent_name), [])

--- a/core/switch_core/bridges/collaboration/discord/adapter.py
+++ b/core/switch_core/bridges/collaboration/discord/adapter.py
@@ -442,7 +442,7 @@ class DiscordAdapter(CollaborationAdapter):
 
     # ── Runtime state ────────────────────────────────────────────────────────
 
-    async def apply_runtime_state(
+    async def _apply_runtime_state(
         self,
         channel_id: str,
         agent_name: str,

--- a/core/switch_core/bridges/collaboration/discord/adapter.py
+++ b/core/switch_core/bridges/collaboration/discord/adapter.py
@@ -399,6 +399,24 @@ class DiscordAdapter(CollaborationAdapter):
         if not message_id:
             logger.error("Cannot delete message: invalid message ref %s", message_ref)
             return
+
+        # Agent posts are authored by the channel webhook, not the bot, so the
+        # bot may only remove them with Manage Messages. Delete through the
+        # webhook that sent it, mirroring update_message, and keep the bot path
+        # for messages the bot really did post (admin notices, DM fallbacks).
+        kwargs: dict[str, Any] = {}
+        if location_id and location_id != channel_id:
+            kwargs["thread"] = discord.Object(id=int(location_id))
+        try:
+            webhook = await self._get_webhook(int(channel_id))
+            await webhook.delete_message(int(message_id), **kwargs)
+            return
+        except discord.NotFound:
+            pass
+        except discord.HTTPException as e:
+            logger.error("Failed to delete Discord message %s: %s", message_ref, e)
+            return
+
         try:
             target = await self._get_channel(int(location_id or channel_id))
             await target.get_partial_message(int(message_id)).delete()

--- a/core/switch_core/bridges/collaboration/mattermost/adapter.py
+++ b/core/switch_core/bridges/collaboration/mattermost/adapter.py
@@ -535,6 +535,12 @@ class MattermostAdapter(CollaborationAdapter):
                 )
             return
 
+        if self._working_msg.get(key) is not live:
+            # The turn ended while the delete was in flight. The old post is
+            # already gone and the entry with it, so there is nothing left to
+            # move — reposting now would strand an indicator no one will clear.
+            return
+
         ref = await self.send_message(channel_id, agent_name, live.body, thread_root_id)
         if ref is None:
             # The old post is already gone, so there is nothing to fall back to.
@@ -546,6 +552,13 @@ class MattermostAdapter(CollaborationAdapter):
                 channel_id,
             )
             return
+
+        if self._working_msg.get(key) is not live:
+            # Same race, one step later: the replacement has no owner now, so
+            # take it back down rather than leave it in the channel.
+            await self._permanent_delete(ref)
+            return
+
         self._working_msg[key] = replace(
             live, message_ref=ref, thread_root_id=thread_root_id
         )

--- a/core/switch_core/bridges/collaboration/mattermost/adapter.py
+++ b/core/switch_core/bridges/collaboration/mattermost/adapter.py
@@ -503,7 +503,9 @@ class MattermostAdapter(CollaborationAdapter):
                 agent_name, post_id, self.translate_outbound("✓ input received")
             )
 
-    async def reposition_runtime_state(self, channel_id: str, agent_name: str) -> None:
+    async def reposition_runtime_state(
+        self, channel_id: str, agent_name: str, thread_root_id: str | None
+    ) -> None:
         """Move the indicator only when Mattermost will truly delete the old one.
 
         This inverts the base class's post-then-delete order. Mattermost can only
@@ -533,9 +535,7 @@ class MattermostAdapter(CollaborationAdapter):
                 )
             return
 
-        ref = await self.send_message(
-            channel_id, agent_name, live.body, live.thread_root_id
-        )
+        ref = await self.send_message(channel_id, agent_name, live.body, thread_root_id)
         if ref is None:
             # The old post is already gone, so there is nothing to fall back to.
             self._working_msg.pop(key, None)
@@ -546,7 +546,9 @@ class MattermostAdapter(CollaborationAdapter):
                 channel_id,
             )
             return
-        self._working_msg[key] = replace(live, message_ref=ref)
+        self._working_msg[key] = replace(
+            live, message_ref=ref, thread_root_id=thread_root_id
+        )
 
     async def _dispose_working(self, channel_id: str, agent_name: str) -> None:
         """Remove the live "working on it…" message when the turn ends.

--- a/core/switch_core/bridges/collaboration/mattermost/adapter.py
+++ b/core/switch_core/bridges/collaboration/mattermost/adapter.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
+from dataclasses import replace
 from typing import Any
 
 import httpx
@@ -17,7 +18,10 @@ import requests as sync_requests
 from mattermostdriver import Driver
 from mattermostdriver.exceptions import NoAccessTokenProvided
 
-from switch_core.bridges.collaboration.adapter import CollaborationAdapter
+from switch_core.bridges.collaboration.adapter import (
+    CollaborationAdapter,
+    LiveRuntimeIndicator,
+)
 from switch_core.bridges.collaboration.models import (
     Attachment,
     AttachmentFailure,
@@ -76,16 +80,13 @@ class MattermostAdapter(CollaborationAdapter):
         self._seen_post_ids_max = 1000
         self._seen_lock = threading.Lock()
 
-        # (channel_id, agent_name) -> post id of the agent's live "working on
-        # it…" runtime-state message. Mattermost's delete leaves a "(message
-        # deleted)" tombstone, so the message is never deleted — it is edited in
-        # place to a terminal marker when the turn ends (idle) or repurposed
-        # into the operator ping (awaiting-input).
-        self._working_msg: dict[tuple[str, str], str] = {}
-        # (channel_id, agent_name) -> post ids of the live "needs your input"
-        # pings, kept so they can be removed when the turn ends. The working
-        # indicator stays up alongside these — the agent is mid-turn, paused.
-        self._input_pings: dict[tuple[str, str], list[str]] = {}
+        # Mattermost's ordinary delete leaves a "(message deleted)" tombstone,
+        # so the runtime indicator (base class `_working_msg`) is never soft
+        # deleted — it is hard deleted where the server permits it, and
+        # otherwise edited in place to a terminal marker when the turn ends.
+        # Channels where the hard delete has been found unavailable, so the
+        # operator is warned once rather than on every message.
+        self._no_hard_delete_warned: set[str] = set()
 
         self._main_loop: asyncio.AbstractEventLoop | None = None
 
@@ -472,11 +473,14 @@ class MattermostAdapter(CollaborationAdapter):
             existing = self._working_msg.get(key)
             if existing is not None:
                 # Refresh the live message in place with the latest activity.
-                await self._patch_post_as(agent_name, existing, body)
+                await self._patch_post_as(agent_name, existing.message_ref, body)
+                self._working_msg[key] = replace(existing, body=body)
                 return
             ref = await self.send_message(channel_id, agent_name, body, thread_root_id)
             if ref is not None:
-                self._working_msg[key] = ref
+                self._working_msg[key] = LiveRuntimeIndicator(
+                    message_ref=ref, body=body, thread_root_id=thread_root_id
+                )
         elif state == "awaiting-input":
             ref = await self._ping_operator(
                 channel_id, agent_name, notify_user, thread_root_id, deeplink_url
@@ -499,6 +503,51 @@ class MattermostAdapter(CollaborationAdapter):
                 agent_name, post_id, self.translate_outbound("✓ input received")
             )
 
+    async def reposition_runtime_state(self, channel_id: str, agent_name: str) -> None:
+        """Move the indicator only when Mattermost will truly delete the old one.
+
+        This inverts the base class's post-then-delete order. Mattermost can only
+        remove a post without leaving a "(message deleted)" tombstone when the
+        server permits a hard delete (v10.2+, ``EnableAPIPostDeletion``, and a
+        system-admin account). Reposting first and discovering the delete is
+        unavailable would strand a dead marker in the channel on *every*
+        message, so the delete is attempted first and the move is abandoned —
+        loudly — when it fails.
+        """
+        key = (channel_id, agent_name)
+        live = self._working_msg.get(key)
+        if live is None:
+            return
+
+        if not await self._permanent_delete(live.message_ref):
+            if channel_id not in self._no_hard_delete_warned:
+                self._no_hard_delete_warned.add(channel_id)
+                logger.warning(
+                    "Cannot move the runtime indicator in Mattermost channel %s: "
+                    "hard delete is unavailable, so the indicator would leave a "
+                    "marker behind each time it moved. It will stay where it was "
+                    "first posted. Requires Mattermost v10.2+ with "
+                    "ServiceSettings.EnableAPIPostDeletion and a system-admin "
+                    "account.",
+                    channel_id,
+                )
+            return
+
+        ref = await self.send_message(
+            channel_id, agent_name, live.body, live.thread_root_id
+        )
+        if ref is None:
+            # The old post is already gone, so there is nothing to fall back to.
+            self._working_msg.pop(key, None)
+            logger.error(
+                "Removed the runtime indicator for %s in %s but could not repost "
+                "it; the channel now shows no indicator for this turn",
+                agent_name,
+                channel_id,
+            )
+            return
+        self._working_msg[key] = replace(live, message_ref=ref)
+
     async def _dispose_working(self, channel_id: str, agent_name: str) -> None:
         """Remove the live "working on it…" message when the turn ends.
 
@@ -507,13 +556,13 @@ class MattermostAdapter(CollaborationAdapter):
         ``ServiceSettings.EnableAPIPostDeletion`` enabled and a system-admin
         account, so when it is unavailable we fall back to editing the message
         in place — never a soft delete, which would leave a tombstone."""
-        post_id = self._working_msg.pop((channel_id, agent_name), None)
-        if post_id is None:
+        live = self._working_msg.pop((channel_id, agent_name), None)
+        if live is None:
             return
-        if await self._permanent_delete(post_id):
+        if await self._permanent_delete(live.message_ref):
             return
         await self._patch_post_as(
-            agent_name, post_id, self.translate_outbound("✓ done")
+            agent_name, live.message_ref, self.translate_outbound("✓ done")
         )
 
     async def _permanent_delete(self, post_id: str) -> bool:

--- a/core/switch_core/bridges/collaboration/mattermost/adapter.py
+++ b/core/switch_core/bridges/collaboration/mattermost/adapter.py
@@ -440,7 +440,7 @@ class MattermostAdapter(CollaborationAdapter):
 
     # ── Runtime state ──────────────────────────────────────────────────────────
 
-    async def apply_runtime_state(
+    async def _apply_runtime_state(
         self,
         channel_id: str,
         agent_name: str,
@@ -503,7 +503,7 @@ class MattermostAdapter(CollaborationAdapter):
                 agent_name, post_id, self.translate_outbound("✓ input received")
             )
 
-    async def reposition_runtime_state(
+    async def _reposition_runtime_state(
         self, channel_id: str, agent_name: str, thread_root_id: str | None
     ) -> None:
         """Move the indicator only when Mattermost will truly delete the old one.
@@ -535,12 +535,6 @@ class MattermostAdapter(CollaborationAdapter):
                 )
             return
 
-        if self._working_msg.get(key) is not live:
-            # The turn ended while the delete was in flight. The old post is
-            # already gone and the entry with it, so there is nothing left to
-            # move — reposting now would strand an indicator no one will clear.
-            return
-
         ref = await self.send_message(channel_id, agent_name, live.body, thread_root_id)
         if ref is None:
             # The old post is already gone, so there is nothing to fall back to.
@@ -551,12 +545,6 @@ class MattermostAdapter(CollaborationAdapter):
                 agent_name,
                 channel_id,
             )
-            return
-
-        if self._working_msg.get(key) is not live:
-            # Same race, one step later: the replacement has no owner now, so
-            # take it back down rather than leave it in the channel.
-            await self._permanent_delete(ref)
             return
 
         self._working_msg[key] = replace(

--- a/core/switch_core/bridges/collaboration/slack/adapter.py
+++ b/core/switch_core/bridges/collaboration/slack/adapter.py
@@ -5,6 +5,7 @@ import re
 import uuid
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
+from dataclasses import replace
 
 import httpx
 from pydantic import BaseModel
@@ -14,7 +15,10 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web.async_client import AsyncWebClient
 
-from switch_core.bridges.collaboration.adapter import CollaborationAdapter
+from switch_core.bridges.collaboration.adapter import (
+    CollaborationAdapter,
+    LiveRuntimeIndicator,
+)
 from switch_core.bridges.collaboration.models import (
     Attachment,
     AttachmentFailure,
@@ -64,15 +68,6 @@ class SlackAdapter(CollaborationAdapter):
         # Slack mentions. Populated as users are resolved.
         self._username_to_id: dict[str, str] = {}
         self._thinking_ts: dict[tuple[str, str], str] = {}
-        # (channel_id, agent_name) -> message ref of the agent's live "working
-        # on it…" runtime-state message, so it can be deleted when the agent
-        # stops working. Slack can truly delete, so a persistent message is
-        # preferable to the ephemeral typing indicator here.
-        self._working_msg: dict[tuple[str, str], str] = {}
-        # (channel_id, agent_name) -> refs of the live "needs your input" pings,
-        # kept so they can be removed when the turn ends. The working indicator
-        # stays up alongside these — the agent is mid-turn, just paused.
-        self._input_pings: dict[tuple[str, str], list[str]] = {}
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
 
@@ -482,11 +477,16 @@ class SlackAdapter(CollaborationAdapter):
             existing = self._working_msg.get(key)
             if existing is not None:
                 # Refresh the live message in place with the latest activity.
-                await self.update_message(channel_id, existing, body)
+                # Position is a separate concern — see reposition_runtime_state,
+                # which moves the indicator when the conversation moves on.
+                await self.update_message(channel_id, existing.message_ref, body)
+                self._working_msg[key] = replace(existing, body=body)
                 return
             ref = await self.send_message(channel_id, agent_name, body, thread_root_id)
             if ref is not None:
-                self._working_msg[key] = ref
+                self._working_msg[key] = LiveRuntimeIndicator(
+                    message_ref=ref, body=body, thread_root_id=thread_root_id
+                )
         elif state == "awaiting-input":
             # Leave the working indicator up; add a ping and track it.
             ref = await self._ping_operator(
@@ -499,9 +499,9 @@ class SlackAdapter(CollaborationAdapter):
             await self._clear_input_pings(channel_id, agent_name)
 
     async def _clear_working(self, channel_id: str, agent_name: str) -> None:
-        ref = self._working_msg.pop((channel_id, agent_name), None)
-        if ref is not None:
-            await self.delete_message(channel_id, ref)
+        live = self._working_msg.pop((channel_id, agent_name), None)
+        if live is not None:
+            await self.delete_message(channel_id, live.message_ref)
 
     async def _clear_input_pings(self, channel_id: str, agent_name: str) -> None:
         refs = self._input_pings.pop((channel_id, agent_name), [])

--- a/core/switch_core/bridges/collaboration/slack/adapter.py
+++ b/core/switch_core/bridges/collaboration/slack/adapter.py
@@ -444,7 +444,7 @@ class SlackAdapter(CollaborationAdapter):
 
     # ── Runtime state ──────────────────────────────────────────────────────────
 
-    async def apply_runtime_state(
+    async def _apply_runtime_state(
         self,
         channel_id: str,
         agent_name: str,

--- a/core/switch_core/bridges/collaboration/teams/adapter.py
+++ b/core/switch_core/bridges/collaboration/teams/adapter.py
@@ -6,6 +6,7 @@ import logging
 import re
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import quote
@@ -14,7 +15,10 @@ import httpx
 from aiohttp import web
 from pydantic.json_schema import SkipJsonSchema
 
-from switch_core.bridges.collaboration.adapter import CollaborationAdapter
+from switch_core.bridges.collaboration.adapter import (
+    CollaborationAdapter,
+    LiveRuntimeIndicator,
+)
 from switch_core.bridges.collaboration.models import (
     BridgeConnectionConfig,
     ChannelType,
@@ -188,11 +192,6 @@ class TeamsAdapter(CollaborationAdapter):
         self._team_of_channel: dict[str, str] = {}
         self._sub_lock = asyncio.Lock()
         self._renewal_task: asyncio.Task[None] | None = None
-
-        # (channel_id, agent_name) -> live "working on it…" message ref.
-        self._working_msg: dict[tuple[str, str], str] = {}
-        # (channel_id, agent_name) -> live "needs your input" ping refs.
-        self._input_pings: dict[tuple[str, str], list[str]] = {}
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
 
@@ -558,11 +557,16 @@ class TeamsAdapter(CollaborationAdapter):
             body = self._working_body(detail, deeplink_url)
             existing = self._working_msg.get(key)
             if existing is not None:
-                await self._refresh_card(channel_id, existing, agent_name, body)
+                await self._refresh_card(
+                    channel_id, existing.message_ref, agent_name, body
+                )
+                self._working_msg[key] = replace(existing, body=body)
                 return
             ref = await self.send_message(channel_id, agent_name, body, thread_root_id)
             if ref is not None:
-                self._working_msg[key] = ref
+                self._working_msg[key] = LiveRuntimeIndicator(
+                    message_ref=ref, body=body, thread_root_id=thread_root_id
+                )
         elif state == "awaiting-input":
             ref = await self._ping_operator(
                 channel_id, agent_name, notify_user, thread_root_id, deeplink_url
@@ -587,9 +591,29 @@ class TeamsAdapter(CollaborationAdapter):
         )
 
     async def _clear_working(self, channel_id: str, agent_name: str) -> None:
-        ref = self._working_msg.pop((channel_id, agent_name), None)
-        if ref is not None:
-            await self.delete_message(channel_id, ref)
+        live = self._working_msg.pop((channel_id, agent_name), None)
+        if live is not None:
+            await self.delete_message(channel_id, live.message_ref)
+
+    async def _remove_runtime_indicator(
+        self, channel_id: str, message_ref: str
+    ) -> None:
+        """Drop a superseded indicator without letting a delete failure escape.
+
+        Unlike the other adapters, Teams' delete raises — on a missing connector
+        and on any non-2xx from the Bot Connector. When the indicator has
+        already been reposted elsewhere, a failure here means a stale duplicate
+        is left visible, which is preferable to aborting the turn."""
+        try:
+            await self.delete_message(channel_id, message_ref)
+        except (RuntimeError, httpx.HTTPError) as e:
+            logger.warning(
+                "Could not remove the superseded runtime indicator %s in %s (%s); "
+                "a stale copy may remain visible",
+                message_ref,
+                channel_id,
+                e,
+            )
 
     async def _clear_input_pings(self, channel_id: str, agent_name: str) -> None:
         refs = self._input_pings.pop((channel_id, agent_name), [])

--- a/core/switch_core/bridges/collaboration/teams/adapter.py
+++ b/core/switch_core/bridges/collaboration/teams/adapter.py
@@ -531,7 +531,7 @@ class TeamsAdapter(CollaborationAdapter):
 
     # ── Runtime state ──────────────────────────────────────────────────────────
 
-    async def apply_runtime_state(
+    async def _apply_runtime_state(
         self,
         channel_id: str,
         agent_name: str,

--- a/core/switch_core/events.py
+++ b/core/switch_core/events.py
@@ -154,6 +154,12 @@ class AgentRuntimeStateEvent(SwitchEvent):
     # place on the live working message. Transient — never persisted. Only
     # meaningful while `state == "working"`; None → generic "working on it…".
     detail: str | None = None
+    # Event id of the most recent message the agent has actually been handed.
+    # The bridge moves the runtime indicator below the conversation when this
+    # changes, so the indicator only claims the agent has seen a message once
+    # the agent really has. Unchanged between reports (e.g. the periodic
+    # activity refresh) means the indicator stays where it is.
+    anchor_event_id: str | None = None
 
 
 # ── Permission ────────────────────────────────────────────────────────────────

--- a/core/tests/switch_core/bridges/agent/api/test_beat_cursor_clamp.py
+++ b/core/tests/switch_core/bridges/agent/api/test_beat_cursor_clamp.py
@@ -1,0 +1,128 @@
+"""A heartbeat cursor is clamped to the buffer head before anything adopts it.
+
+The event buffer is in memory, so restarting switch-core resets the sequence to
+zero while clients keep beating the number they had reached. Nothing downstream
+can undo that: `beat()` and `confirm()` both refuse to move a cursor backwards,
+and the stream's own rewind on resume is re-poisoned by the next heartbeat two
+seconds later.
+
+The result is silent. The connection is claimed, heartbeats succeed and posting
+works, so the session looks healthy while every event up to the stale cursor is
+skipped — and `confirm()` marks those events consumed on the way past.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from switch_core.bridges.agent.api.handlers import connection_beat
+from switch_core.bridges.agent.api.schemas import ConnectionBeatRequest
+from switch_core.bridges.agent.protocol.connections import (
+    PROTOCOL_VERSION,
+    ConnectionRegistry,
+)
+from switch_core.bridges.agent.protocol.event_buffer import EventBuffer
+from switch_core.bridges.agent.protocol.types import AgentEvent, MessagePayload
+
+AGENT_ID = "agent-1"
+CONN_ID = "conn-1"
+ROOM_ID = "room-1"
+
+
+class _Protocol:
+    def __init__(self) -> None:
+        self.event_buffer = EventBuffer()
+        self.connections = ConnectionRegistry()
+
+
+def _message() -> AgentEvent:
+    return AgentEvent(
+        type="message",
+        room_id=ROOM_ID,
+        payload=MessagePayload(
+            addressed=True,
+            sender="@u:s",
+            sender_name="u",
+            message_id="$m",
+            body="hi",
+            timestamp=0,
+        ),
+    )
+
+
+def _connect(protocol: _Protocol, cursor: int = 0) -> Any:
+    conn = protocol.connections.open(
+        agent_id=AGENT_ID,
+        connection_id=CONN_ID,
+        scope="single",
+        delivery_filter="all",
+        spawn_capable=False,
+        cursor=cursor,
+        protocol_version=PROTOCOL_VERSION,
+    )
+    conn.stream_attached = True
+    return conn
+
+
+async def _beat(protocol: _Protocol, cursor: int) -> Any:
+    return await connection_beat(
+        AGENT_ID,
+        ConnectionBeatRequest(connection_id=CONN_ID, cursor=cursor),
+        SimpleNamespace(id=AGENT_ID),  # type: ignore[arg-type]
+        protocol,  # type: ignore[arg-type]
+    )
+
+
+async def test_a_cursor_past_the_head_is_pulled_back_to_it() -> None:
+    # The restart case: the buffer is empty (head 0) and the client is still
+    # beating the sequence it reached before the process died.
+    protocol = _Protocol()
+    conn = _connect(protocol)
+
+    result = await _beat(protocol, cursor=9)
+
+    assert protocol.event_buffer.head(AGENT_ID) == 0
+    assert conn.cursor == 0
+    assert result["cursor"] == 0
+
+
+async def test_the_first_event_after_a_restart_is_still_delivered() -> None:
+    # The symptom the clamp exists to prevent: without it the connection sits at
+    # cursor 9, and sequences 1..9 — including the message that arrives next —
+    # are skipped with no error anywhere.
+    protocol = _Protocol()
+    conn = _connect(protocol)
+    protocol.connections.claim_room(conn, ROOM_ID, takeover=True)
+
+    await _beat(protocol, cursor=9)
+    protocol.event_buffer.enqueue(AGENT_ID, ROOM_ID, _message())
+
+    delivered = protocol.event_buffer.read_from(AGENT_ID, conn.cursor, rooms={ROOM_ID})
+    assert [item.seq for item in delivered] == [1]
+
+
+async def test_a_cursor_within_the_buffer_is_left_alone() -> None:
+    protocol = _Protocol()
+    conn = _connect(protocol)
+    for _ in range(3):
+        protocol.event_buffer.enqueue(AGENT_ID, ROOM_ID, _message())
+
+    await _beat(protocol, cursor=2)
+
+    assert conn.cursor == 2
+
+
+async def test_the_clamped_value_is_what_gets_confirmed() -> None:
+    # confirm() drives retention. Handing it the stale cursor would mark events
+    # consumed that were never delivered, so the clamp has to reach it too.
+    protocol = _Protocol()
+    _connect(protocol)
+    confirmed: list[int] = []
+    protocol.event_buffer.confirm = (  # type: ignore[method-assign]
+        lambda agent_id, connection_id, cursor: confirmed.append(cursor)
+    )
+
+    await _beat(protocol, cursor=9)
+
+    assert confirmed == [0]

--- a/core/tests/switch_core/bridges/agent/operations/test_binding_row_is_legacy_only.py
+++ b/core/tests/switch_core/bridges/agent/operations/test_binding_row_is_legacy_only.py
@@ -1,0 +1,117 @@
+"""The room binding row is written only for callers with no connection.
+
+A connection carries its own rooms, so a row written for one records a binding
+nothing reads. It matters because that row has no liveness check and no expiry:
+it outlives the connection it was written for and keeps answering room-scoped
+calls. A connection that reopens without re-claiming its room then looks
+connected to the send path while delivery, which reads the connection, has
+nothing — the agent posts into a room it is no longer receiving from, and
+neither side can see the discrepancy.
+
+MCP transport sessions have no connection and the row is the only thing holding
+them to a room, so it is still written for them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from switch_core.bridges.agent.operations.definitions import (
+    bind_room_for_connectionless_caller,
+)
+from switch_core.bridges.agent.protocol.connections import (
+    PROTOCOL_VERSION,
+    ConnectionRegistry,
+)
+
+AGENT = "agent-1"
+ROOM = "room-1"
+CONN = "conn-1"
+
+
+class _RecordingSessionStore:
+    """Captures binding-row writes without a database."""
+
+    def __init__(self) -> None:
+        self.writes: list[dict[str, Any]] = []
+
+    async def set_connected_room(self, _db: Any, **kwargs: Any) -> None:
+        self.writes.append(kwargs)
+
+
+def _open(registry: ConnectionRegistry, connection_id: str) -> Any:
+    return registry.open(
+        agent_id=AGENT,
+        connection_id=connection_id,
+        scope="single",
+        delivery_filter="all",
+        spawn_capable=False,
+        cursor=0,
+        protocol_version=PROTOCOL_VERSION,
+    )
+
+
+async def _write_binding_row_if_needed(protocol: Any, key: str) -> bool:
+    return await bind_room_for_connectionless_caller(
+        protocol,
+        agent_id=AGENT,
+        connection_id=key,
+        room_id=ROOM,
+        connection_model="session_addressable",
+    )
+
+
+def _protocol(registry: ConnectionRegistry, store: _RecordingSessionStore) -> Any:
+    class _Db:
+        async def __aenter__(self) -> Any:
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+        async def commit(self) -> None:
+            return None
+
+    return SimpleNamespace(
+        connections=registry,
+        agent_session_store=store,
+        session_factory=lambda: _Db(),
+    )
+
+
+async def test_no_row_is_written_for_a_connection_backed_caller() -> None:
+    registry = ConnectionRegistry()
+    _open(registry, CONN)
+    store = _RecordingSessionStore()
+
+    await _write_binding_row_if_needed(_protocol(registry, store), CONN)
+
+    assert store.writes == []
+
+
+async def test_the_row_is_still_written_for_an_mcp_transport_session() -> None:
+    # No connection was ever opened for this key, so the row is the only thing
+    # that can resolve the caller's room.
+    registry = ConnectionRegistry()
+    store = _RecordingSessionStore()
+
+    await _write_binding_row_if_needed(_protocol(registry, store), "mcp-session-1")
+
+    assert len(store.writes) == 1
+    assert store.writes[0]["transport_session_id"] == "mcp-session-1"
+    assert store.writes[0]["room_id"] == ROOM
+
+
+async def test_a_closed_connection_falls_back_to_writing_the_row() -> None:
+    # A runtime reusing a key whose connection has expired is indistinguishable
+    # from an MCP transport session, and resolves the same way.
+    registry = ConnectionRegistry()
+    _open(registry, CONN)
+    registry.close(CONN, "gone")
+    store = _RecordingSessionStore()
+
+    await _write_binding_row_if_needed(_protocol(registry, store), CONN)
+
+    assert len(store.writes) == 1
+    assert store.writes[0]["transport_session_id"] == CONN

--- a/core/tests/switch_core/bridges/collaboration/test_bridge_inbound_media.py
+++ b/core/tests/switch_core/bridges/collaboration/test_bridge_inbound_media.py
@@ -61,6 +61,9 @@ class _FakeAdapter:
     def translate_inbound(self, content: str) -> str:
         return content
 
+    def agents_with_live_runtime_state(self, channel_id: str) -> list[str]:
+        return []
+
 
 def _fake_bridge() -> SimpleNamespace:
     puppet = _FakePuppet()
@@ -75,7 +78,7 @@ def _fake_bridge() -> SimpleNamespace:
     async def _record_message_map(**kwargs: str) -> None:
         recorded.append(kwargs)
 
-    return SimpleNamespace(
+    ns = SimpleNamespace(
         _adapter=_FakeAdapter(),
         _channel_to_room={"chan-1": ("room-1", "!room:s")},
         _is_registered_agent=_is_registered_agent,
@@ -83,7 +86,13 @@ def _fake_bridge() -> SimpleNamespace:
         _record_message_map=_record_message_map,
         puppet=puppet,
         recorded=recorded,
+        _indicator_move_timers={},
     )
+    ns._move_indicators_for_addressees = (
+        BridgeCore._move_indicators_for_addressees.__get__(ns)
+    )
+    ns._schedule_indicator_move = BridgeCore._schedule_indicator_move.__get__(ns)
+    return ns
 
 
 def _msg(

--- a/core/tests/switch_core/bridges/collaboration/test_bridge_inbound_media.py
+++ b/core/tests/switch_core/bridges/collaboration/test_bridge_inbound_media.py
@@ -61,9 +61,6 @@ class _FakeAdapter:
     def translate_inbound(self, content: str) -> str:
         return content
 
-    def agents_with_live_runtime_state(self, channel_id: str) -> list[str]:
-        return []
-
 
 def _fake_bridge() -> SimpleNamespace:
     puppet = _FakePuppet()
@@ -86,12 +83,7 @@ def _fake_bridge() -> SimpleNamespace:
         _record_message_map=_record_message_map,
         puppet=puppet,
         recorded=recorded,
-        _indicator_move_timers={},
     )
-    ns._move_indicators_for_addressees = (
-        BridgeCore._move_indicators_for_addressees.__get__(ns)
-    )
-    ns._schedule_indicator_move = BridgeCore._schedule_indicator_move.__get__(ns)
     return ns
 
 

--- a/core/tests/switch_core/bridges/collaboration/test_bridge_indicator_position.py
+++ b/core/tests/switch_core/bridges/collaboration/test_bridge_indicator_position.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+from switch_core.bridges.collaboration.bridge_core import BridgeCore
+
+
+class _FakeAdapter:
+    def __init__(self, live: list[str]) -> None:
+        self._live = live
+        self.moved: list[tuple[str, str]] = []
+
+    def agents_with_live_runtime_state(self, channel_id: str) -> list[str]:
+        return list(self._live)
+
+    async def reposition_runtime_state(self, channel_id: str, agent_name: str) -> None:
+        self.moved.append((channel_id, agent_name))
+
+
+def _bridge(live: list[str], *, aliases: dict[str, str] | None = None) -> Any:
+    """A BridgeCore stand-in wired to the real positioning methods."""
+    adapter = _FakeAdapter(live)
+    alias_map = aliases or {}
+
+    class _RoomStore:
+        async def get_agent_id_by_alias(
+            self, _session: Any, _room_id: str, alias: str
+        ) -> str | None:
+            return alias_map.get(alias.lower())
+
+    class _AgentStore:
+        async def get(self, _session: Any, agent_id: str) -> Any:
+            return SimpleNamespace(name=agent_id)
+
+    class _Session:
+        async def __aenter__(self) -> Any:
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+    ns = SimpleNamespace(
+        _adapter=adapter,
+        _room_store=_RoomStore(),
+        _agent_store=_AgentStore(),
+        _session_factory=lambda: _Session(),
+        _indicator_move_timers={},
+        adapter_spy=adapter,
+    )
+    for name in (
+        "_move_indicator_for_sender",
+        "_move_indicators_for_addressees",
+        "_live_agents_addressed_by_alias",
+        "_schedule_indicator_move",
+        "_run_indicator_move",
+    ):
+        setattr(ns, name, getattr(BridgeCore, name).__get__(ns))
+    return ns
+
+
+def _drain(bridge: Any, coro: Any) -> list[tuple[str, str]]:
+    """Run `coro`, then let every queued move fire, and report what moved."""
+
+    async def _go() -> None:
+        await coro
+        timers = list(bridge._indicator_move_timers.values())
+        # Fire the coalescing timers immediately rather than waiting them out.
+        for timer in timers:
+            timer.cancel()
+        for key in list(bridge._indicator_move_timers):
+            await bridge._run_indicator_move(key)
+
+    asyncio.run(_go())
+    return bridge.adapter_spy.moved
+
+
+def _addressees(bridge: Any, content: str, channel_type: str = "channel_public") -> Any:
+    return bridge._move_indicators_for_addressees(
+        channel_id="chan-1",
+        room_id="room-1",
+        channel_type=channel_type,
+        content=content,
+        mention_target=None,
+    )
+
+
+# ── Inbound: only agents the message addresses ──────────────────────────────
+
+
+def test_addressed_agent_indicator_follows_the_message() -> None:
+    bridge = _bridge(["agent-a"])
+
+    moved = _drain(bridge, _addressees(bridge, "@agent-a can you look at this?"))
+
+    assert moved == [("chan-1", "agent-a")]
+
+
+def test_unaddressed_chatter_leaves_the_indicator_alone() -> None:
+    # The whole point of scoping this per agent: a busy channel must not drag a
+    # working agent's indicator around on traffic that has nothing to do with it.
+    bridge = _bridge(["agent-a"])
+
+    moved = _drain(bridge, _addressees(bridge, "unrelated chatter between humans"))
+
+    assert moved == []
+
+
+def test_only_the_addressed_agent_of_several_moves() -> None:
+    bridge = _bridge(["agent-a", "agent-b"])
+
+    moved = _drain(bridge, _addressees(bridge, "@agent-b over to you"))
+
+    assert moved == [("chan-1", "agent-b")]
+
+
+def test_a_prefix_of_a_longer_name_is_not_treated_as_addressed() -> None:
+    bridge = _bridge(["agent-a"])
+
+    moved = _drain(bridge, _addressees(bridge, "@agent-a-2 please take this"))
+
+    assert moved == []
+
+
+def test_agent_addressed_by_its_room_alias_moves() -> None:
+    bridge = _bridge(["agent-a"], aliases={"worker": "agent-a"})
+
+    moved = _drain(bridge, _addressees(bridge, "@worker ping"))
+
+    assert moved == [("chan-1", "agent-a")]
+
+
+def test_every_message_addresses_the_agent_in_a_dm_room() -> None:
+    bridge = _bridge(["agent-a"])
+
+    moved = _drain(
+        bridge, _addressees(bridge, "no mention here", channel_type="direct")
+    )
+
+    assert moved == [("chan-1", "agent-a")]
+
+
+def test_nothing_is_scheduled_when_no_indicator_is_live() -> None:
+    bridge = _bridge([])
+
+    moved = _drain(bridge, _addressees(bridge, "@agent-a hello"))
+
+    assert moved == []
+
+
+# ── Outbound: the agent's own messages ──────────────────────────────────────
+
+
+def test_indicator_follows_a_message_the_agent_posts() -> None:
+    bridge = _bridge(["agent-a"])
+
+    moved = _drain(bridge, bridge._move_indicator_for_sender("chan-1", "agent-a"))
+
+    assert moved == [("chan-1", "agent-a")]
+
+
+def test_another_agents_message_does_not_move_this_indicator() -> None:
+    bridge = _bridge(["agent-a"])
+
+    moved = _drain(bridge, bridge._move_indicator_for_sender("chan-1", "agent-b"))
+
+    assert moved == []
+
+
+# ── Coalescing ──────────────────────────────────────────────────────────────
+
+
+def test_a_burst_of_messages_costs_a_single_move() -> None:
+    bridge = _bridge(["agent-a"])
+    scheduled: list[Any] = []
+
+    async def burst() -> None:
+        for _ in range(20):
+            await _addressees(bridge, "@agent-a another one")
+            scheduled.append(bridge._indicator_move_timers[("chan-1", "agent-a")])
+
+    moved = _drain(bridge, burst())
+
+    # One timer object throughout: later messages were absorbed into the queued
+    # move rather than each scheduling their own.
+    assert len(scheduled) == 20
+    assert all(timer is scheduled[0] for timer in scheduled)
+    assert moved == [("chan-1", "agent-a")]
+
+
+def test_a_later_message_does_not_push_the_queued_move_back() -> None:
+    # A sustained conversation must not starve the move by resetting its timer
+    # on every message, so the deadline is set once and left alone.
+    bridge = _bridge(["agent-a"])
+    deadlines: list[float] = []
+
+    async def burst() -> None:
+        for _ in range(3):
+            await _addressees(bridge, "@agent-a keep talking")
+            deadlines.append(
+                bridge._indicator_move_timers[("chan-1", "agent-a")].when()
+            )
+
+    _drain(bridge, burst())
+
+    assert len(set(deadlines)) == 1
+
+
+def test_a_platform_failure_during_a_move_does_not_escape() -> None:
+    # The indicator is cosmetic; a failed move must not propagate into the
+    # bridge callback that happened to trigger it.
+    bridge = _bridge(["agent-a"])
+
+    async def boom(_channel_id: str, _agent_name: str) -> None:
+        raise RuntimeError("platform down")
+
+    bridge._adapter.reposition_runtime_state = boom
+
+    asyncio.run(bridge._run_indicator_move(("chan-1", "agent-a")))

--- a/core/tests/switch_core/bridges/collaboration/test_bridge_indicator_position.py
+++ b/core/tests/switch_core/bridges/collaboration/test_bridge_indicator_position.py
@@ -23,43 +23,21 @@ class _FakeAdapter:
         self.targets.append(thread_root_id)
 
 
-def _bridge(live: list[str], *, aliases: dict[str, str] | None = None) -> Any:
+def _bridge(live: list[str]) -> Any:
     """A BridgeCore stand-in wired to the real positioning methods."""
     adapter = _FakeAdapter(live)
-    alias_map = aliases or {}
-
-    class _RoomStore:
-        async def get_agent_id_by_alias(
-            self, _session: Any, _room_id: str, alias: str
-        ) -> str | None:
-            return alias_map.get(alias.lower())
-
-    class _AgentStore:
-        async def get(self, _session: Any, agent_id: str) -> Any:
-            return SimpleNamespace(name=agent_id)
-
-    class _Session:
-        async def __aenter__(self) -> Any:
-            return self
-
-        async def __aexit__(self, *_exc: Any) -> None:
-            return None
-
     ns = SimpleNamespace(
         _adapter=adapter,
-        _room_store=_RoomStore(),
-        _agent_store=_AgentStore(),
-        _session_factory=lambda: _Session(),
         _indicator_move_timers={},
         _indicator_move_targets={},
+        _reported_anchors={},
         adapter_spy=adapter,
     )
     for name in (
         "_move_indicator_for_sender",
-        "_move_indicators_for_addressees",
-        "_live_agents_addressed_by_alias",
         "_schedule_indicator_move",
         "_run_indicator_move",
+        "_follow_reported_anchor",
     ):
         setattr(ns, name, getattr(BridgeCore, name).__get__(ns))
     return ns
@@ -70,9 +48,7 @@ def _drain(bridge: Any, coro: Any) -> list[tuple[str, str]]:
 
     async def _go() -> None:
         await coro
-        timers = list(bridge._indicator_move_timers.values())
-        # Fire the coalescing timers immediately rather than waiting them out.
-        for timer in timers:
+        for timer in list(bridge._indicator_move_timers.values()):
             timer.cancel()
         for key in list(bridge._indicator_move_timers):
             await bridge._run_indicator_move(key)
@@ -81,89 +57,101 @@ def _drain(bridge: Any, coro: Any) -> list[tuple[str, str]]:
     return bridge.adapter_spy.moved
 
 
-def _addressees(
-    bridge: Any,
-    content: str,
-    channel_type: str = "channel_public",
-    thread_root_id: str | None = None,
+def _anchor(
+    bridge: Any, anchor_event_id: str | None, *, thread: str | None = None
 ) -> Any:
-    return bridge._move_indicators_for_addressees(
-        channel_id="chan-1",
-        room_id="room-1",
-        channel_type=channel_type,
-        content=content,
-        mention_target=None,
-        thread_root_id=thread_root_id,
+    return bridge._follow_reported_anchor(
+        "chan-1", "agent-a", "working", anchor_event_id, thread
     )
 
 
-# ── Inbound: only agents the message addresses ──────────────────────────────
+# ── Inbound: driven by what the agent reports it has received ───────────────
 
 
-def test_addressed_agent_indicator_follows_the_message() -> None:
+def test_a_new_reported_anchor_moves_the_indicator() -> None:
     bridge = _bridge(["agent-a"])
 
-    moved = _drain(bridge, _addressees(bridge, "@agent-a can you look at this?"))
+    async def go() -> None:
+        await _anchor(bridge, "$m1")
+        await _anchor(bridge, "$m2")
 
-    assert moved == [("chan-1", "agent-a")]
+    assert _drain(bridge, go()) == [("chan-1", "agent-a")]
 
 
-def test_unaddressed_chatter_leaves_the_indicator_alone() -> None:
-    # The whole point of scoping this per agent: a busy channel must not drag a
-    # working agent's indicator around on traffic that has nothing to do with it.
+def test_the_first_anchor_of_a_turn_moves_nothing() -> None:
+    # The indicator was only just posted against that message.
     bridge = _bridge(["agent-a"])
 
-    moved = _drain(bridge, _addressees(bridge, "unrelated chatter between humans"))
-
-    assert moved == []
+    assert _drain(bridge, _anchor(bridge, "$m1")) == []
 
 
-def test_only_the_addressed_agent_of_several_moves() -> None:
-    bridge = _bridge(["agent-a", "agent-b"])
-
-    moved = _drain(bridge, _addressees(bridge, "@agent-b over to you"))
-
-    assert moved == [("chan-1", "agent-b")]
-
-
-def test_a_prefix_of_a_longer_name_is_not_treated_as_addressed() -> None:
+def test_repeating_the_same_anchor_moves_nothing() -> None:
+    # The 5s activity refresh replays the current anchor; it must not churn.
     bridge = _bridge(["agent-a"])
 
-    moved = _drain(bridge, _addressees(bridge, "@agent-a-2 please take this"))
+    async def go() -> None:
+        await _anchor(bridge, "$m1")
+        for _ in range(5):
+            await _anchor(bridge, "$m1")
 
-    assert moved == []
-
-
-def test_agent_addressed_by_its_room_alias_moves() -> None:
-    bridge = _bridge(["agent-a"], aliases={"worker": "agent-a"})
-
-    moved = _drain(bridge, _addressees(bridge, "@worker ping"))
-
-    assert moved == [("chan-1", "agent-a")]
+    assert _drain(bridge, go()) == []
 
 
-def test_every_message_addresses_the_agent_in_a_dm_room() -> None:
+def test_a_message_the_agent_has_not_been_given_moves_nothing() -> None:
+    # The whole point of the redesign: arriving in the room is not evidence the
+    # agent saw it, so only what the agent reports may move the indicator.
     bridge = _bridge(["agent-a"])
 
-    moved = _drain(
-        bridge, _addressees(bridge, "no mention here", channel_type="direct")
-    )
+    async def go() -> None:
+        await _anchor(bridge, "$m1")
+        # A message lands in the room, but the agent is busy and is never
+        # handed it — so no new anchor is ever reported.
+        await _anchor(bridge, "$m1")
 
-    assert moved == [("chan-1", "agent-a")]
+    assert _drain(bridge, go()) == []
 
 
-def test_nothing_is_scheduled_when_no_indicator_is_live() -> None:
-    bridge = _bridge([])
+def test_a_report_without_an_anchor_moves_nothing() -> None:
+    # Connectors that don't report anchors simply never reposition.
+    bridge = _bridge(["agent-a"])
 
-    moved = _drain(bridge, _addressees(bridge, "@agent-a hello"))
+    async def go() -> None:
+        await _anchor(bridge, "$m1")
+        await _anchor(bridge, None)
 
-    assert moved == []
+    assert _drain(bridge, go()) == []
+
+
+def test_the_move_lands_in_the_thread_of_the_reported_message() -> None:
+    bridge = _bridge(["agent-a"])
+
+    async def go() -> None:
+        await _anchor(bridge, "$m1", thread=None)
+        await _anchor(bridge, "$m2", thread="root-7")
+
+    _drain(bridge, go())
+
+    assert bridge.adapter_spy.targets == ["root-7"]
+
+
+def test_the_anchor_resets_when_the_turn_ends() -> None:
+    # A later turn's first anchor must not be mistaken for a move within the
+    # previous one.
+    bridge = _bridge(["agent-a"])
+
+    async def go() -> None:
+        await _anchor(bridge, "$m1")
+        await bridge._follow_reported_anchor("chan-1", "agent-a", "idle", None, None)
+        await _anchor(bridge, "$m2")
+
+    assert _drain(bridge, go()) == []
 
 
 # ── Outbound: the agent's own messages ──────────────────────────────────────
 
 
 def test_indicator_follows_a_message_the_agent_posts() -> None:
+    # No ambiguity here — the agent demonstrably acted, so core may move it.
     bridge = _bridge(["agent-a"])
 
     moved = _drain(bridge, bridge._move_indicator_for_sender("chan-1", "agent-a", None))
@@ -179,77 +167,27 @@ def test_another_agents_message_does_not_move_this_indicator() -> None:
     assert moved == []
 
 
-# ── Threads ─────────────────────────────────────────────────────────────────
+def test_nothing_moves_when_no_indicator_is_live() -> None:
+    bridge = _bridge([])
+
+    moved = _drain(bridge, bridge._move_indicator_for_sender("chan-1", "agent-a", None))
+
+    assert moved == []
 
 
-def test_the_move_targets_the_thread_the_message_arrived_in() -> None:
-    bridge = _bridge(["agent-a"])
-
-    _drain(bridge, _addressees(bridge, "@agent-a in here", thread_root_id="root-7"))
-
-    assert bridge.adapter_spy.targets == ["root-7"]
-
-
-def test_a_coalesced_burst_lands_in_the_most_recent_thread() -> None:
-    # The indicator should follow where the conversation ended up, not where it
-    # was when the coalescing window opened.
-    bridge = _bridge(["agent-a"])
-
-    async def burst() -> None:
-        await _addressees(bridge, "@agent-a first", thread_root_id="root-1")
-        await _addressees(bridge, "@agent-a second", thread_root_id="root-2")
-        await _addressees(bridge, "@agent-a third", thread_root_id="root-3")
-
-    _drain(bridge, burst())
-
-    assert bridge.adapter_spy.targets == ["root-3"]
-
-
-def test_a_message_at_the_channel_root_brings_the_indicator_back_out() -> None:
-    bridge = _bridge(["agent-a"])
-
-    _drain(bridge, _addressees(bridge, "@agent-a out here", thread_root_id=None))
-
-    assert bridge.adapter_spy.targets == [None]
-
-
-# ── Coalescing ──────────────────────────────────────────────────────────────
-
-
-def test_a_burst_of_messages_costs_a_single_move() -> None:
+def test_a_burst_of_agent_posts_costs_a_single_move() -> None:
     bridge = _bridge(["agent-a"])
     scheduled: list[Any] = []
 
     async def burst() -> None:
         for _ in range(20):
-            await _addressees(bridge, "@agent-a another one")
+            await bridge._move_indicator_for_sender("chan-1", "agent-a", None)
             scheduled.append(bridge._indicator_move_timers[("chan-1", "agent-a")])
 
     moved = _drain(bridge, burst())
 
-    # One timer object throughout: later messages were absorbed into the queued
-    # move rather than each scheduling their own.
-    assert len(scheduled) == 20
     assert all(timer is scheduled[0] for timer in scheduled)
     assert moved == [("chan-1", "agent-a")]
-
-
-def test_a_later_message_does_not_push_the_queued_move_back() -> None:
-    # A sustained conversation must not starve the move by resetting its timer
-    # on every message, so the deadline is set once and left alone.
-    bridge = _bridge(["agent-a"])
-    deadlines: list[float] = []
-
-    async def burst() -> None:
-        for _ in range(3):
-            await _addressees(bridge, "@agent-a keep talking")
-            deadlines.append(
-                bridge._indicator_move_timers[("chan-1", "agent-a")].when()
-            )
-
-    _drain(bridge, burst())
-
-    assert len(set(deadlines)) == 1
 
 
 def test_a_platform_failure_during_a_move_does_not_escape() -> None:

--- a/core/tests/switch_core/bridges/collaboration/test_bridge_indicator_position.py
+++ b/core/tests/switch_core/bridges/collaboration/test_bridge_indicator_position.py
@@ -11,12 +11,16 @@ class _FakeAdapter:
     def __init__(self, live: list[str]) -> None:
         self._live = live
         self.moved: list[tuple[str, str]] = []
+        self.targets: list[str | None] = []
 
     def agents_with_live_runtime_state(self, channel_id: str) -> list[str]:
         return list(self._live)
 
-    async def reposition_runtime_state(self, channel_id: str, agent_name: str) -> None:
+    async def reposition_runtime_state(
+        self, channel_id: str, agent_name: str, thread_root_id: str | None
+    ) -> None:
         self.moved.append((channel_id, agent_name))
+        self.targets.append(thread_root_id)
 
 
 def _bridge(live: list[str], *, aliases: dict[str, str] | None = None) -> Any:
@@ -47,6 +51,7 @@ def _bridge(live: list[str], *, aliases: dict[str, str] | None = None) -> Any:
         _agent_store=_AgentStore(),
         _session_factory=lambda: _Session(),
         _indicator_move_timers={},
+        _indicator_move_targets={},
         adapter_spy=adapter,
     )
     for name in (
@@ -76,13 +81,19 @@ def _drain(bridge: Any, coro: Any) -> list[tuple[str, str]]:
     return bridge.adapter_spy.moved
 
 
-def _addressees(bridge: Any, content: str, channel_type: str = "channel_public") -> Any:
+def _addressees(
+    bridge: Any,
+    content: str,
+    channel_type: str = "channel_public",
+    thread_root_id: str | None = None,
+) -> Any:
     return bridge._move_indicators_for_addressees(
         channel_id="chan-1",
         room_id="room-1",
         channel_type=channel_type,
         content=content,
         mention_target=None,
+        thread_root_id=thread_root_id,
     )
 
 
@@ -155,7 +166,7 @@ def test_nothing_is_scheduled_when_no_indicator_is_live() -> None:
 def test_indicator_follows_a_message_the_agent_posts() -> None:
     bridge = _bridge(["agent-a"])
 
-    moved = _drain(bridge, bridge._move_indicator_for_sender("chan-1", "agent-a"))
+    moved = _drain(bridge, bridge._move_indicator_for_sender("chan-1", "agent-a", None))
 
     assert moved == [("chan-1", "agent-a")]
 
@@ -163,9 +174,43 @@ def test_indicator_follows_a_message_the_agent_posts() -> None:
 def test_another_agents_message_does_not_move_this_indicator() -> None:
     bridge = _bridge(["agent-a"])
 
-    moved = _drain(bridge, bridge._move_indicator_for_sender("chan-1", "agent-b"))
+    moved = _drain(bridge, bridge._move_indicator_for_sender("chan-1", "agent-b", None))
 
     assert moved == []
+
+
+# ── Threads ─────────────────────────────────────────────────────────────────
+
+
+def test_the_move_targets_the_thread_the_message_arrived_in() -> None:
+    bridge = _bridge(["agent-a"])
+
+    _drain(bridge, _addressees(bridge, "@agent-a in here", thread_root_id="root-7"))
+
+    assert bridge.adapter_spy.targets == ["root-7"]
+
+
+def test_a_coalesced_burst_lands_in_the_most_recent_thread() -> None:
+    # The indicator should follow where the conversation ended up, not where it
+    # was when the coalescing window opened.
+    bridge = _bridge(["agent-a"])
+
+    async def burst() -> None:
+        await _addressees(bridge, "@agent-a first", thread_root_id="root-1")
+        await _addressees(bridge, "@agent-a second", thread_root_id="root-2")
+        await _addressees(bridge, "@agent-a third", thread_root_id="root-3")
+
+    _drain(bridge, burst())
+
+    assert bridge.adapter_spy.targets == ["root-3"]
+
+
+def test_a_message_at_the_channel_root_brings_the_indicator_back_out() -> None:
+    bridge = _bridge(["agent-a"])
+
+    _drain(bridge, _addressees(bridge, "@agent-a out here", thread_root_id=None))
+
+    assert bridge.adapter_spy.targets == [None]
 
 
 # ── Coalescing ──────────────────────────────────────────────────────────────
@@ -212,7 +257,9 @@ def test_a_platform_failure_during_a_move_does_not_escape() -> None:
     # bridge callback that happened to trigger it.
     bridge = _bridge(["agent-a"])
 
-    async def boom(_channel_id: str, _agent_name: str) -> None:
+    async def boom(
+        _channel_id: str, _agent_name: str, _thread_root_id: str | None
+    ) -> None:
         raise RuntimeError("platform down")
 
     bridge._adapter.reposition_runtime_state = boom

--- a/core/tests/switch_core/bridges/collaboration/test_bridge_outbound_media.py
+++ b/core/tests/switch_core/bridges/collaboration/test_bridge_outbound_media.py
@@ -54,6 +54,9 @@ class _FakeAdapter:
         self.batches: list[dict[str, Any]] = []
         self.messages: list[dict[str, Any]] = []
 
+    def agents_with_live_runtime_state(self, channel_id: str) -> list[str]:
+        return []
+
     async def send_attachment(
         self,
         channel_id,
@@ -132,6 +135,7 @@ def _fake_bridge(
         recorded=recorded,
         _outbound_groups={},
         _outbound_group_timers={},
+        _indicator_move_timers={},
     )
     ns._find_channel = lambda room_id=None, matrix_room_id=None: (
         "chan-1" if matrix_room_id == "!room:s" else None
@@ -145,6 +149,8 @@ def _fake_bridge(
         ns
     )
     ns._relay_outbound_group = BridgeCore._relay_outbound_group.__get__(ns)
+    ns._move_indicator_for_sender = BridgeCore._move_indicator_for_sender.__get__(ns)
+    ns._schedule_indicator_move = BridgeCore._schedule_indicator_move.__get__(ns)
     ns._flush_incomplete_outbound_group = (
         BridgeCore._flush_incomplete_outbound_group.__get__(ns)
     )

--- a/core/tests/switch_core/bridges/collaboration/test_discord_adapter.py
+++ b/core/tests/switch_core/bridges/collaboration/test_discord_adapter.py
@@ -163,7 +163,9 @@ class _FakeWebhook:
         self.token = token
         self.sent: list[dict[str, Any]] = []
         self.edits: list[dict[str, Any]] = []
+        self.deletes: list[dict[str, Any]] = []
         self.edit_raises_not_found = False
+        self.delete_raises_not_found = False
 
     async def send(self, **kwargs: Any) -> Any:
         self.sent.append(kwargs)
@@ -175,6 +177,11 @@ class _FakeWebhook:
         if self.edit_raises_not_found:
             raise discord.NotFound(_FakeResponse(), "unknown message")
         self.edits.append({"message_id": message_id, **kwargs})
+
+    async def delete_message(self, message_id: int, **kwargs: Any) -> None:
+        if self.delete_raises_not_found:
+            raise discord.NotFound(_FakeResponse(), "unknown message")
+        self.deletes.append({"message_id": message_id, **kwargs})
 
 
 class _FakeClient:
@@ -739,9 +746,44 @@ def test_update_message_falls_back_to_bot_message_edit() -> None:
     assert bot_msg.edited == "edited"
 
 
-def test_delete_message_uses_partial_message_in_location_channel() -> None:
+def test_delete_message_goes_through_the_webhook_that_sent_it() -> None:
+    # Agent posts are authored by the webhook, not the bot. Deleting them as the
+    # bot needs Manage Messages and silently fails without it, which left every
+    # runtime indicator stranded in the channel.
     adapter = _adapter()
     channel = _FakeChannel()
+    webhook = _FakeWebhook()
+    channel.existing_webhooks = [webhook]
+    adapter._client = _FakeClient({CHANNEL_ID: channel})
+
+    _run(adapter.delete_message(str(CHANNEL_ID), f"{CHANNEL_ID}:901"))
+
+    assert [d["message_id"] for d in webhook.deletes] == [901]
+    assert channel.deleted_ids == []
+
+
+def test_delete_message_in_a_thread_passes_the_thread_through() -> None:
+    adapter = _adapter()
+    channel = _FakeChannel()
+    webhook = _FakeWebhook()
+    channel.existing_webhooks = [webhook]
+    thread = _FakeThread(parent=channel, thread_id=4000)
+    adapter._client = _FakeClient({CHANNEL_ID: channel, 4000: thread})
+
+    _run(adapter.delete_message(str(CHANNEL_ID), "4000:901"))
+
+    assert webhook.deletes[0]["message_id"] == 901
+    assert webhook.deletes[0]["thread"].id == 4000
+
+
+def test_delete_message_falls_back_to_the_bot_for_its_own_posts() -> None:
+    # Admin notices and DM fallbacks are posted by the bot, so the webhook does
+    # not own them and reports NotFound.
+    adapter = _adapter()
+    channel = _FakeChannel()
+    webhook = _FakeWebhook()
+    webhook.delete_raises_not_found = True
+    channel.existing_webhooks = [webhook]
     thread = _FakeThread(parent=channel, thread_id=4000)
     thread.deleted_ids = []  # type: ignore[attr-defined]
     thread.get_partial_message = lambda mid: _FakePartialMessage(thread, mid)  # type: ignore[attr-defined]
@@ -749,6 +791,7 @@ def test_delete_message_uses_partial_message_in_location_channel() -> None:
 
     _run(adapter.delete_message(str(CHANNEL_ID), "4000:901"))
 
+    assert webhook.deletes == []
     assert thread.deleted_ids == [901]  # type: ignore[attr-defined]
 
 
@@ -831,7 +874,7 @@ def test_runtime_state_detail_edits_message_in_place() -> None:
 
 
 def test_runtime_state_idle_clears_working_message() -> None:
-    adapter, channel, _ = _runtime_setup()
+    adapter, channel, webhook = _runtime_setup()
 
     _run(
         adapter.apply_runtime_state(
@@ -848,7 +891,8 @@ def test_runtime_state_idle_clears_working_message() -> None:
         )
     )
 
-    assert channel.deleted_ids == [901]
+    assert [d["message_id"] for d in webhook.deletes] == [901]
+    assert channel.deleted_ids == []
     assert (str(CHANNEL_ID), "my-agent") not in adapter._working_msg
 
 
@@ -891,7 +935,7 @@ def test_runtime_state_awaiting_input_pings_and_resume_clears_pings() -> None:
             thread_root_id=None,
         )
     )
-    assert channel.deleted_ids == [902]
+    assert [d["message_id"] for d in webhook.deletes] == [902]
     assert (str(CHANNEL_ID), "my-agent") not in adapter._input_pings
 
 

--- a/core/tests/switch_core/bridges/collaboration/test_discord_adapter.py
+++ b/core/tests/switch_core/bridges/collaboration/test_discord_adapter.py
@@ -791,7 +791,10 @@ def test_runtime_state_working_posts_persistent_indicator() -> None:
     assert len(webhook.sent) == 1
     assert webhook.sent[0]["content"] == "⚙️ _Working on it…_"
     assert webhook.sent[0]["username"] == "my-agent"
-    assert adapter._working_msg[(str(CHANNEL_ID), "my-agent")] == f"{CHANNEL_ID}:901"
+    assert (
+        adapter._working_msg[(str(CHANNEL_ID), "my-agent")].message_ref
+        == f"{CHANNEL_ID}:901"
+    )
 
 
 def test_runtime_state_detail_edits_message_in_place() -> None:
@@ -821,7 +824,10 @@ def test_runtime_state_detail_edits_message_in_place() -> None:
     assert len(webhook.edits) == 1
     assert webhook.edits[0]["message_id"] == 901
     assert webhook.edits[0]["content"] == "⚙️ Editing adapter.py"
-    assert adapter._working_msg[(str(CHANNEL_ID), "my-agent")] == f"{CHANNEL_ID}:901"
+    assert (
+        adapter._working_msg[(str(CHANNEL_ID), "my-agent")].message_ref
+        == f"{CHANNEL_ID}:901"
+    )
 
 
 def test_runtime_state_idle_clears_working_message() -> None:

--- a/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
+++ b/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
@@ -37,6 +37,9 @@ class _Recorder:
         self.hard_deletes: list[str] = []
         self.patches: list[tuple[str, str]] = []
         self.sends: list[tuple[str, str, str, str | None]] = []
+        # Post ids actually handed back, so a test can assert that everything
+        # posted was also removed.
+        self.sent_ids: list[str] = []
         self._next_id = iter(["post-2", "post-3", "post-4"])
 
     def install(self, adapter: MattermostAdapter) -> None:
@@ -54,7 +57,9 @@ class _Recorder:
             thread_root_id: str | None = None,
         ) -> str | None:
             self.sends.append((channel_id, sender_name, content, thread_root_id))
-            return next(self._next_id)
+            ref = next(self._next_id)
+            self.sent_ids.append(ref)
+            return ref
 
         adapter._permanent_delete = permanent_delete  # type: ignore[method-assign]
         adapter._patch_post_as = patch_post_as  # type: ignore[method-assign]
@@ -155,47 +160,58 @@ def test_failed_repost_after_delete_drops_the_stale_ref() -> None:
     assert ("chan-1", "worker") not in adapter._working_msg
 
 
-def test_a_turn_ending_mid_delete_abandons_the_move() -> None:
-    # Mattermost deletes first, so a turn ending during that delete leaves
-    # nothing to move — reposting anyway would strand an indicator forever.
+def test_a_turn_ending_during_a_move_leaves_nothing_behind() -> None:
+    # The move and the end-of-turn clear share the agent's runtime lock, so
+    # they cannot interleave: whichever runs second sees the other's result.
+    # Either way the channel ends up with no indicator and none is tracked.
     adapter = _adapter()
     recorder = _Recorder(hard_delete_works=True)
     recorder.install(adapter)
     _seed_indicator(adapter)
 
-    real_delete = adapter._permanent_delete
+    async def scenario() -> None:
+        await asyncio.gather(
+            adapter.reposition_runtime_state("chan-1", "worker", None),
+            adapter.apply_runtime_state(
+                "chan-1", "worker", "idle", notify_user=None, thread_root_id=None
+            ),
+        )
 
-    async def delete_then_go_idle(post_id: str) -> bool:
-        ok = await real_delete(post_id)
-        adapter._working_msg.pop(("chan-1", "worker"), None)
-        return ok
+    _run(scenario())
 
-    adapter._permanent_delete = delete_then_go_idle  # type: ignore[method-assign]
-    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
-
-    assert recorder.sends == []
+    posted = {"post-1", *(ref for ref in recorder.sent_ids)}
+    assert posted <= set(recorder.hard_deletes)
     assert ("chan-1", "worker") not in adapter._working_msg
 
 
-def test_a_turn_ending_mid_repost_takes_the_replacement_back_down() -> None:
+def test_a_refresh_during_a_move_does_not_strand_the_replacement() -> None:
+    # The reported leftover: the periodic activity refresh and the move both
+    # read-modify-write the tracked indicator. Serialised, the refresh edits
+    # whichever message is actually posted rather than restoring a dead ref.
     adapter = _adapter()
     recorder = _Recorder(hard_delete_works=True)
     recorder.install(adapter)
     _seed_indicator(adapter)
 
-    real_send = adapter.send_message
+    async def scenario() -> None:
+        await asyncio.gather(
+            adapter.reposition_runtime_state("chan-1", "worker", None),
+            adapter.apply_runtime_state(
+                "chan-1",
+                "worker",
+                "working",
+                notify_user=None,
+                thread_root_id=None,
+                detail="Ran tool post_message",
+            ),
+        )
 
-    async def send_then_go_idle(*args: Any, **kwargs: Any) -> str | None:
-        ref = await real_send(*args, **kwargs)
-        adapter._working_msg.pop(("chan-1", "worker"), None)
-        return ref
+    _run(scenario())
 
-    adapter.send_message = send_then_go_idle  # type: ignore[method-assign]
-    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
-
-    # post-1 was the move's own delete; post-2 is the orphan being cleaned up.
-    assert recorder.hard_deletes == ["post-1", "post-2"]
-    assert ("chan-1", "worker") not in adapter._working_msg
+    live = adapter._working_msg[("chan-1", "worker")]
+    posted = {"post-1", *recorder.sent_ids}
+    still_up = posted - set(recorder.hard_deletes)
+    assert still_up == {live.message_ref}
 
 
 def test_idle_still_falls_back_to_a_terminal_marker() -> None:

--- a/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
+++ b/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from switch_core.bridges.collaboration.adapter import LiveRuntimeIndicator
+from switch_core.bridges.collaboration.mattermost.adapter import (
+    MattermostAdapter,
+    MattermostConnectionConfig,
+)
+
+
+def _adapter() -> MattermostAdapter:
+    return MattermostAdapter(
+        config=MattermostConnectionConfig(
+            url="http://mm",
+            admin_user="admin",
+            admin_password="pw",
+            team_name="team",
+        )
+    )
+
+
+def _run(coro: Any) -> Any:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _Recorder:
+    """Records the adapter's platform calls, with a togglable hard delete."""
+
+    def __init__(self, *, hard_delete_works: bool) -> None:
+        self.hard_delete_works = hard_delete_works
+        self.hard_deletes: list[str] = []
+        self.patches: list[tuple[str, str]] = []
+        self.sends: list[tuple[str, str, str, str | None]] = []
+        self._next_id = iter(["post-2", "post-3", "post-4"])
+
+    def install(self, adapter: MattermostAdapter) -> None:
+        async def permanent_delete(post_id: str) -> bool:
+            self.hard_deletes.append(post_id)
+            return self.hard_delete_works
+
+        async def patch_post_as(agent_name: str, post_id: str, content: str) -> None:
+            self.patches.append((post_id, content))
+
+        async def send_message(
+            channel_id: str,
+            sender_name: str,
+            content: str,
+            thread_root_id: str | None = None,
+        ) -> str | None:
+            self.sends.append((channel_id, sender_name, content, thread_root_id))
+            return next(self._next_id)
+
+        adapter._permanent_delete = permanent_delete  # type: ignore[method-assign]
+        adapter._patch_post_as = patch_post_as  # type: ignore[method-assign]
+        adapter.send_message = send_message  # type: ignore[method-assign]
+
+
+def _seed_indicator(
+    adapter: MattermostAdapter, *, thread_root_id: str | None = None
+) -> None:
+    adapter._working_msg[("chan-1", "worker")] = LiveRuntimeIndicator(
+        message_ref="post-1",
+        body="⚙️ _Working on it…_",
+        thread_root_id=thread_root_id,
+    )
+
+
+def test_reposition_deletes_before_reposting_when_hard_delete_works() -> None:
+    # Mattermost inverts the usual post-then-delete order: the old post must be
+    # provably gone before a replacement is posted, or a failure would strand a
+    # marker in the channel.
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=True)
+    recorder.install(adapter)
+    _seed_indicator(adapter, thread_root_id="root-9")
+
+    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+
+    assert recorder.hard_deletes == ["post-1"]
+    assert recorder.sends == [("chan-1", "worker", "⚙️ _Working on it…_", "root-9")]
+    assert recorder.patches == []
+    assert adapter._working_msg[("chan-1", "worker")].message_ref == "post-2"
+
+
+def test_reposition_abandoned_when_hard_delete_is_unavailable() -> None:
+    # Without a hard delete, moving would leave a "✓ done" marker behind on
+    # every message. The indicator stays where it is instead.
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=False)
+    recorder.install(adapter)
+    _seed_indicator(adapter)
+
+    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+
+    assert recorder.sends == []
+    assert recorder.patches == []
+    assert adapter._working_msg[("chan-1", "worker")].message_ref == "post-1"
+
+
+def test_unavailable_hard_delete_is_warned_once_per_channel() -> None:
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=False)
+    recorder.install(adapter)
+    _seed_indicator(adapter)
+
+    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+
+    assert adapter._no_hard_delete_warned == {"chan-1"}
+
+
+def test_reposition_is_a_noop_without_a_live_indicator() -> None:
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=True)
+    recorder.install(adapter)
+
+    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+
+    assert recorder.hard_deletes == []
+    assert recorder.sends == []
+
+
+def test_failed_repost_after_delete_drops_the_stale_ref() -> None:
+    # The old post is already gone here, so there is nothing to fall back to —
+    # the tracked ref must not keep pointing at a deleted post.
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=True)
+    recorder.install(adapter)
+    _seed_indicator(adapter)
+
+    async def failing_send(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    adapter.send_message = failing_send  # type: ignore[method-assign]
+    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+
+    assert ("chan-1", "worker") not in adapter._working_msg
+
+
+def test_idle_still_falls_back_to_a_terminal_marker() -> None:
+    # Turn end is unchanged: without a hard delete the post is edited rather
+    # than soft deleted, so no "(message deleted)" tombstone is left.
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=False)
+    recorder.install(adapter)
+    _seed_indicator(adapter)
+
+    _run(
+        adapter.apply_runtime_state(
+            "chan-1", "worker", "idle", notify_user=None, thread_root_id=None
+        )
+    )
+
+    assert recorder.patches == [("post-1", "✓ done")]
+    assert ("chan-1", "worker") not in adapter._working_msg

--- a/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
+++ b/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
@@ -80,12 +80,24 @@ def test_reposition_deletes_before_reposting_when_hard_delete_works() -> None:
     recorder.install(adapter)
     _seed_indicator(adapter, thread_root_id="root-9")
 
-    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+    _run(adapter.reposition_runtime_state("chan-1", "worker", "root-9"))
 
     assert recorder.hard_deletes == ["post-1"]
     assert recorder.sends == [("chan-1", "worker", "⚙️ _Working on it…_", "root-9")]
     assert recorder.patches == []
     assert adapter._working_msg[("chan-1", "worker")].message_ref == "post-2"
+
+
+def test_reposition_rehomes_into_the_thread_of_the_latest_message() -> None:
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=True)
+    recorder.install(adapter)
+    _seed_indicator(adapter, thread_root_id="root-9")
+
+    _run(adapter.reposition_runtime_state("chan-1", "worker", "root-42"))
+
+    assert recorder.sends == [("chan-1", "worker", "⚙️ _Working on it…_", "root-42")]
+    assert adapter._working_msg[("chan-1", "worker")].thread_root_id == "root-42"
 
 
 def test_reposition_abandoned_when_hard_delete_is_unavailable() -> None:
@@ -96,7 +108,7 @@ def test_reposition_abandoned_when_hard_delete_is_unavailable() -> None:
     recorder.install(adapter)
     _seed_indicator(adapter)
 
-    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
 
     assert recorder.sends == []
     assert recorder.patches == []
@@ -109,8 +121,8 @@ def test_unavailable_hard_delete_is_warned_once_per_channel() -> None:
     recorder.install(adapter)
     _seed_indicator(adapter)
 
-    _run(adapter.reposition_runtime_state("chan-1", "worker"))
-    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
+    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
 
     assert adapter._no_hard_delete_warned == {"chan-1"}
 
@@ -120,7 +132,7 @@ def test_reposition_is_a_noop_without_a_live_indicator() -> None:
     recorder = _Recorder(hard_delete_works=True)
     recorder.install(adapter)
 
-    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
 
     assert recorder.hard_deletes == []
     assert recorder.sends == []
@@ -138,7 +150,7 @@ def test_failed_repost_after_delete_drops_the_stale_ref() -> None:
         return None
 
     adapter.send_message = failing_send  # type: ignore[method-assign]
-    _run(adapter.reposition_runtime_state("chan-1", "worker"))
+    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
 
     assert ("chan-1", "worker") not in adapter._working_msg
 

--- a/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
+++ b/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
@@ -155,6 +155,49 @@ def test_failed_repost_after_delete_drops_the_stale_ref() -> None:
     assert ("chan-1", "worker") not in adapter._working_msg
 
 
+def test_a_turn_ending_mid_delete_abandons_the_move() -> None:
+    # Mattermost deletes first, so a turn ending during that delete leaves
+    # nothing to move — reposting anyway would strand an indicator forever.
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=True)
+    recorder.install(adapter)
+    _seed_indicator(adapter)
+
+    real_delete = adapter._permanent_delete
+
+    async def delete_then_go_idle(post_id: str) -> bool:
+        ok = await real_delete(post_id)
+        adapter._working_msg.pop(("chan-1", "worker"), None)
+        return ok
+
+    adapter._permanent_delete = delete_then_go_idle  # type: ignore[method-assign]
+    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
+
+    assert recorder.sends == []
+    assert ("chan-1", "worker") not in adapter._working_msg
+
+
+def test_a_turn_ending_mid_repost_takes_the_replacement_back_down() -> None:
+    adapter = _adapter()
+    recorder = _Recorder(hard_delete_works=True)
+    recorder.install(adapter)
+    _seed_indicator(adapter)
+
+    real_send = adapter.send_message
+
+    async def send_then_go_idle(*args: Any, **kwargs: Any) -> str | None:
+        ref = await real_send(*args, **kwargs)
+        adapter._working_msg.pop(("chan-1", "worker"), None)
+        return ref
+
+    adapter.send_message = send_then_go_idle  # type: ignore[method-assign]
+    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
+
+    # post-1 was the move's own delete; post-2 is the orphan being cleaned up.
+    assert recorder.hard_deletes == ["post-1", "post-2"]
+    assert ("chan-1", "worker") not in adapter._working_msg
+
+
 def test_idle_still_falls_back_to_a_terminal_marker() -> None:
     # Turn end is unchanged: without a hard delete the post is edited rather
     # than soft deleted, so no "(message deleted)" tombstone is left.

--- a/core/tests/switch_core/bridges/collaboration/test_runtime_indicator_race.py
+++ b/core/tests/switch_core/bridges/collaboration/test_runtime_indicator_race.py
@@ -1,0 +1,186 @@
+"""Moving the runtime indicator and refreshing it must not interleave.
+
+Two independent callers mutate ``_working_msg`` for the same agent: the
+periodic activity refresh (``apply_runtime_state`` with ``working``, every few
+seconds) and a reposition triggered by new traffic. Both read the entry, await
+a platform call, then write it back.
+
+Interleaved, the refresh's write lands after the move's and restores the
+superseded message ref. The entry then points at a message the move has just
+deleted, and the message the move posted is referenced by nothing — so the
+end-of-turn clear cannot remove it and it stays in the channel forever.
+
+The invariant each test asserts is the same: whatever is still posted on the
+platform is exactly what the adapter thinks is posted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from switch_core.bridges.collaboration.adapter import LiveRuntimeIndicator
+from switch_core.bridges.collaboration.slack.adapter import (
+    SlackAdapter,
+    SlackConnectionConfig,
+)
+
+CHANNEL = "chan-1"
+AGENT = "worker"
+KEY = (CHANNEL, AGENT)
+
+
+class _Platform:
+    """Records posts, edits and deletes, yielding once per call.
+
+    The single yield is what lets the two coroutines interleave at all — it
+    stands in for the network round trip each of these calls really makes.
+    """
+
+    def __init__(self, adapter: SlackAdapter, seeded_ref: str) -> None:
+        self.live: set[str] = {seeded_ref}
+        self.edits: list[tuple[str, str]] = []
+        self._next = iter(f"msg-{n}" for n in range(2, 20))
+
+        async def send_message(
+            channel_id: str,
+            sender_name: str,
+            content: str,
+            thread_root_id: str | None = None,
+        ) -> str | None:
+            await asyncio.sleep(0)
+            ref = next(self._next)
+            self.live.add(ref)
+            return ref
+
+        async def update_message(
+            channel_id: str, message_ref: str, new_content: str
+        ) -> None:
+            await asyncio.sleep(0)
+            self.edits.append((message_ref, new_content))
+
+        async def delete_message(channel_id: str, message_ref: str) -> None:
+            await asyncio.sleep(0)
+            self.live.discard(message_ref)
+
+        adapter.send_message = send_message  # type: ignore[method-assign]
+        adapter.update_message = update_message  # type: ignore[method-assign]
+        adapter.delete_message = delete_message  # type: ignore[method-assign]
+
+
+def _adapter() -> tuple[SlackAdapter, _Platform]:
+    adapter = SlackAdapter(
+        config=SlackConnectionConfig(
+            bot_token="xoxb-test", app_token="xapp-test", workspace_id="T-test"
+        )
+    )
+    adapter._working_msg[KEY] = LiveRuntimeIndicator(
+        message_ref="msg-1",
+        body="⚙️ _Working on it…_",
+        thread_root_id=None,
+    )
+    return adapter, _Platform(adapter, "msg-1")
+
+
+def _refresh(adapter: SlackAdapter, detail: str) -> Any:
+    return adapter.apply_runtime_state(
+        CHANNEL,
+        AGENT,
+        "working",
+        notify_user=None,
+        thread_root_id=None,
+        detail=detail,
+    )
+
+
+def _assert_consistent(adapter: SlackAdapter, platform: _Platform) -> None:
+    live = adapter._working_msg.get(KEY)
+    tracked = {live.message_ref} if live is not None else set()
+    assert platform.live == tracked, (
+        f"platform still shows {sorted(platform.live)} but the adapter tracks "
+        f"{sorted(tracked)} — the difference is stranded and nothing will remove it"
+    )
+
+
+async def test_a_refresh_landing_during_a_move_does_not_strand_the_new_message() -> (
+    None
+):
+    # The reported bug: the refresh read the entry before the move rewrote it,
+    # so its write restored the old ref and orphaned the message the move
+    # posted. The turn's clear then removed the already-deleted one.
+    adapter, platform = _adapter()
+
+    await asyncio.gather(
+        adapter.reposition_runtime_state(CHANNEL, AGENT, None),
+        _refresh(adapter, "Ran tool post_message"),
+    )
+
+    _assert_consistent(adapter, platform)
+
+
+async def test_a_move_still_moves_when_a_refresh_races_it() -> None:
+    # The same interleaving in the other order silently abandons the move: the
+    # indicator stays where it was, which is the whole defect this feature
+    # exists to fix.
+    adapter, platform = _adapter()
+
+    await asyncio.gather(
+        _refresh(adapter, "Ran tool post_message"),
+        adapter.reposition_runtime_state(CHANNEL, AGENT, None),
+    )
+
+    live = adapter._working_msg[KEY]
+    assert live.message_ref != "msg-1", (
+        "the indicator was never repositioned — a concurrent activity refresh "
+        "cancelled the move"
+    )
+    _assert_consistent(adapter, platform)
+
+
+async def test_the_refresh_body_survives_a_concurrent_move() -> None:
+    # Whichever order they run in, the latest activity line must end up on the
+    # message that is actually still posted — not on a deleted one.
+    adapter, platform = _adapter()
+
+    await asyncio.gather(
+        adapter.reposition_runtime_state(CHANNEL, AGENT, None),
+        _refresh(adapter, "Editing foo.py"),
+    )
+
+    live = adapter._working_msg[KEY]
+    assert "Editing foo.py" in live.body
+    assert live.message_ref in platform.live
+
+
+async def test_a_burst_of_moves_and_refreshes_leaves_exactly_one_message() -> None:
+    # The steady state under load: several repositions and refreshes overlapping
+    # must still converge on a single tracked, still-posted indicator.
+    adapter, platform = _adapter()
+
+    await asyncio.gather(
+        *(adapter.reposition_runtime_state(CHANNEL, AGENT, None) for _ in range(4)),
+        *(_refresh(adapter, f"step {n}") for n in range(4)),
+    )
+
+    assert len(platform.live) == 1
+    _assert_consistent(adapter, platform)
+
+
+async def test_the_turn_end_clear_removes_everything() -> None:
+    # After a contended turn, going idle must leave the channel clean.
+    adapter, platform = _adapter()
+
+    await asyncio.gather(
+        adapter.reposition_runtime_state(CHANNEL, AGENT, None),
+        _refresh(adapter, "Ran tool post_message"),
+    )
+    await adapter.apply_runtime_state(
+        CHANNEL,
+        AGENT,
+        "idle",
+        notify_user=None,
+        thread_root_id=None,
+    )
+
+    assert platform.live == set()
+    assert KEY not in adapter._working_msg

--- a/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
+++ b/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
@@ -50,6 +50,9 @@ class _FakeWebClient:
         self.calls: list[dict[str, Any]] = []
         self.deletes: list[dict[str, Any]] = []
         self.updates: list[dict[str, Any]] = []
+        # ts values actually handed back, in order — lets a test assert that
+        # everything posted was also removed.
+        self.issued: list[str] = []
         self._next_ts = iter(["999.9", "888.8", "777.7"])
 
     async def chat_postMessage(self, **kwargs: Any) -> dict[str, str]:
@@ -58,6 +61,7 @@ class _FakeWebClient:
             ts = next(self._next_ts)
         except StopIteration:
             ts = "000.0"
+        self.issued.append(ts)
         return {"ts": ts}
 
     async def chat_delete(self, **kwargs: Any) -> dict[str, bool]:
@@ -771,35 +775,30 @@ def test_reposition_is_a_noop_without_a_live_indicator() -> None:
     assert fake.deletes == []
 
 
-def test_a_turn_ending_mid_move_does_not_strand_the_replacement() -> None:
-    # The turn can go idle while the replacement post is still in flight. The
-    # clear removes the message this move was replacing, so the replacement
-    # would be left with nothing to ever clear it — it must be taken back down.
+def test_a_turn_ending_during_a_move_clears_what_the_move_left() -> None:
+    # A move and the end-of-turn clear cannot interleave: both run under the
+    # agent's runtime lock, so the clear sees the moved indicator rather than
+    # the message the move already deleted. Nothing is left in the channel.
     adapter = _adapter()
     fake = _FakeWebClient()
     adapter._web_client = fake  # type: ignore[assignment]
 
-    _run(
-        adapter.apply_runtime_state(
+    async def scenario() -> None:
+        await adapter.apply_runtime_state(
             "C123", "agent-bot", "working", notify_user=None, thread_root_id=None
         )
-    )
-
-    real_send = adapter.send_message
-
-    async def send_then_go_idle(*args: Any, **kwargs: Any) -> str | None:
-        ref = await real_send(*args, **kwargs)
-        await adapter.apply_runtime_state(
-            "C123", "agent-bot", "idle", notify_user=None, thread_root_id=None
+        await asyncio.gather(
+            adapter.reposition_runtime_state("C123", "agent-bot", None),
+            adapter.apply_runtime_state(
+                "C123", "agent-bot", "idle", notify_user=None, thread_root_id=None
+            ),
         )
-        return ref
 
-    adapter.send_message = send_then_go_idle  # type: ignore[method-assign]
-    _run(adapter.reposition_runtime_state("C123", "agent-bot", None))
+    _run(scenario())
 
-    # Both the original and the orphaned replacement are gone, and nothing is
-    # left tracked for a turn that has ended.
-    assert {d["ts"] for d in fake.deletes} == {"999.9", "888.8"}
+    # Every message the adapter posted was deleted again — whichever order the
+    # two ran in, the channel ends up empty and nothing is left tracked.
+    assert set(fake.issued) == {d["ts"] for d in fake.deletes}
     assert ("C123", "agent-bot") not in adapter._working_msg
 
 

--- a/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
+++ b/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
@@ -689,7 +689,7 @@ def test_reposition_reposts_indicator_below_newer_traffic() -> None:
             detail="Editing adapter.py",
         )
     )
-    _run(adapter.reposition_runtime_state("C123", "agent-bot"))
+    _run(adapter.reposition_runtime_state("C123", "agent-bot", None))
 
     # Reposted verbatim, then the original removed — never edited in place.
     assert len(fake.calls) == 2
@@ -699,7 +699,7 @@ def test_reposition_reposts_indicator_below_newer_traffic() -> None:
     assert adapter._working_msg[("C123", "agent-bot")].message_ref == "C123:888.8"
 
 
-def test_reposition_keeps_the_indicator_in_its_thread() -> None:
+def test_reposition_stays_in_the_thread_when_the_message_is_in_it() -> None:
     adapter = _adapter()
     fake = _FakeWebClient()
     adapter._web_client = fake  # type: ignore[assignment]
@@ -713,9 +713,51 @@ def test_reposition_keeps_the_indicator_in_its_thread() -> None:
             thread_root_id="C123:111.1",
         )
     )
-    _run(adapter.reposition_runtime_state("C123", "agent-bot"))
+    _run(adapter.reposition_runtime_state("C123", "agent-bot", "C123:111.1"))
 
     assert fake.calls[1]["thread_ts"] == "111.1"
+
+
+def test_reposition_follows_the_agent_into_a_different_thread() -> None:
+    # The indicator re-homes rather than being stranded in whichever thread the
+    # turn happened to open in.
+    adapter = _adapter()
+    fake = _FakeWebClient()
+    adapter._web_client = fake  # type: ignore[assignment]
+
+    _run(
+        adapter.apply_runtime_state(
+            "C123",
+            "agent-bot",
+            "working",
+            notify_user=None,
+            thread_root_id="C123:111.1",
+        )
+    )
+    _run(adapter.reposition_runtime_state("C123", "agent-bot", "C123:222.2"))
+
+    assert fake.calls[1]["thread_ts"] == "222.2"
+    assert adapter._working_msg[("C123", "agent-bot")].thread_root_id == "C123:222.2"
+
+
+def test_reposition_follows_the_agent_back_out_to_the_channel_root() -> None:
+    adapter = _adapter()
+    fake = _FakeWebClient()
+    adapter._web_client = fake  # type: ignore[assignment]
+
+    _run(
+        adapter.apply_runtime_state(
+            "C123",
+            "agent-bot",
+            "working",
+            notify_user=None,
+            thread_root_id="C123:111.1",
+        )
+    )
+    _run(adapter.reposition_runtime_state("C123", "agent-bot", None))
+
+    assert fake.calls[1]["thread_ts"] is None
+    assert adapter._working_msg[("C123", "agent-bot")].thread_root_id is None
 
 
 def test_reposition_is_a_noop_without_a_live_indicator() -> None:
@@ -723,7 +765,7 @@ def test_reposition_is_a_noop_without_a_live_indicator() -> None:
     fake = _FakeWebClient()
     adapter._web_client = fake  # type: ignore[assignment]
 
-    _run(adapter.reposition_runtime_state("C123", "agent-bot"))
+    _run(adapter.reposition_runtime_state("C123", "agent-bot", None))
 
     assert fake.calls == []
     assert fake.deletes == []
@@ -746,7 +788,7 @@ def test_reposition_leaves_the_original_when_the_repost_fails() -> None:
         return None
 
     adapter.send_message = failing_send  # type: ignore[method-assign]
-    _run(adapter.reposition_runtime_state("C123", "agent-bot"))
+    _run(adapter.reposition_runtime_state("C123", "agent-bot", None))
 
     assert fake.deletes == []
     assert adapter._working_msg[("C123", "agent-bot")].message_ref == "C123:999.9"

--- a/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
+++ b/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
@@ -616,7 +616,7 @@ def test_runtime_state_working_posts_generic_indicator() -> None:
 
     assert len(fake.calls) == 1
     assert fake.calls[0]["text"] == "⚙️ _Working on it…_"
-    assert adapter._working_msg[("C123", "agent-bot")] == "C123:999.9"
+    assert adapter._working_msg[("C123", "agent-bot")].message_ref == "C123:999.9"
 
 
 def test_runtime_state_detail_edits_message_in_place() -> None:
@@ -648,7 +648,7 @@ def test_runtime_state_detail_edits_message_in_place() -> None:
     assert fake.updates[0]["ts"] == "999.9"
     assert fake.updates[0]["text"] == "⚙️ Editing room-connection.ts"
     # The tracked ref is unchanged.
-    assert adapter._working_msg[("C123", "agent-bot")] == "C123:999.9"
+    assert adapter._working_msg[("C123", "agent-bot")].message_ref == "C123:999.9"
 
 
 def test_runtime_state_idle_clears_working_message() -> None:
@@ -669,6 +669,87 @@ def test_runtime_state_idle_clears_working_message() -> None:
 
     assert fake.deletes == [{"channel": "C123", "ts": "999.9"}]
     assert ("C123", "agent-bot") not in adapter._working_msg
+
+
+# ── Runtime state (following the latest message) ────────────────────────────
+
+
+def test_reposition_reposts_indicator_below_newer_traffic() -> None:
+    adapter = _adapter()
+    fake = _FakeWebClient()
+    adapter._web_client = fake  # type: ignore[assignment]
+
+    _run(
+        adapter.apply_runtime_state(
+            "C123",
+            "agent-bot",
+            "working",
+            notify_user=None,
+            thread_root_id=None,
+            detail="Editing adapter.py",
+        )
+    )
+    _run(adapter.reposition_runtime_state("C123", "agent-bot"))
+
+    # Reposted verbatim, then the original removed — never edited in place.
+    assert len(fake.calls) == 2
+    assert fake.calls[1]["text"] == "⚙️ Editing adapter.py"
+    assert fake.updates == []
+    assert fake.deletes == [{"channel": "C123", "ts": "999.9"}]
+    assert adapter._working_msg[("C123", "agent-bot")].message_ref == "C123:888.8"
+
+
+def test_reposition_keeps_the_indicator_in_its_thread() -> None:
+    adapter = _adapter()
+    fake = _FakeWebClient()
+    adapter._web_client = fake  # type: ignore[assignment]
+
+    _run(
+        adapter.apply_runtime_state(
+            "C123",
+            "agent-bot",
+            "working",
+            notify_user=None,
+            thread_root_id="C123:111.1",
+        )
+    )
+    _run(adapter.reposition_runtime_state("C123", "agent-bot"))
+
+    assert fake.calls[1]["thread_ts"] == "111.1"
+
+
+def test_reposition_is_a_noop_without_a_live_indicator() -> None:
+    adapter = _adapter()
+    fake = _FakeWebClient()
+    adapter._web_client = fake  # type: ignore[assignment]
+
+    _run(adapter.reposition_runtime_state("C123", "agent-bot"))
+
+    assert fake.calls == []
+    assert fake.deletes == []
+
+
+def test_reposition_leaves_the_original_when_the_repost_fails() -> None:
+    # A move must never end with no indicator at all: if the replacement cannot
+    # be posted, the original stays where it is rather than being deleted.
+    adapter = _adapter()
+    fake = _FakeWebClient()
+    adapter._web_client = fake  # type: ignore[assignment]
+
+    _run(
+        adapter.apply_runtime_state(
+            "C123", "agent-bot", "working", notify_user=None, thread_root_id=None
+        )
+    )
+
+    async def failing_send(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    adapter.send_message = failing_send  # type: ignore[method-assign]
+    _run(adapter.reposition_runtime_state("C123", "agent-bot"))
+
+    assert fake.deletes == []
+    assert adapter._working_msg[("C123", "agent-bot")].message_ref == "C123:999.9"
 
 
 # ── Self-mention (tagging the app) ───────────────────────────────────────────

--- a/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
+++ b/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
@@ -771,6 +771,38 @@ def test_reposition_is_a_noop_without_a_live_indicator() -> None:
     assert fake.deletes == []
 
 
+def test_a_turn_ending_mid_move_does_not_strand_the_replacement() -> None:
+    # The turn can go idle while the replacement post is still in flight. The
+    # clear removes the message this move was replacing, so the replacement
+    # would be left with nothing to ever clear it — it must be taken back down.
+    adapter = _adapter()
+    fake = _FakeWebClient()
+    adapter._web_client = fake  # type: ignore[assignment]
+
+    _run(
+        adapter.apply_runtime_state(
+            "C123", "agent-bot", "working", notify_user=None, thread_root_id=None
+        )
+    )
+
+    real_send = adapter.send_message
+
+    async def send_then_go_idle(*args: Any, **kwargs: Any) -> str | None:
+        ref = await real_send(*args, **kwargs)
+        await adapter.apply_runtime_state(
+            "C123", "agent-bot", "idle", notify_user=None, thread_root_id=None
+        )
+        return ref
+
+    adapter.send_message = send_then_go_idle  # type: ignore[method-assign]
+    _run(adapter.reposition_runtime_state("C123", "agent-bot", None))
+
+    # Both the original and the orphaned replacement are gone, and nothing is
+    # left tracked for a turn that has ended.
+    assert {d["ts"] for d in fake.deletes} == {"999.9", "888.8"}
+    assert ("C123", "agent-bot") not in adapter._working_msg
+
+
 def test_reposition_leaves_the_original_when_the_repost_fails() -> None:
     # A move must never end with no indicator at all: if the replacement cannot
     # be posted, the original stays where it is rather than being deleted.

--- a/core/tests/switch_core/bridges/collaboration/test_teams_adapter.py
+++ b/core/tests/switch_core/bridges/collaboration/test_teams_adapter.py
@@ -907,7 +907,7 @@ def test_working_posts_status_card() -> None:
     )
 
     assert len(fake.threads) == 1
-    assert adapter._working_msg[("19:abc@thread.tacv2", "worker")] == "M1"
+    assert adapter._working_msg[("19:abc@thread.tacv2", "worker")].message_ref == "M1"
 
 
 def test_working_detail_refreshes_in_place() -> None:
@@ -939,7 +939,7 @@ def test_working_detail_refreshes_in_place() -> None:
     assert len(fake.threads) == 1
     assert len(fake.updates) == 1
     assert fake.updates[0]["activity_id"] == "M1"
-    assert adapter._working_msg[("19:abc@thread.tacv2", "worker")] == "M1"
+    assert adapter._working_msg[("19:abc@thread.tacv2", "worker")].message_ref == "M1"
 
 
 def test_idle_clears_working_message() -> None:
@@ -996,7 +996,7 @@ def test_awaiting_input_keeps_working_and_pings() -> None:
     )
 
     # Working indicator stays up; a ping is tracked separately.
-    assert adapter._working_msg[key] == "M1"
+    assert adapter._working_msg[key].message_ref == "M1"
     assert adapter._input_pings[key] == ["M2"]
 
     _run(

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2433,7 +2433,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/dash/apps/switchdash-desktop/src/main/core/switch-rooms/room-connection.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-rooms/room-connection.test.ts
@@ -35,7 +35,8 @@ function commandEvent(
 function messageEvent(
   addressed: boolean,
   threadId: string | null = null,
-  attachments: AttachmentRef[] = []
+  attachments: AttachmentRef[] = [],
+  messageId = 'msg-1'
 ): AgentBridgeEvent {
   return {
     type: 'message',
@@ -44,7 +45,7 @@ function messageEvent(
       addressed,
       sender: '@someone:switch',
       sender_name: 'Someone',
-      message_id: 'msg-1',
+      message_id: messageId,
       body: 'hello agent',
       timestamp: 1,
       thread_id: threadId,
@@ -119,6 +120,22 @@ function runtimeDetails(fetchMock: ReturnType<typeof makeFetch>): (string | null
   return fetchMock.mock.calls
     .filter((c) => String(c[0]).includes('/runtime-state'))
     .map((c) => JSON.parse((c[1] as RequestInit).body as string).detail);
+}
+
+function runtimeAnchors(fetchMock: ReturnType<typeof makeFetch>): (string | null)[] {
+  return fetchMock.mock.calls
+    .filter((c) => String(c[0]).includes('/runtime-state'))
+    .map((c) => JSON.parse((c[1] as RequestInit).body as string).anchor_event_id);
+}
+
+/** Anchors carried on `working` posts only — the bridge ignores the anchor on
+ * any other state, so those carry whatever happened to be set. */
+function workingAnchors(fetchMock: ReturnType<typeof makeFetch>): (string | null)[] {
+  return fetchMock.mock.calls
+    .filter((c) => String(c[0]).includes('/runtime-state'))
+    .map((c) => JSON.parse((c[1] as RequestInit).body as string))
+    .filter((b) => b.state === 'working')
+    .map((b) => b.anchor_event_id);
 }
 
 async function flush(times = 4): Promise<void> {
@@ -328,6 +345,101 @@ describe('RoomConnection', () => {
       // The gate re-checks after HUMAN_GATE_RETRY_MS (500ms).
       await vi.advanceTimersByTimeAsync(500);
       expect(vi.mocked(target.write).mock.calls.map((c) => c[0])[0]).toContain('<<');
+
+      conn.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The bridge repositions the runtime indicator only when the anchor CHANGES,
+  // and only ever to a message the agent has actually been handed — so these
+  // report what the session has seen, never what merely arrived in the room.
+
+  it('reports the addressed message as the anchor for the turn it starts', async () => {
+    const target: InjectionTarget = { write: vi.fn() };
+    const { conn, fetchMock } = connect({ acquire: () => target }, [
+      messageEvent(true, null, [], 'msg-alpha'),
+    ]);
+
+    await flush();
+
+    expect(runtimeAnchors(fetchMock)).toContain('msg-alpha');
+    conn.stop();
+  });
+
+  it('moves the anchor to a follow-up message injected mid-turn', async () => {
+    const target: InjectionTarget = { write: vi.fn() };
+    const { conn, fetchMock } = connect({ acquire: () => target }, [
+      messageEvent(true, null, [], 'msg-alpha'),
+      messageEvent(true, null, [], 'msg-beta'),
+    ]);
+
+    await flush(12);
+    // Force a push rather than waiting out the 5s refresh; the anchor rides on
+    // whatever the next runtime-state post happens to be.
+    conn.reportActivity('Editing x.py');
+    await flush();
+
+    const anchors = runtimeAnchors(fetchMock);
+    expect(anchors.at(-1)).toBe('msg-beta');
+    conn.stop();
+  });
+
+  it('does not anchor to a message the agent was never handed', async () => {
+    const target: InjectionTarget = { write: vi.fn() };
+    const { conn, fetchMock } = connect({ acquire: () => target }, [
+      messageEvent(true, null, [], 'msg-alpha'),
+      // Unaddressed: surfaced as context only, so it must not look like the
+      // agent turned its attention to it.
+      messageEvent(false, null, [], 'msg-unaddressed'),
+    ]);
+
+    await flush(12);
+    conn.reportActivity('Editing x.py');
+    await flush();
+
+    expect(runtimeAnchors(fetchMock)).not.toContain('msg-unaddressed');
+    conn.stop();
+  });
+
+  it('stops reporting a live anchor once the turn ends', async () => {
+    // The refresh is what keeps re-reporting the anchor. If it outlived the
+    // turn it would go on naming a finished turn's message as the live one.
+    vi.useFakeTimers();
+    try {
+      const target: InjectionTarget = { write: vi.fn() };
+      const { conn, fetchMock } = connect({ acquire: () => target }, [
+        messageEvent(true, null, [], 'msg-alpha'),
+      ]);
+      await vi.advanceTimersByTimeAsync(1);
+
+      conn.onAgentStatusChange('idle');
+      await vi.advanceTimersByTimeAsync(1);
+      const settled = workingAnchors(fetchMock).length;
+
+      await vi.advanceTimersByTimeAsync(16_000);
+
+      expect(workingAnchors(fetchMock).length).toBe(settled);
+      conn.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('repeats the current anchor on the periodic refresh so it moves nothing', async () => {
+    vi.useFakeTimers();
+    try {
+      const target: InjectionTarget = { write: vi.fn() };
+      const { conn, fetchMock } = connect({ acquire: () => target }, [
+        messageEvent(true, null, [], 'msg-alpha'),
+      ]);
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(11_000);
+
+      const anchors = workingAnchors(fetchMock);
+      expect(anchors.length).toBeGreaterThan(1);
+      expect(anchors.every((a) => a === 'msg-alpha')).toBe(true);
 
       conn.stop();
     } finally {

--- a/dash/apps/switchdash-desktop/src/main/core/switch-rooms/room-connection.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-rooms/room-connection.ts
@@ -107,6 +107,12 @@ interface QueuedInjection {
    * room root.
    */
   threadId: string | null;
+  /**
+   * The message's own id. Reported to the bridge once this injection actually
+   * reaches the session, so the runtime indicator only moves below a message
+   * the agent has really been handed.
+   */
+  messageId: string | null;
 }
 
 /** Provider-specific keystroke payload builder, injected to keep the core free
@@ -233,6 +239,13 @@ export class RoomConnection {
   private roomTurnActive = false;
   /** Thread of the current room turn (see QueuedInjection.threadId). */
   private currentThreadId: string | null = null;
+  /**
+   * The last message actually delivered into the session. Reported with runtime
+   * state so the bridge can position the indicator below what the agent has
+   * genuinely received — a message that merely arrived in the room must not
+   * make the indicator claim the agent has seen it.
+   */
+  private currentAnchorId: string | null = null;
   /** Last activity line (without the elapsed suffix), to skip redundant refreshes. */
   private lastActivityDetail: string | null = null;
   /** Monotonic timestamp the current working turn began, for the elapsed suffix. */
@@ -398,6 +411,7 @@ export class RoomConnection {
       this.runtimeState = 'idle';
       this.roomTurnActive = false;
       this.currentThreadId = null;
+      this.currentAnchorId = null;
       void this.postRuntimeState('idle', null, { detached: true }).catch(() => {});
     }
     this.abort.abort();
@@ -483,6 +497,10 @@ export class RoomConnection {
           room_id: this.roomId,
           state,
           thread_id: threadId,
+          // Reported on every push, including the periodic activity refresh.
+          // The bridge repositions only when the value CHANGES, so a refresh
+          // that repeats the current anchor deliberately moves nothing.
+          anchor_event_id: this.currentAnchorId,
           deeplink_url: this.sessionDeeplink(),
           detail: detail ?? null,
           control_capabilities: this.control.capabilities,
@@ -513,6 +531,8 @@ export class RoomConnection {
     const addressed = event.type === 'message' && (event.payload as MessagePayload).addressed;
     const threadId =
       event.type === 'message' ? ((event.payload as MessagePayload).thread_id ?? null) : null;
+    const messageId =
+      event.type === 'message' ? (event.payload as MessagePayload).message_id : null;
     if (event.type === 'message' && !addressed) {
       this.missed += 1;
     }
@@ -550,7 +570,7 @@ export class RoomConnection {
       body = `${body}\n(Some earlier room events were dropped and cannot be replayed: ${this.pendingGapReason} — call read_context before responding.)`;
       this.pendingGapReason = null;
     }
-    this.enqueue({ text: body, addressed, threadId });
+    this.enqueue({ text: body, addressed, threadId, messageId });
   }
 
   /**
@@ -668,6 +688,7 @@ export class RoomConnection {
       if (next === 'idle') {
         this.roomTurnActive = false;
         this.currentThreadId = null;
+        this.currentAnchorId = null;
       }
     }
     this.busy = isBlockingStatus(status, notificationType);
@@ -860,6 +881,7 @@ export class RoomConnection {
     if (item.addressed) {
       this.roomTurnActive = true;
       this.currentThreadId = item.threadId;
+      this.currentAnchorId = item.messageId;
       this.setRuntimeState('working');
     }
 

--- a/dash/apps/switchdash-desktop/src/renderer/app/app-menu-events.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/app/app-menu-events.tsx
@@ -2,8 +2,8 @@ import { useEffect } from 'react';
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { events, rpc } from '@renderer/lib/ipc';
 import { useNavigate } from '@renderer/lib/layout/navigation-provider';
-import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { toggleSettingsView } from '@renderer/lib/layout/settings-toggle';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import {
   menuGiveFeedbackChannel,

--- a/dash/apps/switchdash-desktop/src/renderer/app/app-menu-events.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/app/app-menu-events.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { events, rpc } from '@renderer/lib/ipc';
-import { useNavigate, useWorkspaceSlots } from '@renderer/lib/layout/navigation-provider';
+import { useNavigate } from '@renderer/lib/layout/navigation-provider';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { toggleSettingsView } from '@renderer/lib/layout/settings-toggle';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import {

--- a/dash/apps/switchdash-desktop/src/renderer/app/workspace.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/app/workspace.tsx
@@ -5,9 +5,9 @@ import { AppKeyboardShortcuts } from '@renderer/lib/components/app-keyboard-shor
 import { MonacoKeyboardBridge } from '@renderer/lib/components/monaco-keyboard-bridge';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import {
-  useWorkspaceSlots,
   useWorkspaceWrapParams,
 } from '@renderer/lib/layout/navigation-provider';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { WorkspaceContentLayout, WorkspaceLayout } from '@renderer/lib/layout/workspace-layout';
 import { Toaster } from '@renderer/lib/ui/toaster';
 

--- a/dash/apps/switchdash-desktop/src/renderer/app/workspace.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/app/workspace.tsx
@@ -4,11 +4,9 @@ import { CommandShortcutBinder } from '@renderer/lib/commands/command-shortcut-b
 import { AppKeyboardShortcuts } from '@renderer/lib/components/app-keyboard-shortcuts';
 import { MonacoKeyboardBridge } from '@renderer/lib/components/monaco-keyboard-bridge';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
-import {
-  useWorkspaceWrapParams,
-} from '@renderer/lib/layout/navigation-provider';
-import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
+import { useWorkspaceWrapParams } from '@renderer/lib/layout/navigation-provider';
 import { WorkspaceContentLayout, WorkspaceLayout } from '@renderer/lib/layout/workspace-layout';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { Toaster } from '@renderer/lib/ui/toaster';
 
 export function Workspace() {

--- a/dash/apps/switchdash-desktop/src/renderer/features/sessions/hooks/use-is-active-session.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sessions/hooks/use-is-active-session.ts
@@ -1,7 +1,10 @@
-import { useParams, useWorkspaceSlots } from '@renderer/lib/layout/navigation-provider';
+import { useCurrentViewId, useParams } from '@renderer/lib/layout/navigation-provider';
 
 export function useIsActiveSession(sessionId: string): boolean {
-  const { currentView } = useWorkspaceSlots();
+  // Deliberately not useWorkspaceSlots: this hook is reachable from the session
+  // view, so loading the view registry here would make the registry depend on
+  // its own members being initialised first.
+  const currentView = useCurrentViewId();
   const { params } = useParams('session');
   return currentView === 'session' && params.sessionId === sessionId;
 }

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/agent-item.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/agent-item.tsx
@@ -25,8 +25,8 @@ import { rpc } from '@renderer/lib/ipc';
 import {
   useNavigate,
   useParams,
-  useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { sidebarStore } from '@renderer/lib/stores/app-state';
 import {

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/agent-item.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/agent-item.tsx
@@ -22,10 +22,7 @@ import { switchRoomsStore } from '@renderer/features/switch-servers/switch-rooms
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
 import { useToast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
-import {
-  useNavigate,
-  useParams,
-} from '@renderer/lib/layout/navigation-provider';
+import { useNavigate, useParams } from '@renderer/lib/layout/navigation-provider';
 import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { sidebarStore } from '@renderer/lib/stores/app-state';

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
@@ -1,10 +1,7 @@
 import { FolderInput, Server, Settings } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
-import {
-  isCurrentView,
-  useNavigate,
-} from '@renderer/lib/layout/navigation-provider';
+import { isCurrentView, useNavigate } from '@renderer/lib/layout/navigation-provider';
 import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { cn } from '@renderer/utils/utils';

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 import {
   isCurrentView,
   useNavigate,
-  useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { cn } from '@renderer/utils/utils';
 import { ServersSidebarSection } from '../switch-servers/ServersSidebarSection';

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/session-item.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/session-item.tsx
@@ -10,8 +10,8 @@ import { SessionSidebarTrailingSlot } from '@renderer/features/sidebar/session-s
 import {
   useNavigate,
   useParams,
-  useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { sidebarStore } from '@renderer/lib/stores/app-state';
 import { cn } from '@renderer/utils/utils';

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/session-item.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/session-item.tsx
@@ -7,10 +7,7 @@ import {
   getSessionStore,
 } from '@renderer/features/sessions/stores/session-selectors';
 import { SessionSidebarTrailingSlot } from '@renderer/features/sidebar/session-sidebar-agent-status';
-import {
-  useNavigate,
-  useParams,
-} from '@renderer/lib/layout/navigation-provider';
+import { useNavigate, useParams } from '@renderer/lib/layout/navigation-provider';
 import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { sidebarStore } from '@renderer/lib/stores/app-state';

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-search-trigger.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-search-trigger.tsx
@@ -1,6 +1,7 @@
 import { Search } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useParams, useWorkspaceSlots } from '@renderer/lib/layout/navigation-provider';
+import { useParams } from '@renderer/lib/layout/navigation-provider';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { SidebarMenuButton } from './sidebar-primitives';

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -13,11 +13,7 @@ import {
 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useEffect } from 'react';
-import {
-  isCurrentView,
-  useNavigate,
-  useParams,
-} from '@renderer/lib/layout/navigation-provider';
+import { isCurrentView, useNavigate, useParams } from '@renderer/lib/layout/navigation-provider';
 import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { buttonVariants } from '@renderer/lib/ui/button';

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -17,8 +17,8 @@ import {
   isCurrentView,
   useNavigate,
   useParams,
-  useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { buttonVariants } from '@renderer/lib/ui/button';
 import {

--- a/dash/apps/switchdash-desktop/src/renderer/lib/commands/registry.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/commands/registry.ts
@@ -1,5 +1,4 @@
 import { comparer, makeAutoObservable, reaction } from 'mobx';
-import { views } from '@renderer/app/view-registry';
 import type { ShortcutSettingsKey } from '@renderer/lib/hooks/useKeyboardShortcuts';
 import { appState } from '@renderer/lib/stores/app-state';
 import { SCOPE_LEVELS, type AppCommand, type CommandProvider, type ScopeId } from './types';
@@ -66,12 +65,22 @@ class CommandRegistry {
 
 export const commandRegistry = new CommandRegistry();
 
+export type ViewCommandProviders = Record<
+  string,
+  { commandProvider?: (params: unknown) => CommandProvider }
+>;
+
 /**
  * Wires a MobX reaction that keeps the session-scope CommandProvider in sync
  * with the active view. Must be called once at app startup (after navigation
  * state is restored). No React dependency — runs entirely off MobX observables.
+ *
+ * The view map is passed in rather than imported: this module is reachable from
+ * the modal tree, so importing the registry's value here closed a cycle back
+ * into view-registry and left its initialisation order load-order dependent.
+ * The caller is the app entry point, which already owns the registry.
  */
-export function setupViewCommandProvider(): void {
+export function setupViewCommandProvider(views: ViewCommandProviders): void {
   reaction(
     () => {
       const viewId = appState.navigation.currentViewId;
@@ -79,9 +88,7 @@ export function setupViewCommandProvider(): void {
     },
     ({ viewId, params }) => {
       commandRegistry.unregister('session');
-      const def = (
-        views as unknown as Record<string, { commandProvider?: (p: unknown) => CommandProvider }>
-      )[viewId];
+      const def = views[viewId];
       if (def?.commandProvider) commandRegistry.register(def.commandProvider(params));
     },
     { fireImmediately: true, equals: comparer.structural }

--- a/dash/apps/switchdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
@@ -5,10 +5,7 @@ import {
   getHotkeyRegistration,
 } from '@renderer/lib/hooks/useKeyboardShortcuts';
 import { useWorkspaceLayoutContext } from '@renderer/lib/layout/layout-provider';
-import {
-  useNavigate,
-  useParams,
-} from '@renderer/lib/layout/navigation-provider';
+import { useNavigate, useParams } from '@renderer/lib/layout/navigation-provider';
 import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { modalStore } from '@renderer/lib/modal/modal-store';

--- a/dash/apps/switchdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
@@ -8,8 +8,8 @@ import { useWorkspaceLayoutContext } from '@renderer/lib/layout/layout-provider'
 import {
   useNavigate,
   useParams,
-  useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
+import { useWorkspaceSlots } from '@renderer/lib/layout/workspace-slots';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { modalStore } from '@renderer/lib/modal/modal-store';
 

--- a/dash/apps/switchdash-desktop/src/renderer/lib/layout/navigation-provider.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/layout/navigation-provider.tsx
@@ -1,11 +1,8 @@
 import { useObserver } from 'mobx-react-lite';
-import { Fragment, useCallback, type ComponentType, type ReactNode } from 'react';
-import {
-  views,
-  type ViewDefinition,
-  type ViewId,
-  type WrapParams,
-} from '@renderer/app/view-registry';
+import { useCallback, type ComponentType, type ReactNode } from 'react';
+// Type-only, and it must stay that way: importing the registry's value here
+// would close a cycle back through every view module. See workspace-slots.ts.
+import type { ViewId, WrapParams } from '@renderer/app/view-registry';
 import { appState } from '@renderer/lib/stores/app-state';
 
 export type NonSettingsViewId = Exclude<ViewId, 'settings'>;
@@ -52,23 +49,15 @@ export function useNavigate(): { navigate: NavigateFnTyped } {
   return { navigate };
 }
 
-export function useWorkspaceSlots(): SlotsContextValue {
-  return useObserver(() => {
-    const viewId = appState.navigation.currentViewId;
-    const registry = views as unknown as Record<string, ViewDefinition<Record<string, unknown>>>;
-    const viewDef = registry[viewId];
-    const def = viewDef ?? registry.home;
-    const resolvedViewId = viewDef ? viewId : 'home';
-    return {
-      WrapView: (def.WrapView ?? Fragment) as ComponentType<
-        { children: ReactNode } & Record<string, unknown>
-      >,
-      TitlebarSlot: def.TitlebarSlot ?? (() => null),
-      MainPanel: def.MainPanel,
-      currentView: resolvedViewId,
-      lastNonSettingsView: appState.navigation.lastNonSettingsView,
-    };
-  });
+/**
+ * The active view id, without consulting the view registry.
+ *
+ * `useWorkspaceSlots` also reports this, but resolving it there means loading
+ * the registry — which view modules cannot do without closing an import cycle.
+ * Callers that only need to know *which* view is active should use this.
+ */
+export function useCurrentViewId(): ViewId {
+  return useObserver(() => appState.navigation.currentViewId);
 }
 
 export function useWorkspaceWrapParams(): WrapParamsContextValue {

--- a/dash/apps/switchdash-desktop/src/renderer/lib/layout/workspace-slots.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/layout/workspace-slots.ts
@@ -1,0 +1,35 @@
+import { useObserver } from 'mobx-react-lite';
+import { Fragment, type ComponentType, type ReactNode } from 'react';
+import { views, type ViewDefinition } from '@renderer/app/view-registry';
+import type { SlotsContextValue } from '@renderer/lib/layout/navigation-provider';
+import { appState } from '@renderer/lib/stores/app-state';
+
+/**
+ * Resolve the active view's slots from the view registry.
+ *
+ * Kept out of navigation-provider deliberately. This is the only navigation
+ * hook that needs the registry's *value*, and view modules import
+ * navigation-provider for `useNavigate` / `useParams`. Holding this here too
+ * closed a cycle — view-registry → a view → navigation-provider → view-registry
+ * — that made the registry's own initialisation order load-order dependent, and
+ * it would intermittently evaluate the `views` object while one of the view
+ * bindings it reads was still in its temporal dead zone.
+ */
+export function useWorkspaceSlots(): SlotsContextValue {
+  return useObserver(() => {
+    const viewId = appState.navigation.currentViewId;
+    const registry = views as unknown as Record<string, ViewDefinition<Record<string, unknown>>>;
+    const viewDef = registry[viewId];
+    const def = viewDef ?? registry.home;
+    const resolvedViewId = viewDef ? viewId : 'home';
+    return {
+      WrapView: (def.WrapView ?? Fragment) as ComponentType<
+        { children: ReactNode } & Record<string, unknown>
+      >,
+      TitlebarSlot: def.TitlebarSlot ?? (() => null),
+      MainPanel: def.MainPanel,
+      currentView: resolvedViewId,
+      lastNonSettingsView: appState.navigation.lastNonSettingsView,
+    };
+  });
+}

--- a/dash/apps/switchdash-desktop/src/renderer/main.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/main.tsx
@@ -5,7 +5,10 @@ import './index.css';
 import 'devicon/devicon.min.css';
 import 'katex/dist/katex.min.css';
 import { setupAppCommandProvider } from '@renderer/lib/commands/app-commands';
-import { setupViewCommandProvider, type ViewCommandProviders } from '@renderer/lib/commands/registry';
+import {
+  setupViewCommandProvider,
+  type ViewCommandProviders,
+} from '@renderer/lib/commands/registry';
 import { wireExternalLinkRequests } from '@renderer/lib/external-link-requests';
 import { rpc } from '@renderer/lib/ipc';
 import { viewStateCache } from '@renderer/lib/stores/view-state-cache';

--- a/dash/apps/switchdash-desktop/src/renderer/main.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/main.tsx
@@ -1,11 +1,11 @@
 import ReactDOM from 'react-dom/client';
-import { setupNavigationGuards } from '@renderer/app/view-registry';
+import { setupNavigationGuards, views } from '@renderer/app/view-registry';
 import { prefetchAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import './index.css';
 import 'devicon/devicon.min.css';
 import 'katex/dist/katex.min.css';
 import { setupAppCommandProvider } from '@renderer/lib/commands/app-commands';
-import { setupViewCommandProvider } from '@renderer/lib/commands/registry';
+import { setupViewCommandProvider, type ViewCommandProviders } from '@renderer/lib/commands/registry';
 import { wireExternalLinkRequests } from '@renderer/lib/external-link-requests';
 import { rpc } from '@renderer/lib/ipc';
 import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
@@ -35,7 +35,7 @@ async function bootstrap() {
   setupNavigationGuards();
   if (navResult) appState.navigation.restoreSnapshot(navResult);
   setupAppCommandProvider();
-  setupViewCommandProvider();
+  setupViewCommandProvider(views as unknown as ViewCommandProviders);
   if (sidebarResult) {
     appState.sidebar.restoreSnapshot(sidebarResult as Partial<SidebarSnapshot>);
   } else {


### PR DESCRIPTION
Closes [CHOO-1104](https://sandboxquantum.atlassian.net/browse/CHOO-1104).

## The problem

The `⚙️ Working on it…` indicator was refreshed **in place** — `apply_runtime_state` called `update_message` on the existing message rather than moving it. So it stayed pinned wherever the turn began and every message that arrived afterwards rendered below it, making it read as stale.

Scope is both directions, per the reporter: the indicator must follow messages the agent **receives** *and* messages it **sends**, and must keep moving *during* a turn rather than being placed once at the start.

## Two things that shaped the design

**1. Positioning had to be kept off the refresh path.** The switchdash connector re-POSTs `working` every 5s for the whole turn (`ACTIVITY_TICK_INTERVAL_MS`) to tick the elapsed-time suffix, and `sweep_runtime_states` runs its own 5s loop. Repositioning inside that path would delete-and-repost every 5s on every channel with a live agent. That is also precisely the churn `sweep_runtime_states`' docstring records as a past regression — the in-place edit this PR partly replaces was itself the fix for it. Refresh still edits in place; **only a message crossing the bridge moves the indicator.**

**2. The move is scoped per agent, not per channel.** An agent's indicator follows messages that address *it* — by name, by room alias, or any message in a DM room — and messages it posts itself. Unrelated chatter in a busy channel leaves it where it is. This bounds the churn at the source rather than relying on a debounce to mop it up.

## What changed

- **`LiveRuntimeIndicator`** (base adapter) replaces the bare message-ref string. A move has to repost the body verbatim into the same thread, and it has no access to the `detail`/`deeplink_url` the body was rendered from, so ref + body + thread root are now tracked together.
- **`reposition_runtime_state`** on `CollaborationAdapter`, defaulting to a no-op so typing-indicator adapters are untouched. Posts the replacement **before** removing the original: the indicator never blinks, and a failed repost leaves the original in place rather than clearing it.
- **Trigger in `BridgeCore`** — the one class where both directions converge — on `_handle_inbound_message` (both tails), `handle_outbound_message`, `handle_outbound_media` and `_relay_outbound_group`. Moves are coalesced into a 1s window, and the deadline is deliberately *not* extended by later messages so a sustained conversation cannot starve it.

### Per-platform behaviour

- **Slack / Discord** — full support; both delete cleanly.
- **Teams** — full support. Its delete *raises* where the others log, so a failed cleanup is now caught: a stale duplicate is preferable to a broken turn.
- **Mattermost** — **conditional, by design.** It inverts the order and deletes first. A clean removal needs a hard delete (v10.2+, `ServiceSettings.EnableAPIPostDeletion`, system-admin); reposting first and then discovering the delete is unavailable would strand a `✓ done` marker on **every** message — worse than the bug. Where the hard delete is unavailable it abandons the move and warns once per channel rather than degrading quietly.

## Notes for the reviewer

- **`bridge_message_map` is not affected.** The indicator is never recorded there (only relayed messages call `_record_message_map`), so the delete-and-repost costs no DB churn. This resolves the concern raised in the ticket.
- **Out of scope, flagged for its own ticket:** `_working_msg` is in-memory, so an indicator posted before a switch-core restart is orphaned and never cleaned up. Pre-existing; this change neither fixes nor worsens it.
- **Teams' clean-delete behaviour is documented-not-observed** — taken from the adapter's own docstring, not verified against a live tenant.

## Tests

`BridgeCore`'s runtime-state path and Mattermost's runtime state had **no** coverage at all; the `_permanent_delete` / `✓ done` fallback was entirely untested. Added:

- Slack: the move reposts rather than edits, stays in its thread, no-ops without a live indicator, and leaves the original alone when the repost fails.
- Mattermost: deletes before reposting, abandons the move when the hard delete is unavailable, warns once per channel, drops the stale ref when a post-delete repost fails, and still falls back to the terminal marker at turn end.
- `BridgeCore`: addressed agents move and unaddressed ones do not, name-prefix mentions don't false-match, aliases and DM rooms resolve, the agent's own messages move it, bursts coalesce to one move, the deadline isn't pushed back, and a platform failure during a move doesn't escape.

274 collaboration tests pass; `mypy` clean across 171 source files. (Store/DB tests need a Postgres container unavailable in this environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1104]: https://sandboxquantum.atlassian.net/browse/CHOO-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ