### PR TITLE
fix(security): M2 pre-flip repo files — SECURITY.md, CODEOWNERS, release prep least-privilege (CHOO-1251)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,1 @@
-# Code owners for sandbox-quantum/switch.
-#
-# Owners are automatically requested for review on PRs that touch matching
-# paths. This only *enforces* review when the branch-protection ruleset has
-# "Require review from Code Owners" enabled.
-#
-# Later this can be pointed at a GitHub team (e.g. @sandbox-quantum/switch-maintainers)
-# instead of individual handles.
-
 * @amaudruz @christian-mcdermott

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners for sandbox-quantum/switch.
+#
+# Owners are automatically requested for review on PRs that touch matching
+# paths. This only *enforces* review when the branch-protection ruleset has
+# "Require review from Code Owners" enabled.
+#
+# Later this can be pointed at a GitHub team (e.g. @sandbox-quantum/switch-maintainers)
+# instead of individual handles.
+
+* @amaudruz @christian-mcdermott

--- a/.github/workflows/switch-release.yml
+++ b/.github/workflows/switch-release.yml
@@ -30,6 +30,8 @@ jobs:
   prep:
     name: Resolve + verify version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
       push: ${{ steps.version.outputs.push }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately through GitHub's **private vulnerability reporting**:
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability**.
+3. Describe the issue, including steps to reproduce, affected component(s), and
+   the impact you believe it has.
+
+This opens a private advisory visible only to you and the maintainers.
+
+We aim to acknowledge a report within **3 business days** and to provide an
+initial assessment within **10 business days**. Please give us a reasonable
+window to investigate and ship a fix before any public disclosure, and we will
+keep you informed of progress.
+
+When reporting, please include where relevant:
+
+- The component and version / commit affected (e.g. `switch-core`, the gateway,
+  switchdash, a collaboration bridge).
+- A clear description of the vulnerability and its impact.
+- Steps to reproduce or a proof of concept.
+- Any suggested remediation.
+
+## Scope
+
+This policy covers the code in this repository: the Switch control plane
+(`core/`), the operator gateway (`gateway/`), the switchdash desktop app
+(`dash/`), the connector plugins (`connectors/`), and the deployment assets
+(`deploy/`). Vulnerabilities in third-party dependencies should be reported to
+the upstream project; if a dependency issue affects Switch specifically, let us
+know so we can pull in the fix.


### PR DESCRIPTION
## M2 pre-flip — repo-file subset (CHOO-1251)

Covers the **code** half of the M2 pre-flip subset from the InfoSec review (INFOSEC-499). The paired **settings** changes (default workflow token → read-only, disallow "Actions create/approve PRs", branch protection) were done in the GitHub UI and are not in this diff.

### Changes
- **`SECURITY.md`** — a private disclosure path. Primary channel is **GitHub private vulnerability reporting** (Security tab → Report a vulnerability), plus response SLAs and scope. A public repo otherwise offers researchers no private way to report.
- **`.github/CODEOWNERS`** — global owners (`@amaudruz @christian-mcdermott`) so required review routes to maintainers once the ruleset's "Require review from Code Owners" is enabled.
- **`.github/workflows/switch-release.yml`** — add explicit `permissions: contents: read` to the **prep** job. It runs `python3` against `core/pyproject.toml` and emits the version + push decision the publish jobs consume; it previously inherited the default token while the three downstream jobs (`images`/`chart`/`compose`) already declare `contents: read` + `packages: write`.

### Verification
- Workflow YAML re-parsed; `prep.permissions = {contents: read}`, downstream job permissions unchanged.

### Two things to confirm before merge
1. **SECURITY.md contact** — I made GitHub private vulnerability reporting the channel rather than guess an email. If you want an email listed too, tell me the address and I'll add it. (Also: enable private vulnerability reporting in Settings → Code security for the button to exist.)
2. **CODEOWNERS handles** — set to `@amaudruz` + `@christian-mcdermott`. Swap to a team slug (e.g. `@sandbox-quantum/switch-maintainers`) if you'd prefer; only enforces when "Require review from Code Owners" is on.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)