### PR TITLE
release(switch-core): 0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ below:
 
 ### [Unreleased]
 
+### [0.12.3] - 2026-08-07
+
+#### Added
+- Collaboration bridges expose a workspace/home deeplink so a client can open
+  the messaging app's workspace from the gateway (CHOO-1784).
+
+#### Security
+- Admin-gate every collaboration-bridge write: updating and deleting a bridge
+  were ungated, so any authenticated user could toggle agent greetings or delete
+  a bridge (which cascades into deleting every room on it) — now admin-only
+  (CHOO-1784).
+
 ### [0.12.2] - 2026-08-07
 
 #### Changed

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.12.2"
+version = "0.12.3"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Cut switch-core `0.12.3` (patch). Tag will be `switch-v0.12.3`.

- **Added:** collaboration bridges expose a workspace/home deeplink (CHOO-1784).
- **Security:** admin-gate every collaboration-bridge write — update/delete were ungated (CHOO-1784).

🤖 Generated with [Claude Code](https://claude.com/claude-code)