### PR TITLE
chore(deps): pin gateway base image node:22-alpine to digest (CHOO-1251, M8)

### DIFF
--- a/deploy/shared_resources/images/Dockerfile.gateway
+++ b/deploy/shared_resources/images/Dockerfile.gateway
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS build
 
 WORKDIR /app
 COPY gateway/package.json gateway/package-lock.json ./


### PR DESCRIPTION
## M8 follow-up — pin gateway base image + run the Trivy gate

M8's node:20→22-alpine bump already merged (#162). This pins that base to its **index digest** so the build is reproducible and can't drift to a re-pushed tag — the digest-pinning posture Renovate maintains and that M6 calls for.

It's also on a `renovate/*` branch on purpose: the container-security **Trivy gate** job only runs for `renovate/*` PRs, so this PR triggers the base-image scan on GitHub and produces the CVE report as a check + PR comment (the "scan ran green on GH" artifact).

- `deploy/shared_resources/images/Dockerfile.gateway`: `FROM node:22-alpine` → `FROM node:22-alpine@sha256:c610fcdf…`

The Trivy gate is report-only (never blocks merge). Note node is only the gateway **build** stage; the shipped image is `nginx:alpine`, so base findings there are build-time only.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Vulnerability tracking (VULNMGMT)

- No open VULNMGMT ticket found; created [VULNMGMT-1155](https://sandboxquantum.atlassian.net/browse/VULNMGMT-1155) and routed to its **Business Unit** for triage.

<!-- renovate-jira-close: VULNMGMT-1155 -->


[VULNMGMT-1155]: https://sandboxquantum.atlassian.net/browse/VULNMGMT-1155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ