### PR TITLE
feat(switchdash): show the bundled chat's URL and sign-in on the server page (CHOO-1787)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/constants.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/constants.ts
@@ -67,3 +67,9 @@ export const LOCAL_SERVER_BIND_ADDR = '127.0.0.1';
  * rather than inlined because it is also what a link into the bundled
  * Mattermost has to path through — the two must not drift. */
 export const LOCAL_SERVER_MATTERMOST_TEAM = 'switch';
+
+/** The human account the stack's seeder creates (MATTERMOST_USER), paired with
+ * the generated `mattermostUserPassword`. Three places depend on it being the
+ * name the seeder actually used — the generated env, the embed's silent login,
+ * and the sign-in switchdash shows the user — so it is named once here. */
+export const LOCAL_SERVER_MATTERMOST_USER = 'user';

--- a/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/env-file.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/env-file.ts
@@ -2,6 +2,7 @@ import {
   LOCAL_SERVER_ADMIN_EMAIL,
   LOCAL_SERVER_BIND_ADDR,
   LOCAL_SERVER_MATTERMOST_TEAM,
+  LOCAL_SERVER_MATTERMOST_USER,
 } from './constants';
 import { apiUrlFor, gatewayUrlFor, type LocalServerPorts } from './free-port';
 import type { LocalServerSecrets } from './secret-values';
@@ -67,7 +68,7 @@ export function buildEnvFile(params: LocalServerEnvParams): string {
     'MATTERMOST_ADMIN_USER=admin',
     `MATTERMOST_ADMIN_PASSWORD=${secrets.mattermostAdminPassword}`,
     `MATTERMOST_TEAM_NAME=${LOCAL_SERVER_MATTERMOST_TEAM}`,
-    'MATTERMOST_USER=user',
+    `MATTERMOST_USER=${LOCAL_SERVER_MATTERMOST_USER}`,
     `MATTERMOST_USER_PASSWORD=${secrets.mattermostUserPassword}`,
     '',
   ].join('\n');

--- a/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/secrets.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/managed-switch-server/secrets.ts
@@ -12,17 +12,33 @@ import { generateSecrets, type LocalServerSecrets } from './secret-values';
 export async function loadOrCreateSecrets(
   host: Pick<ServerHost, 'secretsKey'>
 ): Promise<LocalServerSecrets> {
-  const existing = await encryptedAppSecretsStore.getSecret(host.secretsKey);
-  if (existing) {
-    try {
-      return JSON.parse(existing) as LocalServerSecrets;
-    } catch {
-      // Corrupt bundle — fall through and regenerate.
-    }
-  }
+  const existing = await readSecrets(host);
+  if (existing) return existing;
+
   const fresh = generateSecrets();
   await encryptedAppSecretsStore.setSecret(host.secretsKey, JSON.stringify(fresh));
   return fresh;
+}
+
+/**
+ * The host's stored secret bundle, or null when none is stored or the stored
+ * one does not parse.
+ *
+ * The read-only half of {@link loadOrCreateSecrets}, for callers that want to
+ * *display* or inspect the credentials rather than run the stack. Generating a
+ * bundle as a side effect of reading would mint credentials that match no
+ * running deployment, which is exactly the fiction a reader must not be shown.
+ */
+export async function readSecrets(
+  host: Pick<ServerHost, 'secretsKey'>
+): Promise<LocalServerSecrets | null> {
+  const existing = await encryptedAppSecretsStore.getSecret(host.secretsKey);
+  if (!existing) return null;
+  try {
+    return JSON.parse(existing) as LocalServerSecrets;
+  } catch {
+    return null;
+  }
 }
 
 /** Drop the host's secret bundle so the next start generates fresh credentials.

--- a/dash/apps/switchdash-desktop/src/main/core/switch-rooms/mattermost-embed.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-rooms/mattermost-embed.ts
@@ -1,4 +1,5 @@
 import { session as electronSession } from 'electron';
+import { LOCAL_SERVER_MATTERMOST_USER } from '@main/core/managed-switch-server/constants';
 import { managedServerSecretsKey } from '@main/core/managed-switch-server/host/host-for-server';
 import { loadOrCreateSecrets } from '@main/core/managed-switch-server/secrets';
 import { getServer } from '@main/core/switch-servers/servers-store';
@@ -12,7 +13,6 @@ import {
 import { mattermostOriginFor } from './mattermost-origin';
 
 const MATTERMOST_AUTH_COOKIE = 'MMAUTHTOKEN';
-const MATTERMOST_USER = 'user';
 
 /**
  * Log the shared `user` account into Mattermost so the webview's partition
@@ -55,7 +55,7 @@ async function installMattermostSession(origin: string, serverId: string): Promi
     },
     credentials: 'include',
     body: JSON.stringify({
-      login_id: MATTERMOST_USER,
+      login_id: LOCAL_SERVER_MATTERMOST_USER,
       password: secrets.mattermostUserPassword,
     }),
   });

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/bundled-chat-sign-in.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/bundled-chat-sign-in.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SwitchServer } from '@shared/core/switch-servers/switch-servers';
+
+const mattermostOriginFor = vi.hoisted(() => vi.fn());
+const readSecrets = vi.hoisted(() => vi.fn());
+
+vi.mock('@main/core/switch-rooms/mattermost-origin', () => ({ mattermostOriginFor }));
+vi.mock('@main/core/managed-switch-server/secrets', () => ({ readSecrets }));
+
+const { bundledChatSignInFor } = await import('./bundled-chat-sign-in');
+
+const MANAGED = {
+  id: 'srv-1',
+  managed: true,
+  managementKind: 'local',
+  sshHost: null,
+} as SwitchServer;
+
+const EXTERNAL = { id: 'srv-2', managed: false } as SwitchServer;
+
+describe('bundledChatSignInFor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mattermostOriginFor.mockResolvedValue('http://127.0.0.1:53012');
+    readSecrets.mockResolvedValue({ mattermostUserPassword: 'generated-pw' });
+  });
+
+  it("reports the deployment's own port and generated password", async () => {
+    // The whole point of the affordance: neither value is a documented default,
+    // so both have to come from what this stack actually runs.
+    const result = await bundledChatSignInFor(MANAGED);
+
+    expect(result).toEqual({
+      kind: 'available',
+      url: 'http://127.0.0.1:53012',
+      username: 'user',
+      password: 'generated-pw',
+    });
+  });
+
+  it('offers nothing for a server switchdash does not run', async () => {
+    const result = await bundledChatSignInFor(EXTERNAL);
+
+    expect(result.kind).toBe('unavailable');
+    // Nothing was even looked up — an external server has no local state to read.
+    expect(mattermostOriginFor).not.toHaveBeenCalled();
+    expect(readSecrets).not.toHaveBeenCalled();
+  });
+
+  it('says so when the stack has never started, rather than guessing a port', async () => {
+    mattermostOriginFor.mockResolvedValue(null);
+
+    const result = await bundledChatSignInFor(MANAGED);
+
+    expect(result.kind).toBe('unavailable');
+    expect(result).toMatchObject({ reason: expect.stringContaining('not started') });
+  });
+
+  it('says so when no credentials are stored', async () => {
+    readSecrets.mockResolvedValue(null);
+
+    const result = await bundledChatSignInFor(MANAGED);
+
+    expect(result.kind).toBe('unavailable');
+    expect(result).toMatchObject({ reason: expect.stringContaining('no stored credentials') });
+  });
+
+  it('treats a bundle missing the chat password as unavailable, not as an empty password', async () => {
+    // A partial bundle would otherwise render as a blank password field, which
+    // reads as "the password is empty" rather than "switchdash cannot read it".
+    readSecrets.mockResolvedValue({ dbPassword: 'x' });
+
+    const result = await bundledChatSignInFor(MANAGED);
+
+    expect(result.kind).toBe('unavailable');
+  });
+
+  it('never resolves to a server that is gone', async () => {
+    const result = await bundledChatSignInFor(null);
+
+    expect(result.kind).toBe('unavailable');
+  });
+});

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/bundled-chat-sign-in.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/bundled-chat-sign-in.ts
@@ -1,0 +1,72 @@
+import { LOCAL_SERVER_MATTERMOST_USER } from '@main/core/managed-switch-server/constants';
+import { managedServerSecretsKey } from '@main/core/managed-switch-server/host/host-for-server';
+import { readSecrets } from '@main/core/managed-switch-server/secrets';
+import { mattermostOriginFor } from '@main/core/switch-rooms/mattermost-origin';
+import type { BundledChatSignIn, SwitchServer } from '@shared/core/switch-servers/switch-servers';
+
+/**
+ * Resolve how a user signs in to a managed deployment's bundled Mattermost.
+ *
+ * Both halves come from what this deployment actually runs, never from the
+ * defaults the docs quote: the origin is built from the host port switchdash
+ * chose and persisted for *this* stack, and the password is the generated one
+ * in switchdash's encrypted store.
+ *
+ * That store — not the `.env` docker reads — is the source of truth. The env
+ * file is rendered *from* the store at every start, and for a remote-managed
+ * stack it lives on the remote host, so reading it would be both second-hand
+ * and unreachable. It is also the same pair the inline chat pane already logs
+ * in with, so what this shows is credentials switchdash is demonstrably using.
+ *
+ * Every failure resolves to `unavailable` with a reason rather than throwing or
+ * substituting a default: a wrong-but-plausible password sends the user round a
+ * login loop with nothing to blame.
+ */
+export async function bundledChatSignInFor(
+  server: SwitchServer | null
+): Promise<BundledChatSignIn> {
+  if (!server) {
+    return { kind: 'unavailable', reason: 'This server is no longer registered in switchdash.' };
+  }
+  if (!server.managed) {
+    return {
+      kind: 'unavailable',
+      reason:
+        'switchdash does not run this server, so its chat is someone else’s deployment and switchdash holds no sign-in for it.',
+    };
+  }
+
+  const origin = await mattermostOriginFor(server.id);
+  if (!origin) {
+    return {
+      kind: 'unavailable',
+      reason:
+        'switchdash has not started this deployment yet, so it has not chosen the port its chat is published on.',
+    };
+  }
+
+  const secrets = await readSecrets({ secretsKey: managedServerSecretsKey(server) });
+  if (!secrets) {
+    return {
+      kind: 'unavailable',
+      reason:
+        'switchdash has no stored credentials for this deployment. They are generated the first time it starts.',
+    };
+  }
+
+  const password = secrets.mattermostUserPassword;
+  if (typeof password !== 'string' || password === '') {
+    return {
+      kind: 'unavailable',
+      reason:
+        'The stored credentials for this deployment have no chat password. Resetting the server regenerates them.',
+    };
+  }
+
+  return {
+    kind: 'available',
+    url: origin,
+    username: LOCAL_SERVER_MATTERMOST_USER,
+    password,
+  };
+}

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.test.ts
@@ -24,6 +24,8 @@ vi.mock('@main/core/managed-switch-server/managed-server-status', () => ({
   managedServerHostBlocked,
 }));
 vi.mock('./auth', () => ({ oidcLogin: vi.fn(), passwordLogin: vi.fn() }));
+// Reaches the encrypted secrets store, and through it the database client.
+vi.mock('./bundled-chat-sign-in', () => ({ bundledChatSignInFor: vi.fn() }));
 vi.mock('./gateway-web', () => ({ openAuthenticatedGatewayPage: vi.fn() }));
 vi.mock('./gateway-client', () => ({
   fetchMe,

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/controller.ts
@@ -21,6 +21,7 @@ import type {
   AddServerParams,
   AgentDefaults,
   AgentVerifyResult,
+  BundledChatSignIn,
   CreateBridgeParams,
   CreateBridgeResult,
   CreateRoomParams,
@@ -47,6 +48,7 @@ import type {
 import { createRPCController } from '@shared/lib/ipc/rpc';
 import { type LoginError, oidcLogin, passwordLogin } from './auth';
 import { withResolvedHomeUrls } from './bridge-home-url';
+import { bundledChatSignInFor } from './bundled-chat-sign-in';
 import { createBridgeOnServer } from './create-bridge';
 import { createRoomOnServer } from './create-room';
 import {
@@ -208,6 +210,16 @@ export const switchServersController = createRPCController({
 
   listRemoteBridgeTypes: async (serverId: string): Promise<RemoteBridgeType[]> =>
     fetchBridgeTypes(await requireReachableServer(serverId)),
+
+  /**
+   * The bundled chat's address and sign-in for a managed server (CHOO-1787).
+   *
+   * The password crosses IPC only when the renderer asks — the card fetches on
+   * expand, not on render — so it is not sitting in every server page's memory.
+   * Do not log the result.
+   */
+  getBundledChatSignIn: async (serverId: string): Promise<BundledChatSignIn> =>
+    bundledChatSignInFor(await getServer(serverId)),
 
   /**
    * Attach a collaboration bridge to the chosen server (CHOO-1784).

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/BundledChatSignIn.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/BundledChatSignIn.tsx
@@ -1,0 +1,133 @@
+import { useQuery } from '@tanstack/react-query';
+import { Check, ChevronDown, ChevronRight, Copy, Eye, EyeOff } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { rpc } from '@renderer/lib/ipc';
+import { Button } from '@renderer/lib/ui/button';
+import { Spinner } from '@renderer/lib/ui/spinner';
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [value]);
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={copied ? `${label} copied` : `Copy ${label}`}
+      className="shrink-0 rounded p-1 text-foreground-passive hover:bg-background-2 hover:text-foreground"
+    >
+      {copied ? (
+        <Check className="size-3.5 text-foreground-success" />
+      ) : (
+        <Copy className="size-3.5" />
+      )}
+    </button>
+  );
+}
+
+/** One label + value + copy row. `secret` masks the value until revealed —
+ * copying works either way, so the password never has to be on screen to be
+ * used. */
+function CredentialRow({
+  label,
+  value,
+  secret = false,
+}: {
+  label: string;
+  value: string;
+  secret?: boolean;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const masked = secret && !revealed;
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-20 shrink-0 text-xs text-foreground-muted">{label}</span>
+      <code className="min-w-0 flex-1 truncate rounded bg-background-quaternary-1 px-2 py-1 font-mono text-xs text-foreground">
+        {masked ? '••••••••••••' : value}
+      </code>
+      {secret && (
+        <button
+          type="button"
+          onClick={() => setRevealed((r) => !r)}
+          aria-label={revealed ? `Hide ${label}` : `Reveal ${label}`}
+          className="shrink-0 rounded p-1 text-foreground-passive hover:bg-background-2 hover:text-foreground"
+        >
+          {revealed ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+        </button>
+      )}
+      <CopyButton value={value} label={label} />
+    </div>
+  );
+}
+
+/**
+ * The bundled chat's address and sign-in, for signing in outside switchdash —
+ * a browser, a phone, or the desktop Mattermost client (CHOO-1787).
+ *
+ * Collapsed by default, and the values are only fetched once it is opened: the
+ * password should not cross into the renderer for everyone who merely looks at
+ * the server page. When switchdash cannot read the real values it says which
+ * one is missing and why, and shows nothing else — a template password would
+ * only send the user round a login loop.
+ */
+export function BundledChatSignIn({ serverId }: { serverId: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const signInQuery = useQuery({
+    queryKey: ['bundled-chat-sign-in', serverId],
+    queryFn: () => rpc.switchServers.getBundledChatSignIn(serverId),
+    enabled: expanded,
+  });
+
+  const signIn = signInQuery.data;
+
+  return (
+    <div className="mt-1 ml-6">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-auto px-1 py-0.5 text-xs text-foreground-muted"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((e) => !e)}
+      >
+        {expanded ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+        Sign-in details
+      </Button>
+
+      {expanded && (
+        <div className="mt-2 space-y-2">
+          <p className="text-xs text-foreground-muted">
+            Use these to sign in to this chat in a browser, on your phone, or in the Mattermost
+            desktop app.
+          </p>
+
+          {signInQuery.isLoading ? (
+            <Spinner className="size-3.5" />
+          ) : signInQuery.isError ? (
+            <p className="text-destructive text-xs">
+              Could not read the sign-in details:{' '}
+              {signInQuery.error instanceof Error
+                ? signInQuery.error.message
+                : String(signInQuery.error)}
+            </p>
+          ) : signIn?.kind === 'unavailable' ? (
+            <p className="text-xs text-foreground-muted">{signIn.reason}</p>
+          ) : signIn?.kind === 'available' ? (
+            <>
+              <CredentialRow label="Server" value={signIn.url} />
+              <CredentialRow label="Username" value={signIn.username} />
+              <CredentialRow label="Password" value={signIn.password} secret />
+            </>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/BundledChatSignIn.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/BundledChatSignIn.tsx
@@ -69,7 +69,11 @@ function CredentialRow({
 
 /**
  * The bundled chat's address and sign-in, for signing in outside switchdash —
- * a browser, a phone, or the desktop Mattermost client (CHOO-1787).
+ * a browser or the desktop Mattermost client (CHOO-1787).
+ *
+ * Both are on the same machine by necessity: the stack publishes onto loopback
+ * so it is never exposed to the LAN, so the copy must not invite the user to
+ * try a device that cannot reach it.
  *
  * Collapsed by default, and the values are only fetched once it is opened: the
  * password should not cross into the renderer for everyone who merely looks at
@@ -104,8 +108,8 @@ export function BundledChatSignIn({ serverId }: { serverId: string }) {
       {expanded && (
         <div className="mt-2 space-y-2">
           <p className="text-xs text-foreground-muted">
-            Use these to sign in to this chat in a browser, on your phone, or in the Mattermost
-            desktop app.
+            Use these to sign in to this chat in a browser or the Mattermost desktop app on this
+            computer.
           </p>
 
           {signInQuery.isLoading ? (

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/MessagingAppsCard.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/MessagingAppsCard.tsx
@@ -8,6 +8,7 @@ import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { Badge } from '@renderer/lib/ui/badge';
 import { Button } from '@renderer/lib/ui/button';
 import { Spinner } from '@renderer/lib/ui/spinner';
+import { BundledChatSignIn } from './BundledChatSignIn';
 import { switchRoomsStore } from './switch-rooms-store';
 import { switchServersStore } from './switch-servers-store';
 
@@ -30,6 +31,9 @@ export const MessagingAppsCard = observer(function MessagingAppsCard({
   const queryClient = useQueryClient();
   const showConnectMessagingApp = useShowModal('connectMessagingAppModal');
   const isAdmin = switchServersStore.statusFor(serverId)?.user?.role === 'admin';
+  // Only a stack switchdash runs has a chat whose credentials it generated and
+  // can therefore show; anyone else's Mattermost is their own to hand out.
+  const isManaged = !!switchServersStore.servers.find((s) => s.id === serverId)?.managed;
 
   const bridgesQuery = useQuery({
     queryKey: ['remote-bridges', serverId],
@@ -84,32 +88,39 @@ export const MessagingAppsCard = observer(function MessagingAppsCard({
       ) : (
         <ul className="mt-3 space-y-2">
           {bridges.map((bridge) => (
-            <li key={bridge.id} className="flex items-center gap-2 text-sm">
-              {hasBridgeIcon(bridge.type) ? (
-                <BridgeIcon bridgeType={bridge.type} size={16} />
-              ) : (
-                <MessageSquare className="size-4 text-foreground-muted" />
-              )}
-              <span className="min-w-0 flex-1 truncate text-foreground">{bridge.displayName}</span>
-              {/* Offered only when the link resolves — an older server, or a
+            <li key={bridge.id} className="text-sm">
+              <div className="flex items-center gap-2">
+                {hasBridgeIcon(bridge.type) ? (
+                  <BridgeIcon bridgeType={bridge.type} size={16} />
+                ) : (
+                  <MessageSquare className="size-4 text-foreground-muted" />
+                )}
+                <span className="min-w-0 flex-1 truncate text-foreground">
+                  {bridge.displayName}
+                </span>
+                {/* Offered only when the link resolves — an older server, or a
                   bridge that is down, reports none, and a button that cannot
                   do anything is worse than no button. */}
-              {bridge.homeUrl && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  aria-label={`Open ${bridgePlatformLabel(bridge.type)}`}
-                  onClick={() => void rpc.app.openExternal(bridge.homeUrl as string)}
-                >
-                  <ExternalLink className="size-3.5" />
-                  Open
-                </Button>
-              )}
-              {bridge.isDefault && <Badge variant="secondary">Default</Badge>}
-              {/* Surfaced only when it is NOT active: a bridge that is down
+                {bridge.homeUrl && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Open ${bridgePlatformLabel(bridge.type)}`}
+                    onClick={() => void rpc.app.openExternal(bridge.homeUrl as string)}
+                  >
+                    <ExternalLink className="size-3.5" />
+                    Open
+                  </Button>
+                )}
+                {bridge.isDefault && <Badge variant="secondary">Default</Badge>}
+                {/* Surfaced only when it is NOT active: a bridge that is down
                   cannot back a new room, and the room-creation picker silently
                   omits it, so this is where that becomes visible. */}
-              {bridge.status !== 'active' && <Badge variant="destructive">{bridge.status}</Badge>}
+                {bridge.status !== 'active' && <Badge variant="destructive">{bridge.status}</Badge>}
+              </div>
+              {isManaged && bridge.type === 'mattermost' && (
+                <BundledChatSignIn serverId={serverId} />
+              )}
             </li>
           ))}
         </ul>

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
@@ -222,6 +222,24 @@ export type RemoteBridge = {
 };
 
 /**
+ * How to sign in to a managed deployment's bundled Mattermost directly — in a
+ * browser, on a phone, or in the desktop Mattermost client (CHOO-1787).
+ *
+ * `unavailable` carries the reason in words a user can act on, and is the only
+ * alternative to real values: the credentials are per-deployment and generated,
+ * so a plausible-looking default would be worse than saying nothing.
+ */
+export type BundledChatSignIn =
+  | {
+      kind: 'available';
+      /** Origin to paste into the Mattermost client's "server URL" field. */
+      url: string;
+      username: string;
+      password: string;
+    }
+  | { kind: 'unavailable'; reason: string };
+
+/**
  * One credential field a bridge type needs, projected from the JSON Schema the
  * gateway derives from the adapter's Pydantic config model.
  *

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
@@ -223,7 +223,9 @@ export type RemoteBridge = {
 
 /**
  * How to sign in to a managed deployment's bundled Mattermost directly — in a
- * browser, on a phone, or in the desktop Mattermost client (CHOO-1787).
+ * browser or the desktop Mattermost client, on the machine running it
+ * (CHOO-1787). The stack publishes onto loopback, so nothing off that machine
+ * can reach the URL.
  *
  * `unavailable` carries the reason in words a user can act on, and is the only
  * alternative to real values: the credentials are per-deployment and generated,


### PR DESCRIPTION
## What

Signing in to a managed deployment's **bundled Mattermost** directly — in a browser or the desktop Mattermost client — currently means finding the generated `.env` on disk and reading the credentials out of it. No normal user will ever do that.

This adds a collapsed **"Sign-in details"** disclosure to the bundled Mattermost row of the existing messaging-apps card on the managed-server page ([CHOO-1784](https://sandboxquantum.atlassian.net/browse/CHOO-1784)'s surface), showing the server URL, username and password — each with copy-to-clipboard.

Only shown for servers switchdash manages. Anyone else's Mattermost is their own deployment to hand out.

Jira: [CHOO-1787](https://sandboxquantum.atlassian.net/browse/CHOO-1787) · follow-up from CHOO-1674 / #84

## Reflecting reality, not a template

Both values come from what the deployment **actually runs**:

- the **origin** is built from the host port switchdash chose and persisted for *this* stack (never a documented `:8065` default);
- the **password** is the generated one in switchdash's encrypted app-secrets store.

That store — **not** the `.env` docker reads — is the source of truth. The env file is *rendered from* the store at every start, and for a remote-managed stack it lives on the remote host, so reading it would be both second-hand and unreachable. It is also the same pair the inline chat pane already logs in with, so the card shows credentials switchdash is demonstrably using.

When a value can't be read, the card **names which one is missing and why** and shows nothing else. There is no placeholder to mistake for a real password — a wrong-but-plausible one just sends the user round a login loop with nothing to blame.

## Secret handling

- Password is **masked until clicked to reveal**; copying works without revealing it.
- Values are fetched **on expand**, not on render, so the secret doesn't cross IPC for everyone who merely opens the server page.
- Not logged.

## Drift fixes carried along

- `readSecrets` — the read-only half of `loadOrCreateSecrets`. Reading in order to *display* must not mint a bundle that matches no running deployment, which is exactly the fiction a reader must not be shown.
- `LOCAL_SERVER_MATTERMOST_USER` — the seeded username was written out in three places (generated env, embed login, and now this card). Hoisted to one constant so they cannot drift; the card must show the name the seeder actually used.

## Notes

- **Open-in-browser already existed** on that row (the "Open" button, from the bridge's resolved `homeUrl`) and is unchanged. The URL shown here is the bare **origin** — what the Mattermost desktop client asks for — while "Open" still goes to the team page.
- Only the `user` account is shown; that's the one a human signs in with. The seeded `admin` account is deliberately left out.
- **Same machine only.** The stack publishes onto `127.0.0.1` so it is never exposed to the LAN, and the URL is a `localhost` one — so the copy says "on this computer" and deliberately does not invite phone sign-in. Holds for remote-managed too, which is reached through forwarded ports on the same loopback.
- No version bumps: this touches neither connector plugin, the sidecar, nor the runtime package.

## Testing

- New unit cover for the resolver: happy path plus each "can't read it" case (not managed, stack never started, no stored bundle, bundle missing the chat password, server deregistered).
- `controller.test.ts` gains a mock for the new module — it reaches the encrypted store and through it the DB client, which that suite deliberately keeps out of its module graph.
- Full node project green: **2100 tests, 216 files**. Typecheck and lint clean.

## Review focus

Worth a second opinion on the **store-over-`.env`** call — it's the load-bearing decision here, and the alternative (parsing the on-disk env) reads more literally like "what's in effect" even though it's derived and remote-inaccessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1784]: https://sandboxquantum.atlassian.net/browse/CHOO-1784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHOO-1787]: https://sandboxquantum.atlassian.net/browse/CHOO-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
