### PR TITLE
fix(switchdash): restore sidebar drag-to-reorder for agents and rooms (CHOO-2007)

### DIFF
--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/agent-tree.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/agent-tree.tsx
@@ -4,6 +4,7 @@ import { switchRoomsStore } from '@renderer/features/switch-servers/switch-rooms
 import { sidebarStore } from '@renderer/lib/stores/app-state';
 import { agentExpandKey, SidebarAgentItem } from './agent-item';
 import { SidebarSessionItem } from './session-item';
+import { AGENTS_CONTAINER, makeDndId, SortableBranch, SortableList } from './sidebar-dnd';
 import {
   groupByRoom,
   isRoomViewActive,
@@ -89,13 +90,21 @@ const AgentSessions = observer(function AgentSessions({
 });
 
 export const AgentTree = observer(function AgentTree() {
+  const entries = scopedAgents();
   return (
-    <>
-      {scopedAgents().map((entry) => {
+    <SortableList
+      containerId={AGENTS_CONTAINER}
+      itemIds={entries.map((entry) => entry.agent.id)}
+      onReorder={(orderedIds) => sidebarStore.setAgentOrder(orderedIds)}
+    >
+      {entries.map((entry) => {
         const expanded = sidebarStore.isGroupExpanded(agentExpandKey(entry.agent.id));
         return (
-          <div key={entry.agent.id}>
-            <SidebarAgentItem agent={entry.agent} depth={0} />
+          <SortableBranch
+            key={entry.agent.id}
+            id={makeDndId(AGENTS_CONTAINER, entry.agent.id)}
+            header={<SidebarAgentItem agent={entry.agent} depth={0} />}
+          >
             {expanded && (
               <AgentSessions
                 agentId={entry.agent.id}
@@ -104,9 +113,9 @@ export const AgentTree = observer(function AgentTree() {
                 depth={1}
               />
             )}
-          </div>
+          </SortableBranch>
         );
       })}
-    </>
+    </SortableList>
   );
 });

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/room-tree.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/room-tree.tsx
@@ -7,6 +7,7 @@ import { sidebarStore } from '@renderer/lib/stores/app-state';
 import { RoomAgentRow } from './room-agent-row';
 import { filterRoomGroups, sortRoomGroups } from './room-tree-data';
 import { SidebarSessionItem } from './session-item';
+import { makeDndId, ROOMS_CONTAINER, SortableBranch, SortableList } from './sidebar-dnd';
 import {
   groupByRoom,
   isRoomViewActive,
@@ -74,7 +75,7 @@ export const RoomTree = observer(function RoomTree() {
     ]),
   ];
 
-  const groups = sortRoomGroups(
+  const sorted = sortRoomGroups(
     filterRoomGroups(
       groupByRoom(allSessions, alwaysShow)
         // This view lists rooms. A session connected to none of them is not in
@@ -95,36 +96,48 @@ export const RoomTree = observer(function RoomTree() {
     ),
     sidebarStore.roomSortBy
   );
+  // The user's dragged order sits on top of the default one, so a room they
+  // placed stays put while rooms they have not touched keep sorting normally.
+  const groups = sidebarStore.orderRooms(sorted, (group) => group.roomKey);
 
   if (groups.length === 0 && sidebarStore.hasActiveRoomFilters) {
     return <p className="px-2 py-3 text-xs text-foreground-muted">No rooms match filters</p>;
   }
 
   return (
-    <>
+    <SortableList
+      containerId={ROOMS_CONTAINER}
+      itemIds={groups.map((group) => group.roomKey)}
+      onReorder={(orderedIds) => sidebarStore.setRoomOrder(orderedIds)}
+    >
       {groups.map(({ roomKey, sessions: roomSessions }) => {
         const roomViewKey = roomViewGroupKey(roomKey);
         const expanded = sidebarStore.isGroupExpanded(roomViewKey);
         const agentsInRoom = members.get(roomKey) ?? [];
         return (
-          <div key={roomKey}>
-            <RoomRow
-              label={roomLabel(roomKey)}
-              count={roomSessions.length}
-              expanded={expanded}
-              depth={0}
-              bridgeType={switchRoomsStore.roomBridgeTypeById(roomKey)}
-              onToggle={() => sidebarStore.toggleGroupExpanded(roomViewKey)}
-              onSelect={() => openRoomView(roomKey)}
-              isActive={isRoomViewActive(roomKey)}
-              onOpenGateway={() => openRoomInGateway(roomKey)}
-              onOpenChannel={
-                switchRoomsStore.roomChannelUrl(roomKey)
-                  ? () => openRoomInMessagingApp(roomKey)
-                  : null
-              }
-              onAddAgent={() => showAddAgentsToRoomModal({ roomId: roomKey })}
-            />
+          <SortableBranch
+            key={roomKey}
+            id={makeDndId(ROOMS_CONTAINER, roomKey)}
+            header={
+              <RoomRow
+                label={roomLabel(roomKey)}
+                count={roomSessions.length}
+                expanded={expanded}
+                depth={0}
+                bridgeType={switchRoomsStore.roomBridgeTypeById(roomKey)}
+                onToggle={() => sidebarStore.toggleGroupExpanded(roomViewKey)}
+                onSelect={() => openRoomView(roomKey)}
+                isActive={isRoomViewActive(roomKey)}
+                onOpenGateway={() => openRoomInGateway(roomKey)}
+                onOpenChannel={
+                  switchRoomsStore.roomChannelUrl(roomKey)
+                    ? () => openRoomInMessagingApp(roomKey)
+                    : null
+                }
+                onAddAgent={() => showAddAgentsToRoomModal({ roomId: roomKey })}
+              />
+            }
+          >
             {expanded &&
               agentsInRoom.map((entry) => {
                 const sessionsHere = roomSessions.filter(
@@ -148,9 +161,9 @@ export const RoomTree = observer(function RoomTree() {
                   </Fragment>
                 );
               })}
-          </div>
+          </SortableBranch>
         );
       })}
-    </>
+    </SortableList>
   );
 });

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-dnd.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-dnd.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENTS_CONTAINER,
+  makeDndId,
+  parseDndId,
+  reorderOnDrop,
+  ROOMS_CONTAINER,
+} from './sidebar-dnd';
+
+describe('sidebar drag ids', () => {
+  it('round-trips a container and item id', () => {
+    expect(parseDndId(makeDndId(AGENTS_CONTAINER, 'agent-1'))).toEqual({
+      containerId: AGENTS_CONTAINER,
+      itemId: 'agent-1',
+    });
+  });
+
+  it('keeps an item id containing the separator intact', () => {
+    // Room keys are opaque, so the split must be on the FIRST separator only.
+    const id = makeDndId(ROOMS_CONTAINER, 'room~~odd');
+    expect(parseDndId(id)).toEqual({ containerId: ROOMS_CONTAINER, itemId: 'room~~odd' });
+  });
+
+  it('rejects an id with no separator', () => {
+    expect(parseDndId('agents')).toBeNull();
+  });
+});
+
+describe('reorderOnDrop', () => {
+  const ids = ['a', 'b', 'c'];
+  const dnd = (itemId: string) => makeDndId(AGENTS_CONTAINER, itemId);
+
+  it('moves the dragged item to the drop position', () => {
+    expect(reorderOnDrop(ids, dnd('a'), dnd('c'))).toEqual(['b', 'c', 'a']);
+    expect(reorderOnDrop(ids, dnd('c'), dnd('a'))).toEqual(['c', 'a', 'b']);
+  });
+
+  it('is a no-op when dropped on itself', () => {
+    expect(reorderOnDrop(ids, dnd('b'), dnd('b'))).toBeNull();
+  });
+
+  it('refuses a drop into a different container', () => {
+    // Agents and rooms are separate lists; a drag may reorder, never re-parent.
+    expect(reorderOnDrop(ids, dnd('a'), makeDndId(ROOMS_CONTAINER, 'b'))).toBeNull();
+  });
+
+  it('refuses a drop involving an id that is no longer listed', () => {
+    expect(reorderOnDrop(ids, dnd('gone'), dnd('b'))).toBeNull();
+    expect(reorderOnDrop(ids, dnd('a'), dnd('gone'))).toBeNull();
+  });
+
+  it('does not mutate the list it was given', () => {
+    const original = [...ids];
+    reorderOnDrop(ids, dnd('a'), dnd('c'));
+    expect(ids).toEqual(original);
+  });
+});

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-dnd.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-dnd.tsx
@@ -1,0 +1,152 @@
+import {
+  closestCenter,
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * Drag-to-reorder plumbing for the sidebar's two top-level lists: the agents in
+ * the agent view and the rooms in the room view.
+ *
+ * Every draggable carries a composite id `${containerId}~~${itemId}`. The
+ * container id identifies the sibling set an item belongs to; reordering is
+ * restricted to within a container so a drag can only change order, never move
+ * an item into a different list.
+ */
+const SEP = '~~';
+
+/** The reorderable sibling sets. Only the top level of each view is draggable. */
+export const AGENTS_CONTAINER = 'agents';
+export const ROOMS_CONTAINER = 'rooms';
+
+export function makeDndId(containerId: string, itemId: string): string {
+  return `${containerId}${SEP}${itemId}`;
+}
+
+export function parseDndId(dndId: string): { containerId: string; itemId: string } | null {
+  const idx = dndId.indexOf(SEP);
+  if (idx === -1) return null;
+  return { containerId: dndId.slice(0, idx), itemId: dndId.slice(idx + SEP.length) };
+}
+
+/**
+ * Collision detection that only considers droppables in the same container as
+ * the active item, so a drag can only land among its own siblings.
+ */
+const sameContainerCollision: CollisionDetection = (args) => {
+  const active = parseDndId(String(args.active.id));
+  if (!active) return [];
+  const droppableContainers = args.droppableContainers.filter((container) => {
+    const parsed = parseDndId(String(container.id));
+    return parsed?.containerId === active.containerId;
+  });
+  return closestCenter({ ...args, droppableContainers });
+};
+
+/**
+ * The order `ids` takes when the item dragged from `activeId` is dropped on
+ * `overId`, or null when the drop is a no-op (same slot, foreign container, or
+ * an id that is no longer in the list).
+ *
+ * Split out from the drag handler so the reorder rule is testable without a DOM
+ * or a pointer.
+ */
+export function reorderOnDrop(
+  ids: readonly string[],
+  activeId: string,
+  overId: string
+): string[] | null {
+  const from = parseDndId(activeId);
+  const to = parseDndId(overId);
+  if (!from || !to || from.containerId !== to.containerId) return null;
+  const oldIndex = ids.indexOf(from.itemId);
+  const newIndex = ids.indexOf(to.itemId);
+  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return null;
+  return arrayMove([...ids], oldIndex, newIndex);
+}
+
+function useSortableRow(id: string) {
+  const { setNodeRef, transform, transition, isDragging, listeners } = useSortable({ id });
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : undefined,
+    position: 'relative',
+    zIndex: isDragging ? 1 : undefined,
+  };
+  return { setNodeRef, style, listeners };
+}
+
+/**
+ * One draggable top-level row. Only `header` is the drag handle: `children`
+ * (the row's expanded subtree) moves with it but does not start a drag, so
+ * dragging inside an expanded agent or room does nothing rather than picking up
+ * the whole branch by surprise.
+ */
+export function SortableBranch({
+  id,
+  header,
+  children,
+}: {
+  id: string;
+  header: ReactNode;
+  children?: ReactNode;
+}) {
+  const { setNodeRef, style, listeners } = useSortableRow(id);
+  return (
+    <div ref={setNodeRef} style={style}>
+      <div {...listeners}>{header}</div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Wraps one top-level list in the drag context that reorders it. `itemIds` is
+ * the list as currently rendered; `onReorder` receives the new order on drop.
+ */
+export function SortableList({
+  containerId,
+  itemIds,
+  onReorder,
+  children,
+}: {
+  containerId: string;
+  itemIds: string[];
+  onReorder: (orderedItemIds: string[]) => void;
+  children: ReactNode;
+}) {
+  // A short activation distance keeps a click a click: rows open pages, toggle
+  // expansion and open context menus, and none of that may become a drag.
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+
+  function onDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over) return;
+    const reordered = reorderOnDrop(itemIds, String(active.id), String(over.id));
+    if (reordered) onReorder(reordered);
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={sameContainerCollision} onDragEnd={onDragEnd}>
+      <SortableContext
+        items={itemIds.map((itemId) => makeDndId(containerId, itemId))}
+        strategy={verticalListSortingStrategy}
+      >
+        {children}
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -81,37 +81,35 @@ describe('SidebarStore location ordering', () => {
     expect(store.orderedLocations.map((location) => location.id)).toEqual(['new', 'old']);
   });
 
-  it('places locations missing from a saved manual order first', () => {
+  it('orders locations by recency alone — manual order lives on agents, not locations', () => {
     const store = new SidebarStore(
       locationManager([
         { id: 'old', createdAt: '2026-01-01T00:00:00.000Z' },
-        { id: 'manual', createdAt: '2026-01-02T00:00:00.000Z' },
+        { id: 'middle', createdAt: '2026-01-02T00:00:00.000Z' },
         { id: 'new', createdAt: '2026-01-03T00:00:00.000Z' },
       ])
     );
 
-    store.setLocationOrder(['manual', 'old']);
-
-    expect(store.orderedLocations.map((location) => location.id)).toEqual(['new', 'manual', 'old']);
+    expect(store.orderedLocations.map((location) => location.id)).toEqual(['new', 'middle', 'old']);
   });
 
   it('returns visible session entries in rendered location-tree order', () => {
     const store = new SidebarStore(
       locationManagerWithSessions([
         {
+          // Newest, so it renders first and its sessions lead the list.
           id: 'location-1',
-          createdAt: '2026-01-01T00:00:00.000Z',
+          createdAt: '2026-01-02T00:00:00.000Z',
           sessionIds: ['session-1a', 'session-1b'],
         },
         {
           id: 'location-2',
-          createdAt: '2026-01-02T00:00:00.000Z',
+          createdAt: '2026-01-01T00:00:00.000Z',
           sessionIds: ['session-2a'],
         },
       ])
     );
 
-    store.setLocationOrder(['location-1', 'location-2']);
     store.ensureLocationExpanded('location-1');
     store.ensureLocationExpanded('location-2');
     store.setSessionOrder('location-1', ['session-1a', 'session-1b']);
@@ -479,41 +477,54 @@ describe('applyManualOrder', () => {
   });
 });
 
-describe('SidebarStore grouped-view ordering', () => {
-  it('orders top-level room keys by the saved manual room order', () => {
+describe('SidebarStore drag-to-reorder ordering', () => {
+  it('orders top-level rooms by the saved manual room order', () => {
     const store = new SidebarStore(locationManager([]));
     store.setRoomOrder(['room-c', 'room-a']);
+    const rooms = [{ roomKey: 'room-a' }, { roomKey: 'room-b' }, { roomKey: 'room-c' }];
     // Saved rooms come first in saved order; unknown rooms append.
-    expect(store.orderRoomKeys(['room-a', 'room-b', 'room-c'])).toEqual([
-      'room-c',
-      'room-a',
-      'room-b',
+    expect(store.orderRooms(rooms, (room) => room.roomKey)).toEqual([
+      { roomKey: 'room-c' },
+      { roomKey: 'room-a' },
+      { roomKey: 'room-b' },
     ]);
   });
 
-  it('orders a sub-group by its saved order, surfacing new sessions first', () => {
+  it('orders top-level agents by the saved manual agent order', () => {
     const store = new SidebarStore(locationManager([]));
-    const sessions = [{ id: 's1' }, { id: 's2' }, { id: 's3' }];
-    store.setGroupOrder('as:p1|room-1', ['s2', 's1']);
-    expect(store.orderGroupItems('as:p1|room-1', sessions, (s) => s.id, true)).toEqual([
-      { id: 's3' },
-      { id: 's2' },
-      { id: 's1' },
+    store.setAgentOrder(['agent-c', 'agent-a']);
+    const agents = [{ id: 'agent-a' }, { id: 'agent-b' }, { id: 'agent-c' }];
+    expect(store.orderAgents(agents, (agent) => agent.id)).toEqual([
+      { id: 'agent-c' },
+      { id: 'agent-a' },
+      { id: 'agent-b' },
     ]);
   });
 
-  it('round-trips room and group order through the snapshot', () => {
+  it('keeps a dragged agent in place when a new agent arrives', () => {
+    const store = new SidebarStore(locationManager([]));
+    store.setAgentOrder(['agent-b', 'agent-a']);
+    // A newly-added agent must not displace an order the user set deliberately.
+    const agents = [{ id: 'agent-a' }, { id: 'agent-b' }, { id: 'fresh' }];
+    expect(store.orderAgents(agents, (agent) => agent.id).map((agent) => agent.id)).toEqual([
+      'agent-b',
+      'agent-a',
+      'fresh',
+    ]);
+  });
+
+  it('round-trips agent and room order through the snapshot', () => {
     const store = new SidebarStore(locationManager([]));
     store.setRoomOrder(['room-2', 'room-1']);
-    store.setGroupOrder('as:p1|room-1', ['s2', 's1']);
+    store.setAgentOrder(['agent-2', 'agent-1']);
 
     const snapshot = store.snapshot;
     expect(snapshot.roomOrder).toEqual(['room-2', 'room-1']);
-    expect(snapshot.groupOrder).toEqual({ 'as:p1|room-1': ['s2', 's1'] });
+    expect(snapshot.agentOrder).toEqual(['agent-2', 'agent-1']);
 
     const restored = new SidebarStore(locationManager([]));
     restored.restoreSnapshot(snapshot);
     expect(restored.roomOrder).toEqual(['room-2', 'room-1']);
-    expect(restored.groupOrder).toEqual({ 'as:p1|room-1': ['s2', 's1'] });
+    expect(restored.agentOrder).toEqual(['agent-2', 'agent-1']);
   });
 });

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
@@ -131,12 +131,16 @@ export function applyManualOrder<T>(
 }
 
 export class SidebarStore implements Snapshottable<SidebarSnapshot> {
-  locationOrder: string[] = [];
+  /**
+   * Manual order of the top-level agents (agent-focused grouping), by agent id.
+   * The agent is the unit the sidebar lists and the user drags; a location can
+   * hold several agents, so ordering by location cannot express a drag that
+   * moves one of them past its neighbour.
+   */
+  agentOrder: string[] = [];
   sessionOrderByLocation: Record<string, string[]> = {};
   /** Manual order of top-level rooms (room-focused grouping). */
   roomOrder: string[] = [];
-  /** Manual order of items within a grouped-view sub-group, keyed by container id. */
-  groupOrder: Record<string, string[]> = {};
   expandedLocationIds = observable.set<string>();
   sessionSortBy: SidebarSessionSortBy = 'created-at';
   grouping: SidebarGrouping = 'agent';
@@ -223,19 +227,17 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
     return agentsStore.serverIdForLocation(locationId) === activeServerId;
   }
 
+  /**
+   * Server-scoped locations, newest first. Locations are no longer a level of
+   * the sidebar tree — the manual order the user drags lives on agents and
+   * rooms — so this is the plain default order the agent list is built from.
+   */
   get orderedLocations(): LocationStore[] {
     const all = Array.from(this.locationManager.locations.values()).filter((location) =>
       this.isLocationInActiveScope(location.id)
     );
 
-    return [...all].sort((a, b) => {
-      const ai = this.locationOrder.indexOf(a.id);
-      const bi = this.locationOrder.indexOf(b.id);
-      if (ai === -1 && bi === -1) return this.compareSidebarLocations(a, b);
-      if (ai === -1) return -1;
-      if (bi === -1) return 1;
-      return ai - bi;
-    });
+    return [...all].sort((a, b) => this.compareSidebarLocations(a, b));
   }
 
   /** The representative agent of a location (the agent shown on its sidebar row):
@@ -427,14 +429,13 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
   get snapshot(): SidebarSnapshot {
     return {
       expandedLocationIds: [...this.expandedLocationIds],
-      locationOrder: [...this.locationOrder],
+      agentOrder: [...this.agentOrder],
       sessionOrderByLocation: { ...this.sessionOrderByLocation },
       sessionSortBy: this.sessionSortBy,
       grouping: this.grouping,
       expandedRoomKeys: [...this.expandedRoomKeys],
       collapsedGroupKeys: [...this.collapsedGroupKeys],
       roomOrder: [...this.roomOrder],
-      groupOrder: { ...this.groupOrder },
       filterConnections: [...this.filterConnections],
       filterProviderIds: [...this.filterProviderIds],
       filterHasLiveSession: this.filterHasLiveSession,
@@ -448,8 +449,8 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
     if (snapshot.expandedLocationIds !== undefined) {
       this.expandedLocationIds.replace(snapshot.expandedLocationIds);
     }
-    if (snapshot.locationOrder !== undefined) {
-      this.locationOrder = [...snapshot.locationOrder];
+    if (snapshot.agentOrder !== undefined) {
+      this.agentOrder = [...snapshot.agentOrder];
     }
     if (snapshot.sessionOrderByLocation !== undefined) {
       this.sessionOrderByLocation = { ...snapshot.sessionOrderByLocation };
@@ -468,9 +469,6 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
     }
     if (snapshot.roomOrder !== undefined) {
       this.roomOrder = [...snapshot.roomOrder];
-    }
-    if (snapshot.groupOrder !== undefined) {
-      this.groupOrder = { ...snapshot.groupOrder };
     }
     if (snapshot.filterConnections !== undefined) {
       this.filterConnections.replace(snapshot.filterConnections.filter(isAgentConnectionKind));
@@ -615,34 +613,26 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
     this.sessionOrderByLocation = {};
   }
 
-  setLocationOrder(ids: string[]): void {
-    this.locationOrder = ids;
+  setAgentOrder(ids: string[]): void {
+    this.agentOrder = ids;
   }
 
   setRoomOrder(ids: string[]): void {
     this.roomOrder = ids;
   }
 
-  setGroupOrder(containerId: string, ids: string[]): void {
-    this.groupOrder = { ...this.groupOrder, [containerId]: ids };
-  }
-
-  /** Top-level room keys reordered by the saved manual room order. */
-  orderRoomKeys(roomKeys: string[]): string[] {
-    return applyManualOrder(roomKeys, (key) => key, this.roomOrder, false);
-  }
-
   /**
-   * Items within a grouped-view sub-group reordered by its saved manual order.
-   * `newFirst` surfaces freshly-arrived items at the top (used for sessions).
+   * Top-level agents reordered by the saved manual order. An agent the user has
+   * never dragged sorts after the ones they have, keeping a newly-added agent
+   * from displacing an arrangement they set deliberately.
    */
-  orderGroupItems<T>(
-    containerId: string,
-    items: T[],
-    getId: (item: T) => string,
-    newFirst: boolean
-  ): T[] {
-    return applyManualOrder(items, getId, this.groupOrder[containerId], newFirst);
+  orderAgents<T>(agents: T[], getId: (agent: T) => string): T[] {
+    return applyManualOrder(agents, getId, this.agentOrder, false);
+  }
+
+  /** Top-level rooms reordered by the saved manual room order, same rule. */
+  orderRooms<T>(rooms: T[], getId: (room: T) => string): T[] {
+    return applyManualOrder(rooms, getId, this.roomOrder, false);
   }
 
   mergeSessionOrder(locationId: string, sessions: SessionStore[]): SessionStore[] {

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-tree-data.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-tree-data.ts
@@ -14,8 +14,12 @@ import type { Agent } from '@shared/core/agents/agents';
 export type AgentEntry = { agent: Agent; location: LocationStore };
 
 /**
- * The flat list of agents in the active-server scope, newest first. switchdash
- * shows agents as a flat list — not grouped by directory (CHOO-1440).
+ * The flat list of agents in the active-server scope. switchdash shows agents
+ * as a flat list — not grouped by directory (CHOO-1440).
+ *
+ * Newest first, then overlaid with the user's manual drag order: an agent they
+ * have positioned stays where they put it, and one they have not sorts after
+ * those by recency.
  */
 export function scopedAgents(): AgentEntry[] {
   const entries: AgentEntry[] = [];
@@ -24,10 +28,11 @@ export function scopedAgents(): AgentEntry[] {
       entries.push({ agent, location });
     }
   }
-  return entries.sort(
+  entries.sort(
     (a, b) =>
       b.agent.createdAt.localeCompare(a.agent.createdAt) || a.agent.name.localeCompare(b.agent.name)
   );
+  return sidebarStore.orderAgents(entries, (entry) => entry.agent.id);
 }
 
 /**

--- a/dash/apps/switchdash-desktop/src/renderer/tests/browser/sidebar-drag-reorder.test.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/tests/browser/sidebar-drag-reorder.test.tsx
@@ -1,0 +1,150 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+/**
+ * Drag-to-reorder in the sidebar (CHOO-2007).
+ *
+ * The reorder *rule* is unit-tested in `sidebar-dnd.test.ts`; what only a real
+ * browser can show is that a pointer drag reaches that rule at all — dnd-kit
+ * needs real layout to measure droppables and real pointer events to arm its
+ * sensor, and the bug being fixed was precisely a UI that no longer existed
+ * rather than a rule that computed the wrong answer.
+ */
+import {
+  AGENTS_CONTAINER,
+  makeDndId,
+  SortableBranch,
+  SortableList,
+} from '@renderer/features/sidebar/sidebar-dnd';
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+const ROW_HEIGHT = 40;
+
+async function renderList(
+  ids: string[],
+  onReorder: (ordered: string[]) => void
+): Promise<HTMLDivElement> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () =>
+    root!.render(
+      <SortableList containerId={AGENTS_CONTAINER} itemIds={ids} onReorder={onReorder}>
+        {ids.map((id) => (
+          <SortableBranch
+            key={id}
+            id={makeDndId(AGENTS_CONTAINER, id)}
+            header={
+              <div data-row={id} style={{ height: ROW_HEIGHT, lineHeight: `${ROW_HEIGHT}px` }}>
+                {id}
+              </div>
+            }
+          />
+        ))}
+      </SortableList>
+    )
+  );
+  return container;
+}
+
+function row(id: string): HTMLElement {
+  const el = container?.querySelector(`[data-row="${id}"]`);
+  if (!el) throw new Error(`row ${id} not rendered`);
+  return el as HTMLElement;
+}
+
+function centre(el: HTMLElement): { x: number; y: number } {
+  const rect = el.getBoundingClientRect();
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
+
+function pointer(type: string, at: { x: number; y: number }, target: EventTarget): void {
+  target.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: at.x,
+      clientY: at.y,
+      pointerId: 1,
+      pointerType: 'mouse',
+      isPrimary: true,
+      button: 0,
+      buttons: type === 'pointerup' ? 0 : 1,
+    })
+  );
+}
+
+/**
+ * A pointer drag from one row onto another. The intermediate moves matter: the
+ * sensor only arms once the pointer has travelled past its activation distance,
+ * which is what stops a click on a row from becoming a drag.
+ */
+async function drag(fromId: string, toId: string): Promise<void> {
+  const from = row(fromId);
+  const start = centre(from);
+  const end = centre(row(toId));
+
+  await act(async () => {
+    pointer('pointerdown', start, from);
+  });
+  // Cross the 6px activation threshold, then travel to the target.
+  for (const step of [0.05, 0.25, 0.5, 0.75, 1]) {
+    await act(async () => {
+      pointer(
+        'pointermove',
+        { x: start.x + (end.x - start.x) * step, y: start.y + (end.y - start.y) * step },
+        document
+      );
+    });
+  }
+  await act(async () => {
+    pointer('pointerup', end, document);
+  });
+}
+
+describe('sidebar drag-to-reorder', () => {
+  it('reports the new order when a row is dragged past another', async () => {
+    const calls: string[][] = [];
+    await renderList(['agent-a', 'agent-b', 'agent-c'], (ordered) => calls.push(ordered));
+
+    await drag('agent-a', 'agent-c');
+
+    expect(calls).toEqual([['agent-b', 'agent-c', 'agent-a']]);
+  });
+
+  it('moves a row upwards too', async () => {
+    const calls: string[][] = [];
+    await renderList(['agent-a', 'agent-b', 'agent-c'], (ordered) => calls.push(ordered));
+
+    await drag('agent-c', 'agent-a');
+
+    expect(calls).toEqual([['agent-c', 'agent-a', 'agent-b']]);
+  });
+
+  it('does not reorder on a click', async () => {
+    // Sidebar rows open pages and toggle expansion; a plain click must not be
+    // read as a zero-distance drag.
+    const calls: string[][] = [];
+    await renderList(['agent-a', 'agent-b', 'agent-c'], (ordered) => calls.push(ordered));
+
+    const target = row('agent-b');
+    const at = centre(target);
+    await act(async () => {
+      pointer('pointerdown', at, target);
+    });
+    await act(async () => {
+      pointer('pointerup', at, document);
+    });
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/dash/apps/switchdash-desktop/src/shared/view-state.ts
+++ b/dash/apps/switchdash-desktop/src/shared/view-state.ts
@@ -25,7 +25,12 @@ export type SidebarGrouping = 'agent' | 'room';
 /** Persisted sidebar UI state; fields may be absent in older DB blobs. */
 export type SidebarSnapshot = {
   expandedLocationIds?: string[];
-  locationOrder?: string[];
+  /**
+   * Manual order of the top-level agents in the agent-focused grouping, by
+   * agent id. Superseded `locationOrder`, which keyed the same intent by
+   * location and so could not order two agents sharing one.
+   */
+  agentOrder?: string[];
   sessionOrderByLocation?: Record<string, string[]>;
   sessionSortBy?: SidebarSessionSortBy;
   grouping?: SidebarGrouping;
@@ -39,12 +44,6 @@ export type SidebarSnapshot = {
   collapsedGroupKeys?: string[];
   /** Manual order of the top-level rooms in the room-focused grouping. */
   roomOrder?: string[];
-  /**
-   * Manual order of items within a grouped-view sub-group, keyed by a container
-   * id (e.g. an agent's room group, or a room's per-agent session group). Used by
-   * the grouped views' drag-to-reorder; absent groups fall back to the default sort.
-   */
-  groupOrder?: Record<string, string[]>;
   /**
    * Optional left-sidebar filters. Each dimension is additive and composes with
    * the others (AND across dimensions, OR within one). An empty array / false


### PR DESCRIPTION
## What

Drag-to-reorder in the left sidebar — for agents in the agent view and rooms in the room view — stopped working. It was not broken: it was **deleted**.

Commit `d6a34b8e` (*"remove the subagent concept — flat repository-defined agents"*, CHOO-1440) deleted `sidebar-dnd.tsx` and stripped the `DndContext` / `SortableContext` wiring out of the sidebar. Drag-reorder went out as collateral of the flat-agent-list rewrite, and nothing replaced it. The `@dnd-kit/*` dependencies stayed in `package.json` with zero importers.

Jira: [CHOO-2007](https://sandboxquantum.atlassian.net/browse/CHOO-2007)

## Why it is smaller than it sounds

Most of the persistence survived the rewrite — but it was **more dead than it looked**:

- `orderedLocations` did sort by `locationOrder`, but `scopedAgents()` re-sorted the flat result by `agent.createdAt`/name on top, **discarding it**. Nothing could set the order, and nothing would have honoured it if it had.
- `orderRoomKeys()`, `setLocationOrder`, `setRoomOrder`, `setGroupOrder`, `orderGroupItems` — the entire write side had **zero production callers**, referenced only by their own tests.

## What changed

- **`sidebar-dnd.tsx`, re-fitted rather than restored.** Same contract as the deleted module — composite `containerId~~itemId` ids and same-container collision detection, so a drag can reorder but never re-parent — minus the location-grouping and subagent sub-list assumptions CHOO-1440 removed. Two containers: `agents` and `rooms`. Only the row header is a drag handle, so dragging inside an expanded agent does not pick up the whole branch.
- **`agentOrder` replaces `locationOrder`.** Post-CHOO-1440 the top-level row is an *agent*, and many agents can share a location, so a per-location order cannot express moving one agent past its neighbour. Keyed by agent id.
- **Room view wired up** via `orderRooms()`.
- **`groupOrder` and its accessors deleted.** Within-group reordering is out of scope, and leaving unreachable machinery behind is what made a deletion look like a bug.

Persistence needed no new plumbing: the snapshot registry already debounce-saves the sidebar snapshot through a schema-free KV, so `agentOrder` rides along. Older snapshot blobs still load — every field is optional.

## Verification

The point of the ticket is that the order *sticks*, so in-memory was not going to count.

Ran the real app (Electron under Xvfb, driven over its debug port) against an isolated `SWITCHDASH_DB_FILE` and user-data dir:

1. First launch — default order `CCC-gamma, BBB-beta, AAA-alpha`
2. Dragged the top agent to the bottom — `BBB-beta, AAA-alpha, CCC-gamma`
3. SQLite showed `agentOrder: ["agent-beta","agent-alpha","agent-gamma"]`
4. Fully quit — confirmed no Electron processes and the debug port dead
5. **Cold start — `BBB-beta, AAA-alpha, CCC-gamma`**, restored from disk

Automated: 2041 node tests, 66 browser tests, typecheck and lint clean. New coverage includes a **real pointer drag in a headless browser** (dnd-kit needs real layout and real pointer events, so the reducer unit test alone would not have caught a UI that is not wired up) and a check that a plain click does not reorder.

**Not verified end-to-end:** the room view. The Rooms tab sources its list from a live Switch server rather than the local DB, so an isolated instance has no rooms to drag. That path is covered by unit tests and shares all its drag machinery with the agent path, but it has not been exercised against real room data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-2007]: https://sandboxquantum.atlassian.net/browse/CHOO-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ