### PR TITLE
fix(ci): run agent-runtime version guard on main dispatch too (CHOO-1251)

### DIFF
--- a/.github/workflows/switch-agent-runtime-publish.yml
+++ b/.github/workflows/switch-agent-runtime-publish.yml
@@ -32,8 +32,11 @@ on:
   push:
     tags:
       - 'switch-agent-runtime-v*'
-  # Lets you publish from a branch without tagging:
-  #   gh workflow run switch-agent-runtime-publish.yml --ref <branch>
+  # Lets you re-run a publish for an already-tagged commit (e.g. main) without
+  # pushing the tag again:
+  #   gh workflow run switch-agent-runtime-publish.yml --ref main
+  # The version guard still applies: the commit must carry a matching
+  # switch-agent-runtime-v<version> tag, or the run refuses to publish.
   workflow_dispatch:
 
 jobs:
@@ -53,6 +56,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        # Full history + tags so the version guard can resolve the tag pointing
+        # at HEAD on a workflow_dispatch (where github.ref is a branch, not the tag).
+        with:
+          fetch-depth: 0
 
       # Pinned rather than read from packageManager: that field lives in
       # dash/package.json, and the action looks at the repo root.
@@ -84,18 +91,35 @@ jobs:
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")
 
-          # A tag naming one version while package.json says another publishes
-          # something whose name disagrees with its contents. Refuse.
+          # The published version must be backed by a matching tag on this
+          # commit. On a tag push that's the trigger ref; on a workflow_dispatch
+          # (branch ref, e.g. main) we resolve the tag pointing at HEAD. This
+          # guard runs on BOTH paths — previously it lived inside the tag-only
+          # case, so a main dispatch skipped it and could publish an unchecked
+          # version.
           case "$TAG_REF" in
             refs/tags/switch-agent-runtime-v*)
               tagged="${TAG_REF#refs/tags/switch-agent-runtime-v}"
-              if [ "$tagged" != "$version" ]; then
-                echo "Tag says $tagged, package.json says $version." >&2
-                echo "Bump the version and re-tag." >&2
-                exit 1
-              fi
+              ;;
+            *)
+              tag="$(git tag --points-at HEAD --list 'switch-agent-runtime-v*' | head -n1)"
+              tagged="${tag#switch-agent-runtime-v}"
               ;;
           esac
+
+          if [ -z "$tagged" ]; then
+            echo "Refusing to publish: this commit has no switch-agent-runtime-v* tag." >&2
+            echo "Publishing the runtime is a tag — push switch-agent-runtime-v$version first." >&2
+            exit 1
+          fi
+
+          # A tag naming one version while package.json says another publishes
+          # something whose name disagrees with its contents. Refuse.
+          if [ "$tagged" != "$version" ]; then
+            echo "Tag says $tagged, package.json says $version." >&2
+            echo "Bump the version and re-tag." >&2
+            exit 1
+          fi
 
           if npm view "$name@$version" version >/dev/null 2>&1; then
             echo "$name@$version is already published — nothing to do."


### PR DESCRIPTION
## Fast-follow — agent-runtime publish version guard (CHOO-1251, M2)

Closes the fast-follow security noted in the InfoSec review: *"the agent-runtime version guard is still inside the `case` block, so it's skipped on a `main` dispatch."*

### The gap
`switch-agent-runtime-publish.yml` verifies the git tag matches `package.json`'s version before publishing — but that check lived inside a shell `case` that only matched **tag** refs. On a `workflow_dispatch` from `main` (`github.ref = refs/heads/main`) the case didn't match, so the guard was **skipped** and the run would publish whatever `main`'s `package.json` said, unchecked.

Not a vuln — the H4 ref-gating (#119) already restricts dispatch to `main`/tags only, so unreviewed branch code can't reach the `@sandbox-quantum` namespace, and publishing is idempotent. This is the correctness fast-follow.

### The fix
- The version guard now runs on **both** paths. On a tag push it uses the trigger ref; on a dispatch it resolves the tag pointing at **HEAD** (`git tag --points-at HEAD`).
- Checkout now uses `fetch-depth: 0` so tags are available for that resolution.
- If the commit carries **no** matching `switch-agent-runtime-v<version>` tag, the run **fails closed** ("Publishing the runtime is a tag — push the tag first") instead of publishing an unverified version. This keeps dispatch useful (re-run a publish for an already-tagged commit) while honoring the repo's "publishing is a tag, not a merge" doctrine.
- Header comment updated to match.

### Verification
Simulated the guard across all paths:
- tag push, version match → **publish**
- tag push, version mismatch → **fail**
- dispatch, HEAD tag matches → **publish**
- dispatch, HEAD tag mismatches → **fail** (previously skipped)
- dispatch, HEAD untagged → **fail-closed** (previously published unchecked)

YAML re-parsed; shell syntax checked.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)