### PR TITLE
docs(legal): add DRAFT Corporate CLA for legal review (CHOO-1253)

### DIFF
--- a/CCLA.md
+++ b/CCLA.md
@@ -1,0 +1,160 @@
+# Corporate Contributor License Agreement
+
+> **DRAFT — pending SandboxAQ Legal review.** This document is a starting
+> point adapted from the Apache Software Foundation Corporate Contributor
+> License Agreement. It is **not** binding until reviewed and approved by
+> SandboxAQ Legal. Do not rely on this wording as final.
+
+This Corporate Contributor License Agreement ("Agreement") is for corporations
+that wish to authorize their employees to contribute to Agent Switch, a project
+of SB Technology, Inc. dba SandboxAQ (the "Company"). It documents the rights
+granted by a contributing organization to the Company, allows the organization
+(the "Corporation") to submit Contributions, to authorize Contributions
+submitted by its designated employees, and to grant copyright and patent
+licenses thereto.
+
+This Agreement is complementary to the
+[Individual Contributor License Agreement](CLA.md) ("Individual CLA"): the
+Individual CLA §4 contemplates that an employer "has executed a separate
+Corporate CLA with the Company." Signing this Agreement is the mechanism by
+which a Corporation does so.
+
+## How this Agreement is signed
+
+Unlike the Individual CLA — which contributors sign automatically via the CLA
+assistant bot on their first pull request — this Corporate CLA is signed
+**once, out of band**, by a person authorized to bind the Corporation (see the
+signature block below). It is not enforced by the pull-request bot. Complete
+the fields below, have an authorized signatory sign, and return the executed
+Agreement to the Company at the contact address provided by SandboxAQ Legal.
+Keep a copy for your records.
+
+- Corporation name: `________________________________________________`
+- Corporation address: `________________________________________________`
+- Point of Contact: `________________________________________________`
+- E-Mail: `________________________________________________`
+- Telephone: `________________________________________________`
+
+You accept and agree to the following terms and conditions for Your present and
+future Contributions submitted to the Company. Except for the license granted
+herein to the Company and recipients of software distributed by the Company, You
+reserve all right, title, and interest in and to Your Contributions.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with the Company. For legal
+entities, the entity making a Contribution and all other entities that control,
+are controlled by, or are under common control with that entity are considered
+to be a single Contributor. For the purposes of this definition, "control"
+means (i) the power, direct or indirect, to cause the direction or management of
+such entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial ownership
+of such entity.
+
+**"Contribution"** means the code, documentation, or other original works of
+authorship expressly identified in Schedule B, as well as any original work of
+authorship, including any modifications or additions to an existing work, that
+is intentionally submitted by You to the Company for inclusion in, or
+documentation of, any of the products owned or managed by the Company (the
+"Work"). For the purposes of this definition, "submitted" means any form of
+electronic, verbal, or written communication sent to the Company or its
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that are
+managed by, or on behalf of, the Company for the purpose of discussing and
+improving the Work, but excluding communication that is conspicuously marked or
+otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license
+to reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Company and to recipients of software distributed by the Company a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated
+in this section) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer the Work, where such license applies only to
+those patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work to
+which such Contribution(s) were submitted. If any entity institutes patent
+litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that Your Contribution, or the Work to which
+You have contributed, constitutes direct or contributory patent infringement,
+then any patent licenses granted to that entity under this Agreement for that
+Contribution or Work shall terminate as of the date such litigation is filed.
+
+## 4. Authorized Employees
+
+You represent that You are legally entitled to grant the above license. You
+represent further that each employee of the Corporation designated on Schedule A
+below (or in a subsequent written modification to that Schedule) is authorized
+to submit Contributions on behalf of the Corporation.
+
+## 5. Original Creation
+
+You represent that each of Your Contributions is Your original creation (see
+Section 7 for submissions on behalf of others).
+
+## 6. Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Submissions on Behalf of Others
+
+Should You wish to submit work that is not Your original creation, You may submit
+it to the Company separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction (including, but
+not limited to, related patents, trademarks, and license agreements) of which
+You are personally aware, and conspicuously marking the work as "Submitted on
+behalf of a third-party: [named here]".
+
+## 8. Notice
+
+It is Your responsibility to notify the Company when any change is required to
+the list of designated employees authorized to submit Contributions on behalf of
+the Corporation, or to the Corporation's Point of Contact with the Company.
+
+## Signature
+
+```
+Please sign: __________________________________  Date: ___________________
+
+Name:        __________________________________
+
+Title:       __________________________________
+```
+
+## Schedule A
+
+Initial list of designated employees. (NB: authorization is not tied to
+particular Contributions.) List each authorized employee's full name and, where
+possible, their GitHub username so their pull requests can be recognized.
+
+| Full name | GitHub username |
+| --------- | --------------- |
+|           |                 |
+|           |                 |
+|           |                 |
+|           |                 |
+|           |                 |
+
+## Schedule B
+
+Identification of optional concurrent software grant. Leave blank or omit if
+there is no concurrent software grant.
+
+```
+[describe grant here]
+```


### PR DESCRIPTION
## What

Adds `CCLA.md` — a **DRAFT** Corporate Contributor License Agreement — so SandboxAQ Legal has a document to review alongside the existing individual `CLA.md`.

## Why

`CLA.md` §4 already references *"a separate Corporate CLA with the Company,"* but no such document existed. This fills that gap for contributors from corporations that want to authorize their employees to contribute. Part of the OSS Legal track (CHOO-1253).

## Source & approach

- Adapted from the **Apache Software Foundation Corporate CLA** template — the same origin as our individual `CLA.md` (adapted from the ASF ICLA) — so the two documents stay consistent.
- Company set to "SB Technology, Inc. dba SandboxAQ"; carries the same **DRAFT — pending SandboxAQ Legal review** banner.
- Schedule A lists authorized employees (name + GitHub username).

## Important: how it's signed

The CCLA is signed **once, out-of-band** by an authorized company signatory — it is **not** enforced by the PR-comment CLA-assistant bot (which handles the individual CLA only). This is a document-for-legal-review artifact, not a change to CI/bot behavior.

## Review

⚠️ Legal review required — this is draft wording, not final. Decisions and sign-off belong to SandboxAQ Legal.

Jira: [CHOO-1253](https://sandboxquantum.atlassian.net/browse/CHOO-1253)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1253]: https://sandboxquantum.atlassian.net/browse/CHOO-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ