### PR TITLE
release(switch-core): 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ below:
 
 ### [Unreleased]
 
+### [0.12.2] - 2026-08-07
+
+#### Changed
+- The collaboration-bridge runtime indicator now follows the agent: it moves to
+  the foot of the conversation and into the thread the triggering message belongs
+  to (instead of staying where the turn opened), and the agent — not the bridge
+  watching traffic — decides when it moves (new `anchor_event_id` on the
+  runtime-state protocol), so it no longer jumps below a human's message before
+  the agent has been handed it (CHOO-1104).
+
+#### Fixed
+- Runtime-indicator robustness: serialise refresh vs repositioning, and don't
+  strand the indicator when a turn ends mid-move (CHOO-1104).
+- Discord: delete an agent's messages through the same webhook that posted them
+  (CHOO-1104).
+- Agent bridge: clamp a resumed cursor to the in-memory buffer head on heartbeat,
+  so a connection no longer silently skips events up to a stale cursor after a
+  switch-core restart.
+- Agent bridge: write the legacy room-binding row only for connectionless
+  (MCP-transport) callers, so a connection-backed `connect_to_room` no longer
+  leaves an unread, never-cleaned binding row behind.
+
 ### [0.12.1] - 2026-08-05
 
 #### Security

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.12.1"
+version = "0.12.2"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Cut switch-core `0.12.2` (patch).

**Version:** `core/pyproject.toml` 0.12.1 → 0.12.2 (tag will be `switch-v0.12.2`).

**Changelog (## switch-core → [0.12.2]):**
- **Changed:** collaboration-bridge runtime indicator follows the agent — moves to the foot of the conversation + into the triggering thread, agent-driven via `anchor_event_id` (CHOO-1104).
- **Fixed:** indicator refresh/reposition serialisation + no stranding mid-move (CHOO-1104); Discord deletes agent messages via the sending webhook (CHOO-1104); agent-bridge resumed-cursor clamp on heartbeat; room-binding row written only for connectionless callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)