### PR TITLE
release(switchdash): 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,18 @@ below:
 
 ### [Unreleased]
 
+### [0.19.1] - 2026-08-07
+
+#### Changed
+- switchdash sessions report their latest-message anchor so the
+  collaboration-bridge runtime indicator can follow the agent to the foot of the
+  conversation (CHOO-1104).
+
+#### Fixed
+- Fix an import cycle that could leave the view registry half-built — a renderer
+  crash ("Cannot access 'remoteHostsView' before initialization"), deterministic
+  in CI and load-order-dependent locally (CHOO-1104).
+
 ### [0.19.0] - 2026-08-07
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,9 @@ below:
 - switchdash sessions report their latest-message anchor so the
   collaboration-bridge runtime indicator can follow the agent to the foot of the
   conversation (CHOO-1104).
+- Bump the bundled switch-core for local managed servers to `0.12.2`
+  (`COMPATIBLE_SWITCH_VERSION`), so a fresh local stack pulls the latest
+  switch-core and existing stacks flag the drift for a one-click update.
 
 #### Fixed
 - Fix an import cycle that could leave the view registry half-built — a renderer

--- a/dash/apps/switchdash-desktop/package.json
+++ b/dash/apps/switchdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchdash/switchdash-desktop",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/dash/apps/switchdash-desktop/src/shared/app-identity.canary.ts
+++ b/dash/apps/switchdash-desktop/src/shared/app-identity.canary.ts
@@ -12,4 +12,4 @@ export const RELEASE_REPO_OWNER = 'sandbox-quantum';
 export const RELEASE_REPO_NAME = 'switch';
 
 // Keep in sync with COMPATIBLE_SWITCH_VERSION in ./app-identity.ts.
-export const COMPATIBLE_SWITCH_VERSION = '0.12.1';
+export const COMPATIBLE_SWITCH_VERSION = '0.12.2';

--- a/dash/apps/switchdash-desktop/src/shared/app-identity.ts
+++ b/dash/apps/switchdash-desktop/src/shared/app-identity.ts
@@ -27,4 +27,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // artifact. Bump it in lockstep with the bundled compose
 // (src/main/core/managed-switch-server/resources/standalone-docker-compose.pinned.yml)
 // so a switchdash release pins a known-good switch-core stack.
-export const COMPATIBLE_SWITCH_VERSION = '0.12.1';
+export const COMPATIBLE_SWITCH_VERSION = '0.12.2';


### PR DESCRIPTION
Cut switchdash `0.19.1` (patch).

**Version:** `dash/apps/switchdash-desktop/package.json` 0.19.0 → 0.19.1 (tag will be `switchdash-v0.19.1`).

**Changelog (## switchdash → [0.19.1]):**
- **Changed:** report the latest-message anchor so the collaboration-bridge runtime indicator follows the agent (CHOO-1104).
- **Fixed:** break an import cycle that could leave the view registry half-built — a renderer crash, deterministic in CI (CHOO-1104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)