### PR TITLE
feat(gateway): search agent keys and give the table the page's height

### DIFF
--- a/gateway/src/pages/registration-keys/RegistrationKeysPage.tsx
+++ b/gateway/src/pages/registration-keys/RegistrationKeysPage.tsx
@@ -2,6 +2,7 @@ import AddCircleOutline from "@mui/icons-material/AddCircleOutline";
 import ContentCopy from "@mui/icons-material/ContentCopy";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
 import DoneOutline from "@mui/icons-material/DoneOutline";
+import SearchIcon from "@mui/icons-material/Search";
 import {
   Box,
   Button,
@@ -12,7 +13,9 @@ import {
   DialogContentText,
   DialogTitle,
   IconButton,
+  InputAdornment,
   Stack,
+  TextField,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -30,6 +33,7 @@ export default function RegistrationKeysPage() {
   const [deleting, setDeleting] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [agentSearch, setAgentSearch] = useState("");
 
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return;
@@ -67,10 +71,15 @@ export default function RegistrationKeysPage() {
     [keys],
   );
 
-  const agentKeys = useMemo(
-    () => keys?.filter((k) => k.type === "agent") ?? [],
-    [keys],
-  );
+  const agentKeys = useMemo(() => {
+    const all = keys?.filter((k) => k.type === "agent") ?? [];
+    const q = agentSearch.trim().toLowerCase();
+    if (!q) return all;
+    return all.filter(
+      (k) =>
+        k.label.toLowerCase().includes(q) || k.key_prefix.toLowerCase().includes(q),
+    );
+  }, [keys, agentSearch]);
 
   const regColumns = useMemo<GridColDef<ApiKeyDetail>[]>(
     () => [
@@ -162,7 +171,7 @@ export default function RegistrationKeysPage() {
   );
 
   return (
-    <Box>
+    <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1, minHeight: 0 }}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" mb={2}>
         <Typography variant="h5">API Keys</Typography>
         <Button
@@ -180,26 +189,53 @@ export default function RegistrationKeysPage() {
       {loading ? (
         <CircularProgress />
       ) : (
-        <DataTable
-          rows={registrationKeys}
-          columns={regColumns}
-          height={Math.min(400, 108 + registrationKeys.length * 52)}
-          pageSize={10}
-        />
+        <Box
+          sx={{
+            flexShrink: 0,
+            display: "flex",
+            flexDirection: "column",
+            height: Math.min(400, 108 + registrationKeys.length * 52),
+          }}
+        >
+          <DataTable
+            rows={registrationKeys}
+            columns={regColumns}
+            fillHeight
+            pageSize={10}
+          />
+        </Box>
       )}
 
-      <Typography variant="subtitle1" sx={{ fontWeight: 600, mt: 3, mb: 1 }}>
-        Agent Keys
-      </Typography>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ mt: 3, mb: 1 }}
+      >
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          Agent Keys
+        </Typography>
+        <TextField
+          size="small"
+          placeholder="Search agents…"
+          value={agentSearch}
+          onChange={(e) => setAgentSearch(e.target.value)}
+          sx={{ width: 280 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+      </Stack>
       {loading ? (
         <CircularProgress />
       ) : (
-        <DataTable
-          rows={agentKeys}
-          columns={agentColumns}
-          height={Math.min(400, 108 + agentKeys.length * 52)}
-          pageSize={10}
-        />
+        <DataTable rows={agentKeys} columns={agentColumns} fillHeight pageSize={25} />
       )}
 
       <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>


### PR DESCRIPTION
## Problem

The Agent Keys table on the API Keys page listed 125 keys ten at a time inside a 400px box. Finding one key meant paging through it, and there was no way to search.

## Change

- **Search** — a "Search agents…" box on the Agent Keys section header, filtering on agent name *and* key prefix. Follows the pattern already used on the Agents page (same `TextField` + `SearchIcon` adornment treatment).
- **Bigger table** — the Agent Keys grid fills the remaining page height (`fillHeight`) instead of a fixed 400px cap, and pages 25 rows at a time instead of 10.
- Registration Keys keeps its compact, content-sized height so it doesn't steal space from the section that needs it.

## Verification

Ran a dev server against a local backend and checked `/registration-keys`:

- table renders full-height with 25 rows/page
- searching `codex` narrows 80 keys → 1
- `tsc -b` passes clean

## Note

The route is still `/registration-keys` even though the nav and heading say "API Keys". Left as-is to keep this diff scoped; happy to rename separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)