### PR TITLE
release: connector plugins 0.7.9 / 0.2.1 — pin agent-runtime 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,11 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+#### Changed
+- Bump the Codex session runtime pin (`SWITCH_AGENT_RUNTIME_VERSION`) to `0.1.6`
+  so switchdash-launched Codex sessions run the published runtime. Ships in the
+  next switchdash release.
+
 ### [0.19.3] - 2026-08-09
 
 #### Added
@@ -825,8 +830,13 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
-_No changes yet. The plugin ships the room-workflow skill; CHOO-1865 changed
-nothing an agent-facing client needs to know, so it is deliberately unbumped._
+### [0.7.9] - 2026-08-09
+
+#### Changed
+- Bump the pinned `@sandbox-quantum/switch-agent-runtime` to `0.1.6`, so sessions
+  pick up its rationed stream-failure reporting and version declaration
+  (CHOO-1780, CHOO-1865). The plugin version bumps with the pin so installs
+  re-download it.
 
 ### [0.7.8]
 
@@ -841,7 +851,11 @@ manifest history.
 
 ### [Unreleased]
 
-_No changes yet, and deliberately unbumped — see the note above._
+### [0.2.1] - 2026-08-09
+
+#### Changed
+- Bump the pinned `@sandbox-quantum/switch-agent-runtime` to `0.1.6` (CHOO-1780,
+  CHOO-1865). The plugin version bumps with the pin so installs re-download it.
 
 ### [0.2.0]
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.7.8
+    version: 0.7.9
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.2.0
+    version: 0.2.1
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/.mcp.json
+++ b/connectors/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandbox-quantum/switch-agent-runtime@0.1.5"],
+      "args": ["-y", "@sandbox-quantum/switch-agent-runtime@0.1.6"],
       "env": {
         "SWITCH_API_ENDPOINT": "${SWITCH_API_ENDPOINT}",
         "SWITCH_API_TOKEN": "${SWITCH_API_TOKEN}",

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/codex-plugin/.mcp.json
+++ b/connectors/codex-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandbox-quantum/switch-agent-runtime@0.1.5"],
+      "args": ["-y", "@sandbox-quantum/switch-agent-runtime@0.1.6"],
       "env_vars": [
         "SWITCH_API_ENDPOINT",
         "SWITCH_API_TOKEN",

--- a/connectors/codex-plugin/README.md
+++ b/connectors/codex-plugin/README.md
@@ -29,7 +29,7 @@ The config holds **no secret**. It names the variables the runtime needs under
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandbox-quantum/switch-agent-runtime@0.1.4"],
+      "args": ["-y", "@sandbox-quantum/switch-agent-runtime@0.1.6"],
       "env_vars": ["SWITCH_API_ENDPOINT", "SWITCH_API_TOKEN", "SWITCH_AGENT_ID", "…"],
       "startup_timeout_sec": 60
     }

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -28,8 +28,8 @@ ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "setup": "0.12.4",
     "helm-chart": "0.12.4",
     "compose": "0.12.4",
-    "switch-connector": "0.7.8",
-    "switch-connector-codex": "0.2.0",
+    "switch-connector": "0.7.9",
+    "switch-connector-codex": "0.2.1",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-rooms/switch-agent-runtime.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-rooms/switch-agent-runtime.ts
@@ -20,7 +20,7 @@ export const SWITCH_AGENT_RUNTIME_PACKAGE = '@sandbox-quantum/switch-agent-runti
  * `connectors/claude-code-plugin/.mcp.json`; `switch-agent-runtime.test.ts`
  * fails if the two drift. Bump both together when the runtime is republished.
  */
-export const SWITCH_AGENT_RUNTIME_VERSION = '0.1.5';
+export const SWITCH_AGENT_RUNTIME_VERSION = '0.1.6';
 
 /**
  * Credentials the runtime refuses to start without: it reads all three at

--- a/dash/packages/shared/src/artifacts.ts
+++ b/dash/packages/shared/src/artifacts.ts
@@ -28,8 +28,8 @@ export const ARTIFACT_VERSIONS = {
   setup: '0.12.4',
   'helm-chart': '0.12.4',
   compose: '0.12.4',
-  'switch-connector': '0.7.8',
-  'switch-connector-codex': '0.2.0',
+  'switch-connector': '0.7.9',
+  'switch-connector-codex': '0.2.1',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/dash/packages/switch-agent-runtime/src/artifacts.ts
+++ b/dash/packages/switch-agent-runtime/src/artifacts.ts
@@ -28,8 +28,8 @@ export const ARTIFACT_VERSIONS = {
   setup: '0.12.4',
   'helm-chart': '0.12.4',
   compose: '0.12.4',
-  'switch-connector': '0.7.8',
-  'switch-connector-codex': '0.2.0',
+  'switch-connector': '0.7.9',
+  'switch-connector-codex': '0.2.1',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;


### PR DESCRIPTION
Release PR 2 of 2 — the runtime pin catch-up, after `switch-agent-runtime-v0.1.6` is published.

## Pins moved to 0.1.6 (all three must agree — `switch-agent-runtime.test.ts`)
- `connectors/claude-code-plugin/.mcp.json`
- `connectors/codex-plugin/.mcp.json`
- `SWITCH_AGENT_RUNTIME_VERSION` in `dash/…/switch-rooms/switch-agent-runtime.ts`

## Plugin version bumps (so installs re-download)
- **switch-connector** (Claude) `0.7.8 → 0.7.9`
- **switch-connector-codex** `0.2.0 → 0.2.1`
- `artifacts.yaml` + regenerated modules; changelog sections cut.

## Notes
- The `SWITCH_AGENT_RUNTIME_VERSION` change is switchdash source — it ships in the **next** switchdash release (recorded in switchdash `[Unreleased]`), not in 0.19.3 which already built with the pin at 0.1.5. This one-release lag is by design (pins never name an unpublished version).
- Refreshed the stale runtime version in the codex plugin README example (`0.1.4 → 0.1.6`).

**Do not merge until `switch-agent-runtime-v0.1.6` has published to the registry.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)