### PR TITLE
release: switch-core 0.12.4, switchdash 0.19.3, agent-runtime 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.12.4] - 2026-08-09
+
 #### Added
 - Cross-artifact version compatibility, part 1 — every artifact declares what it
   is and what it speaks (CHOO-1865). `artifacts.yaml` is the one authored
@@ -72,6 +74,10 @@ version of their own to them without also giving them a release of their own.
   real one is stamped at package time; the file now says `0.0.0-dev` (CHOO-1865).
 - Refreshed the stale switch-core version in `uv.lock`, which the release
   procedure never re-locked (CHOO-1865).
+
+#### Security
+- Bump core Python dependencies (cryptography, aiohttp, starlette, mcp,
+  pydantic-settings, joserfc, python-multipart) to current releases.
 
 ### [0.12.3] - 2026-08-07
 
@@ -268,6 +274,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.19.3] - 2026-08-09
+
 #### Added
 - Declares its `sidecar-control` range in the sidecar's ready file, and reads
   back whatever a running sidecar declares. A sidecar that declares nothing
@@ -291,6 +299,16 @@ version of their own to them without also giving them a release of their own.
   Nothing checked before — the two could drift with only a comment asking
   nicely, which is how the sync script once silently stopped running
   (CHOO-1865).
+- The host-unreachable panel now also shows on a location that mounted while its
+  host was up, not only one that never mounted. Such a location stayed `ready`
+  and kept every control live over a dead SSH transport — the sidebar showed the
+  trouble icon, the main pane did not; it restores itself when the host returns
+  (CHOO-1682).
+
+#### Security
+- Bump bundled dependencies for two advisories — DOMPurify `SAFE_FOR_TEMPLATES`
+  bypass in `RETURN_DOM` mode (GHSA-crv5-9vww-q3g8), and brace-expansion
+  denial-of-service via exponential expansion (GHSA-3jxr-9vmj-r5cp).
 
 ### [0.19.2] - 2026-08-07
 
@@ -742,6 +760,8 @@ The Switch protocol client and MCP runtime
 (`dash/packages/switch-agent-runtime/`). Version lives in its `package.json`.
 
 ### [Unreleased]
+
+### [0.1.6] - 2026-08-09
 
 #### Added
 - Declares its `agent-protocol` range, artifact name and release version on the

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.12.3
+    version: 0.12.4
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switchdash:
     description: The desktop app.
-    version: 0.19.2
+    version: 0.19.3
     declared_in: dash/apps/switchdash-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -82,7 +82,7 @@ artifacts:
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
-    version: 0.1.5
+    version: 0.1.6
     declared_in: dash/packages/switch-agent-runtime/package.json
 
   sidecar:

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.12.3"
+version = "0.12.4"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.12.3",
-    "switchdash": "0.19.2",
-    "agent-runtime": "0.1.5",
+    "switch-core": "0.12.4",
+    "switchdash": "0.19.3",
+    "agent-runtime": "0.1.6",
     "sidecar": "1.8.0",
-    "gateway": "0.12.3",
-    "setup": "0.12.3",
-    "helm-chart": "0.12.3",
-    "compose": "0.12.3",
+    "gateway": "0.12.4",
+    "setup": "0.12.4",
+    "helm-chart": "0.12.4",
+    "compose": "0.12.4",
     "switch-connector": "0.7.8",
     "switch-connector-codex": "0.2.0",
 }

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2433,7 +2433,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.12.3"
+version = "0.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/dash/apps/switchdash-desktop/package.json
+++ b/dash/apps/switchdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switchdash/switchdash-desktop",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/dash/packages/shared/src/artifacts.ts
+++ b/dash/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.12.3',
-  switchdash: '0.19.2',
-  'agent-runtime': '0.1.5',
+  'switch-core': '0.12.4',
+  switchdash: '0.19.3',
+  'agent-runtime': '0.1.6',
   sidecar: '1.8.0',
-  gateway: '0.12.3',
-  setup: '0.12.3',
-  'helm-chart': '0.12.3',
-  compose: '0.12.3',
+  gateway: '0.12.4',
+  setup: '0.12.4',
+  'helm-chart': '0.12.4',
+  compose: '0.12.4',
   'switch-connector': '0.7.8',
   'switch-connector-codex': '0.2.0',
 } as const satisfies Record<string, string>;

--- a/dash/packages/switch-agent-runtime/package.json
+++ b/dash/packages/switch-agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sandbox-quantum/switch-agent-runtime",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Switch agent protocol client, and the local MCP runtime built on it",
   "license": "Apache-2.0",
   "author": {

--- a/dash/packages/switch-agent-runtime/src/artifacts.ts
+++ b/dash/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.12.3',
-  switchdash: '0.19.2',
-  'agent-runtime': '0.1.5',
+  'switch-core': '0.12.4',
+  switchdash: '0.19.3',
+  'agent-runtime': '0.1.6',
   sidecar: '1.8.0',
-  gateway: '0.12.3',
-  setup: '0.12.3',
-  'helm-chart': '0.12.3',
-  compose: '0.12.3',
+  gateway: '0.12.4',
+  setup: '0.12.4',
+  'helm-chart': '0.12.4',
+  compose: '0.12.4',
   'switch-connector': '0.7.8',
   'switch-connector-codex': '0.2.0',
 } as const satisfies Record<string, string>;


### PR DESCRIPTION
Release PR 1 of 2 (the version bumps + changelogs). PR 2 will move the runtime pins + bump the two connector plugins once `0.1.6` is published.

## Bumps
- **switch-core** `0.12.3 → 0.12.4` — `pyproject.toml` + `artifacts.yaml` + `uv.lock`
- **switchdash** `0.19.2 → 0.19.3` — `package.json` + `artifacts.yaml`
- **agent-runtime** `0.1.5 → 0.1.6` — `package.json` + `artifacts.yaml`
- Regenerated artifact modules (`core/switch_core/artifacts.py`, both `artifacts.ts`).

## Changelogs
Cross-checked each `[Unreleased]` against `git log` since its last tag and filled gaps:
- switchdash: added the CHOO-1682 host-unreachable-panel fix and a Security note (DOMPurify GHSA-crv5-9vww-q3g8, brace-expansion GHSA-3jxr-9vmj-r5cp).
- switch-core: added a Security note for the core dependency bumps (cryptography 46→50, aiohttp, starlette, mcp, …).

## Deliberately unchanged
- Runtime **pins** (`connectors/*/.mcp.json`, `SWITCH_AGENT_RUNTIME_VERSION`) stay at `0.1.5` — they move in PR 2 after `switch-agent-runtime-v0.1.6` publishes (test-enforced: pins never ahead of package.json).
- `switchdash.pins.switch-core` stays `0.12.3` (switchdash 0.19.3 does not re-bundle a new core; matches `COMPATIBLE_SWITCH_VERSION`).

## Tags to push on merge
`switch-v0.12.4`, `switchdash-v0.19.3`, `switch-agent-runtime-v0.1.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)