### PR TITLE
release(switchdash): 0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,25 @@ below:
 
 ### [Unreleased]
 
+### [0.19.2] - 2026-08-07
+
+#### Added
+- Connect a messaging app (Slack/Mattermost/Discord/Teams) to a server from
+  within switchdash — per-platform setup-guide links and a Teams icon; open a
+  messaging app's workspace from the server page (CHOO-1784).
+
+#### Changed
+- New macOS app icon (max.tam's mark); a dark mark for non-release (canary/dev)
+  channels; dropped the leftover emdash DMG art/wordmark (CHOO-2004).
+- Bump the bundled switch-core for local managed servers to `0.12.3`
+  (`COMPATIBLE_SWITCH_VERSION`).
+
+#### Fixed
+- Restore sidebar drag-to-reorder for agents and rooms (CHOO-2007).
+- Set `GATEWAY_PUBLIC_URL` so "Open in SwitchDash" links work; redact the
+  credential key names configs actually use; vendor the real Teams logo
+  (CHOO-1784).
+
 ### [0.19.1] - 2026-08-07
 
 #### Changed

--- a/dash/apps/switchdash-desktop/package.json
+++ b/dash/apps/switchdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchdash/switchdash-desktop",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/dash/apps/switchdash-desktop/src/shared/app-identity.canary.ts
+++ b/dash/apps/switchdash-desktop/src/shared/app-identity.canary.ts
@@ -12,4 +12,4 @@ export const RELEASE_REPO_OWNER = 'sandbox-quantum';
 export const RELEASE_REPO_NAME = 'switch';
 
 // Keep in sync with COMPATIBLE_SWITCH_VERSION in ./app-identity.ts.
-export const COMPATIBLE_SWITCH_VERSION = '0.12.2';
+export const COMPATIBLE_SWITCH_VERSION = '0.12.3';

--- a/dash/apps/switchdash-desktop/src/shared/app-identity.ts
+++ b/dash/apps/switchdash-desktop/src/shared/app-identity.ts
@@ -27,4 +27,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // artifact. Bump it in lockstep with the bundled compose
 // (src/main/core/managed-switch-server/resources/standalone-docker-compose.pinned.yml)
 // so a switchdash release pins a known-good switch-core stack.
-export const COMPATIBLE_SWITCH_VERSION = '0.12.2';
+export const COMPATIBLE_SWITCH_VERSION = '0.12.3';


### PR DESCRIPTION
Cut switchdash `0.19.2` (patch). Tag will be `switchdash-v0.19.2`.

- **Added:** connect a messaging app (Slack/Mattermost/Discord/Teams) to a server in-app; open a workspace from the server page (CHOO-1784).
- **Changed:** new macOS app icon + non-release dark mark, drop emdash art (CHOO-2004); bump bundled switch-core to `0.12.3` (COMPATIBLE_SWITCH_VERSION + .canary).
- **Fixed:** restore sidebar drag-to-reorder (CHOO-2007); GATEWAY_PUBLIC_URL, credential-key redaction, real Teams logo (CHOO-1784).

Paired with switch-core 0.12.3 (PR #150); tags pushed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)