### PR TITLE
fix(switchdash): open bridged channels without the desktop app (CHOO-2043)

### DIFF
--- a/dash/apps/switchdash-desktop/src/main/core/switch-rooms/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-rooms/controller.ts
@@ -3,6 +3,7 @@ import type { RoomEmbed } from '@shared/core/switch-rooms/room-embed';
 import type { SessionRoomConnection } from '@shared/core/switch-rooms/switch-rooms';
 import { createRPCController } from '@shared/lib/ipc/rpc';
 import { resolveChannelEmbed } from './mattermost-embed';
+import { openRoomChannel } from './open-channel';
 import { switchNotificationPoller } from './switch-notification-poller';
 import { switchRoomService } from './switch-room-service';
 
@@ -33,4 +34,21 @@ export const switchRoomsController = createRPCController({
     externalChannelUrl: string | null;
     theme: MattermostTheme | null;
   }): Promise<RoomEmbed> => resolveChannelEmbed(params),
+
+  /**
+   * Open a room's channel in the messaging app it is bridged to, or the browser
+   * when that app is not installed. Reports why it could not rather than
+   * leaving a click that appears to do nothing.
+   */
+  openRoomChannel: async (params: {
+    serverId: string;
+    channelUrl: string;
+  }): Promise<{ success: true } | { success: false; error: string }> => {
+    try {
+      await openRoomChannel(params);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
 });

--- a/dash/apps/switchdash-desktop/src/main/core/switch-rooms/open-channel.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-rooms/open-channel.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const openExternal = vi.hoisted(() => vi.fn());
+const mattermostOriginFor = vi.hoisted(() => vi.fn());
+vi.mock('@main/core/app/service', () => ({ appService: { openExternal } }));
+vi.mock('./mattermost-origin', () => ({ mattermostOriginFor }));
+
+const { openRoomChannel } = await import('./open-channel');
+
+describe('openRoomChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mattermostOriginFor.mockResolvedValue('http://127.0.0.1:51002');
+    openExternal.mockResolvedValue(undefined);
+  });
+
+  it('opens a Mattermost channel on the origin switchdash reaches it on', async () => {
+    // The deeplink itself only opens the desktop app; the web address opens
+    // either way, which is the whole point of the fix.
+    await openRoomChannel({
+      serverId: 'srv-1',
+      channelUrl: 'mattermost://mattermost:8065/switch/channels/town-square',
+    });
+
+    expect(openExternal).toHaveBeenCalledWith('http://127.0.0.1:51002/switch/channels/town-square');
+  });
+
+  it('opens a Slack channel through the web client', async () => {
+    await openRoomChannel({ serverId: 'srv-1', channelUrl: 'slack://channel?team=T1&id=C2' });
+
+    expect(openExternal).toHaveBeenCalledWith('https://app.slack.com/client/T1/C2');
+  });
+
+  it('does not probe the Mattermost origin for another platform', async () => {
+    await openRoomChannel({ serverId: 'srv-1', channelUrl: 'slack://channel?team=T1&id=C2' });
+
+    expect(mattermostOriginFor).not.toHaveBeenCalled();
+  });
+
+  it('uses the host the deeplink names when no origin is known', async () => {
+    // An external server's Mattermost — not ours to publish, but its deeplink
+    // names the host the web app is served from.
+    mattermostOriginFor.mockResolvedValue(null);
+
+    await openRoomChannel({
+      serverId: 'srv-2',
+      channelUrl: 'mattermost://chat.example.com/switch/channels/x',
+    });
+
+    expect(openExternal).toHaveBeenCalledWith('https://chat.example.com/switch/channels/x');
+  });
+
+  it('opens a link that is already a web address unchanged', async () => {
+    await openRoomChannel({
+      serverId: 'srv-1',
+      channelUrl: 'https://discord.com/channels/123/456',
+    });
+
+    expect(openExternal).toHaveBeenCalledWith('https://discord.com/channels/123/456');
+  });
+
+  it('refuses a link it cannot translate rather than opening nothing', async () => {
+    await expect(
+      openRoomChannel({ serverId: 'srv-1', channelUrl: 'zulip://stream/general' })
+    ).rejects.toThrow(/zulip:\/\/stream\/general/);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('propagates a failure to open so the caller can report it', async () => {
+    // A silently discarded failure here is what made the broken link invisible.
+    openExternal.mockRejectedValue(new Error('no handler'));
+
+    await expect(
+      openRoomChannel({ serverId: 'srv-1', channelUrl: 'slack://channel?team=T1&id=C2' })
+    ).rejects.toThrow('no handler');
+  });
+});

--- a/dash/apps/switchdash-desktop/src/main/core/switch-rooms/open-channel.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-rooms/open-channel.ts
@@ -1,0 +1,36 @@
+import { appService } from '@main/core/app/service';
+import { browserUrlForChannelLink } from '@shared/core/switch-rooms/channel-links';
+import { mattermostOriginFor } from './mattermost-origin';
+
+/**
+ * Open a room's bridged channel outside switchdash.
+ *
+ * The gateway describes a channel with the link its platform prefers, which for
+ * Mattermost and Slack is one only their desktop app answers. Handing that
+ * straight to the OS is what made the channel action do nothing on a machine
+ * without the app, so translate it to the web address for the same channel
+ * first — see {@link browserUrlForChannelLink}.
+ *
+ * Lives in the main process because the origin a managed stack's Mattermost is
+ * published on is only known here.
+ *
+ * Throws when the channel cannot be opened, so the caller can say so. A link
+ * that opens nothing is the failure this exists to stop repeating.
+ */
+export async function openRoomChannel(params: {
+  serverId: string;
+  channelUrl: string;
+}): Promise<void> {
+  const { serverId, channelUrl } = params;
+
+  const mattermostOrigin = channelUrl.startsWith('mattermost://')
+    ? await mattermostOriginFor(serverId)
+    : null;
+
+  const target = browserUrlForChannelLink(channelUrl, mattermostOrigin);
+  if (!target) {
+    throw new Error(`No web address is known for this channel link: ${channelUrl}`);
+  }
+
+  await appService.openExternal(target);
+}

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/bridge-home-url.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/bridge-home-url.test.ts
@@ -46,38 +46,51 @@ describe('withResolvedHomeUrls', () => {
     expect(resolved.homeUrl).toBe('http://127.0.0.1:8065/switch');
   });
 
-  it('leaves other platforms on the server-built link', async () => {
-    // Slack, Discord and Teams are public platforms — the gateway's URL is
-    // correct everywhere, and switchdash has nothing better to offer.
-    const resolved = await withResolvedHomeUrls(MANAGED, [
+  it('puts a Slack workspace link in web form', async () => {
+    // `slack://` reaches nobody on a machine without the desktop app, which is
+    // the same defect the per-room channel action had.
+    const [resolved] = await withResolvedHomeUrls(MANAGED, [
       bridge({ id: 'b2', type: 'slack', homeUrl: 'slack://open?team=T1' }),
-      bridge({ id: 'b3', type: 'discord', homeUrl: null }),
     ]);
 
-    expect(resolved[0].homeUrl).toBe('slack://open?team=T1');
+    expect(resolved.homeUrl).toBe('https://app.slack.com/client/T1');
+  });
+
+  it('leaves a platform that already hands out a web link alone', async () => {
+    // Discord and Teams use https URLs their apps claim, so there is nothing to
+    // translate and they must not become a special case.
+    const resolved = await withResolvedHomeUrls(MANAGED, [
+      bridge({ id: 'b3', type: 'discord', homeUrl: 'https://discord.com/channels/123' }),
+      bridge({ id: 'b4', type: 'teams', homeUrl: null }),
+    ]);
+
+    expect(resolved[0].homeUrl).toBe('https://discord.com/channels/123');
     expect(resolved[1].homeUrl).toBeNull();
   });
 
-  it('leaves a non-managed server untouched', async () => {
-    // Somebody else's Mattermost: we neither run it nor know where it is
-    // published, so the server's own answer is the only one available.
+  it('reaches a non-managed Mattermost on the host its link names', async () => {
+    // Somebody else's Mattermost: we do not run it and cannot substitute an
+    // origin, but its deeplink names the public host the web app serves.
     const [resolved] = await withResolvedHomeUrls(EXTERNAL, [
       bridge({ homeUrl: 'mattermost://chat.example.com/switch' }),
     ]);
 
-    expect(resolved.homeUrl).toBe('mattermost://chat.example.com/switch');
+    expect(resolved.homeUrl).toBe('https://chat.example.com/switch');
     expect(mattermostOriginFor).not.toHaveBeenCalled();
   });
 
-  it('keeps the server link when the stack is not running', async () => {
-    // No persisted ports (stack never started) means no origin to substitute.
+  it('still hands back a web link when the stack is not running', async () => {
+    // No persisted ports (stack never started) means no origin to substitute,
+    // so the in-compose host is all there is and the link cannot work either
+    // way. Web form at least fails in the browser where the user can see it,
+    // rather than reaching no handler at all.
     mattermostOriginFor.mockResolvedValue(null);
 
     const [resolved] = await withResolvedHomeUrls(MANAGED, [
       bridge({ homeUrl: 'mattermost://mattermost:8065/switch' }),
     ]);
 
-    expect(resolved.homeUrl).toBe('mattermost://mattermost:8065/switch');
+    expect(resolved.homeUrl).toBe('https://mattermost:8065/switch');
   });
 
   it('does not probe the stack when no Mattermost bridge is attached', async () => {

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/bridge-home-url.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/bridge-home-url.ts
@@ -1,5 +1,6 @@
 import { LOCAL_SERVER_MATTERMOST_TEAM } from '@main/core/managed-switch-server/constants';
 import { mattermostOriginFor } from '@main/core/switch-rooms/mattermost-origin';
+import { browserUrlForChannelLink } from '@shared/core/switch-rooms/channel-links';
 import type { RemoteBridge, SwitchServer } from '@shared/core/switch-servers/switch-servers';
 
 /**
@@ -17,20 +18,39 @@ import type { RemoteBridge, SwitchServer } from '@shared/core/switch-servers/swi
  * That substitution is also why the action works before the gateway gains the
  * field at all: for the common case — a managed server's bundled Mattermost —
  * nothing here depends on the server's answer.
+ *
+ * Every remaining link is put in web form for the same reason the per-room
+ * channel action is: Slack and Mattermost describe a workspace with a link only
+ * their desktop app answers, so without that app installed the button does
+ * nothing at all.
  */
 export async function withResolvedHomeUrls(
   server: SwitchServer,
   bridges: RemoteBridge[]
 ): Promise<RemoteBridge[]> {
-  if (!server.managed || !bridges.some((b) => b.type === 'mattermost')) {
-    return bridges;
-  }
+  const localTeamUrl = await localMattermostTeamUrl(server, bridges);
+
+  return bridges.map((bridge) => {
+    if (bridge.type === 'mattermost' && localTeamUrl) {
+      return { ...bridge, homeUrl: localTeamUrl };
+    }
+    if (!bridge.homeUrl) return bridge;
+
+    const webUrl = browserUrlForChannelLink(bridge.homeUrl, null);
+    return webUrl ? { ...bridge, homeUrl: webUrl } : bridge;
+  });
+}
+
+/**
+ * The bundled Mattermost's team page on the origin switchdash published it on,
+ * or null when this is not a managed stack we run and know the ports of.
+ */
+async function localMattermostTeamUrl(
+  server: SwitchServer,
+  bridges: RemoteBridge[]
+): Promise<string | null> {
+  if (!server.managed || !bridges.some((b) => b.type === 'mattermost')) return null;
 
   const origin = await mattermostOriginFor(server.id);
-  if (!origin) return bridges;
-
-  const localTeamUrl = `${origin}/${LOCAL_SERVER_MATTERMOST_TEAM}`;
-  return bridges.map((bridge) =>
-    bridge.type === 'mattermost' ? { ...bridge, homeUrl: localTeamUrl } : bridge
-  );
+  return origin ? `${origin}/${LOCAL_SERVER_MATTERMOST_TEAM}` : null;
 }

--- a/dash/apps/switchdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { PageHeader } from '@renderer/lib/components/page-header';
 import { PageContent, PageLayout, PageSidebarMenu } from '@renderer/lib/components/page-layout';
-import { rpc } from '@renderer/lib/ipc';
+import { openExternalUrl } from '@renderer/lib/open-external';
 import { AgentsSettingsPage } from '../agents-page/AgentsSettingsPage';
 import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
 import InterfaceSettingsCard from './InterfaceSettingsCard';
@@ -93,7 +93,10 @@ export function SettingsPage({
   onTabChange: (tab: SettingsPageTab) => void;
 }) {
   const handleDocsClick = useCallback(() => {
-    void rpc.app.openExternal('https://github.com/sandbox-quantum/switch');
+    void openExternalUrl(
+      'https://github.com/sandbox-quantum/switch',
+      'Could not open the documentation'
+    );
   }, []);
 
   const tabs: Array<{

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-rooms/room-embed-layer.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-rooms/room-embed-layer.tsx
@@ -8,6 +8,7 @@ import { appState } from '@renderer/lib/stores/app-state';
 import { Button } from '@renderer/lib/ui/button';
 import { cn } from '@renderer/utils/utils';
 import type { RoomEmbed } from '@shared/core/switch-rooms/room-embed';
+import { openRoomChannel } from './room-links';
 import { currentMattermostTheme } from './theme-tokens';
 import { WEBVIEW_ALLOW_POPUPS } from './webview-attrs';
 
@@ -202,15 +203,12 @@ export const RoomEmbedLayer = observer(function RoomEmbedLayer() {
         <RoomNotice
           icon={<MessagesSquare className="size-6" />}
           title={`This room lives in ${capitalise(active.embed.platform)}`}
-          detail="Conversations on external platforms open in their own app."
+          detail="Conversations on external platforms open in their own app, or in your browser when it is not installed."
           action={
             <Button
               variant="outline"
               size="sm"
-              onClick={() => {
-                const embed = active.embed;
-                if (embed.kind === 'external') void rpc.app.openExternal(embed.url);
-              }}
+              onClick={() => activeRoomId && openRoomChannel(activeRoomId)}
             >
               <ExternalLink className="size-3" />
               Open in {capitalise(active.embed.platform)}

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-rooms/room-links.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-rooms/room-links.ts
@@ -1,19 +1,38 @@
 import { switchRoomsStore } from '@renderer/features/switch-servers/switch-rooms-store';
+import { bridgePlatformLabel } from '@renderer/lib/components/bridge-platform';
 import { rpc } from '@renderer/lib/ipc';
+import { openExternalUrl, reportOpenAttempt, reportOpenFailure } from '@renderer/lib/open-external';
 
 /**
- * Open a room's bridged channel in the messaging app's desktop client, via the
- * native deeplink the gateway built. No-op when the room has no such link —
- * callers should check {@link switchRoomsStore.roomChannelUrl} first and not
- * offer the action at all rather than present a control that does nothing.
+ * Open a room's bridged channel in the messaging app it lives in, falling back
+ * to that app's web client when the app is not installed.
+ *
+ * Which of the two to open is decided in the main process, because the address
+ * a managed stack's Mattermost is reachable on is only known there. No-op when
+ * the room has no channel — callers should check
+ * {@link switchRoomsStore.roomChannelUrl} first and not offer the action at all
+ * rather than present a control that does nothing.
  */
 export function openRoomChannel(roomId: string): void {
-  const url = switchRoomsStore.roomChannelUrl(roomId);
-  if (url) void rpc.app.openExternal(url);
+  const channelUrl = switchRoomsStore.roomChannelUrl(roomId);
+  if (!channelUrl) return;
+
+  const failureTitle = `Could not open ${bridgePlatformLabel(switchRoomsStore.roomBridgeTypeById(roomId))}`;
+  const serverId = switchRoomsStore.roomServerId(roomId);
+  if (!serverId) {
+    reportOpenFailure(failureTitle, 'This room’s server is still loading. Try again in a moment.');
+    return;
+  }
+
+  void reportOpenAttempt(
+    rpc.switchRooms.openRoomChannel({ serverId, channelUrl }),
+    failureTitle,
+    channelUrl
+  );
 }
 
 /** Open a room's detail page in the gateway web app. */
 export function openRoomGatewayPage(roomId: string): void {
   const url = switchRoomsStore.gatewayRoomUrl(roomId);
-  if (url) void rpc.app.openExternal(url);
+  if (url) void openExternalUrl(url, 'Could not open the room in the gateway');
 }

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ConnectMessagingAppModal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ConnectMessagingAppModal.tsx
@@ -6,6 +6,7 @@ import { BridgeIcon, hasBridgeIcon } from '@renderer/lib/components/bridge-icon'
 import { bridgePlatformLabel, bridgeSetupDocsUrl } from '@renderer/lib/components/bridge-platform';
 import { rpc } from '@renderer/lib/ipc';
 import { type BaseModalProps, useModalContext } from '@renderer/lib/modal/modal-provider';
+import { openExternalUrl } from '@renderer/lib/open-external';
 import { Button } from '@renderer/lib/ui/button';
 import { Checkbox } from '@renderer/lib/ui/checkbox';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
@@ -198,7 +199,12 @@ export const ConnectMessagingAppModal = observer(function ConnectMessagingAppMod
               <button
                 type="button"
                 className="-mt-2 flex w-fit items-center gap-1 text-xs text-foreground-muted underline underline-offset-2 hover:text-foreground"
-                onClick={() => void rpc.app.openExternal(bridgeSetupDocsUrl(selectedType.key))}
+                onClick={() =>
+                  void openExternalUrl(
+                    bridgeSetupDocsUrl(selectedType.key),
+                    'Could not open the setup guide'
+                  )
+                }
               >
                 How to set up {bridgePlatformLabel(selectedType.key)}
                 <ExternalLink className="size-3" />

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/MessagingAppsCard.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/MessagingAppsCard.tsx
@@ -5,6 +5,7 @@ import { BridgeIcon, hasBridgeIcon } from '@renderer/lib/components/bridge-icon'
 import { bridgePlatformLabel } from '@renderer/lib/components/bridge-platform';
 import { rpc } from '@renderer/lib/ipc';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { openExternalUrl } from '@renderer/lib/open-external';
 import { Badge } from '@renderer/lib/ui/badge';
 import { Button } from '@renderer/lib/ui/button';
 import { Spinner } from '@renderer/lib/ui/spinner';
@@ -106,7 +107,12 @@ export const MessagingAppsCard = observer(function MessagingAppsCard({
                     variant="ghost"
                     size="sm"
                     aria-label={`Open ${bridgePlatformLabel(bridge.type)}`}
-                    onClick={() => void rpc.app.openExternal(bridge.homeUrl as string)}
+                    onClick={() =>
+                      void openExternalUrl(
+                        bridge.homeUrl as string,
+                        `Could not open ${bridgePlatformLabel(bridge.type)}`
+                      )
+                    }
                   >
                     <ExternalLink className="size-3.5" />
                     Open

--- a/dash/apps/switchdash-desktop/src/renderer/lib/open-external-link.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/open-external-link.tsx
@@ -1,5 +1,5 @@
-import { rpc } from '@renderer/lib/ipc';
 import { showModal } from '@renderer/lib/modal/modal-provider';
+import { openExternalUrl } from '@renderer/lib/open-external';
 import { normalizeExternalHttpUrl } from './external-url';
 
 const HTTP_URL_PATTERN = /^https?:\/\//i;
@@ -15,8 +15,11 @@ export function confirmOpenExternalLink(url: string, onError?: (error: unknown) 
     url: normalizedUrl,
     canOpenInSwitchdashBrowser: false,
     onSuccess: () => {
-      void rpc.app.openExternal(normalizedUrl).catch((error) => {
-        onError?.(error);
+      // `onError` used to hang off a rejection that never came: the main
+      // process reports a refusal as a value, so it never threw and the
+      // callback never ran.
+      void openExternalUrl(normalizedUrl, 'Could not open the link').then((opened) => {
+        if (!opened) onError?.(new Error(`Could not open ${normalizedUrl}`));
       });
     },
   });

--- a/dash/apps/switchdash-desktop/src/renderer/lib/open-external.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/open-external.ts
@@ -1,0 +1,44 @@
+import { toast } from 'sonner';
+import { rpc } from '@renderer/lib/ipc';
+
+/** What the main process reports back from an attempt to open something. */
+type OpenAttempt = { success: boolean; error?: string };
+
+/** Tell the user an open did not happen, for a caller that never got as far as trying. */
+export function reportOpenFailure(failureTitle: string, failureDetail: string): void {
+  toast.error(failureTitle, { description: failureDetail });
+}
+
+/**
+ * Report an attempt to open something outside switchdash, saying so when it did
+ * not work.
+ *
+ * The main process has always reported whether the hand-off succeeded, and
+ * every call site dropped that answer — so a link the OS could not open looked
+ * exactly like one that opened fine, and a dead action was indistinguishable
+ * from a working one. Route opens through here so the failure reaches whoever
+ * clicked.
+ *
+ * Returns whether it opened, for callers with more to do than tell the user.
+ */
+export async function reportOpenAttempt(
+  attempt: Promise<OpenAttempt>,
+  failureTitle: string,
+  failureDetail: string
+): Promise<boolean> {
+  try {
+    const result = await attempt;
+    if (result.success) return true;
+    toast.error(failureTitle, { description: result.error ?? failureDetail });
+  } catch (cause) {
+    toast.error(failureTitle, {
+      description: cause instanceof Error ? cause.message : String(cause),
+    });
+  }
+  return false;
+}
+
+/** Open a URL outside switchdash, reporting a failure rather than swallowing it. */
+export function openExternalUrl(url: string, failureTitle: string): Promise<boolean> {
+  return reportOpenAttempt(rpc.app.openExternal(url), failureTitle, url);
+}

--- a/dash/apps/switchdash-desktop/src/renderer/lib/stores/update-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/stores/update-store.ts
@@ -2,6 +2,7 @@ import { action, computed, makeObservable, observable, runInAction } from 'mobx'
 import { toast } from 'sonner';
 import { createUpdateToastActionLabel } from '@renderer/lib/components/update-toast-action-label';
 import { events, rpc } from '@renderer/lib/ipc';
+import { openExternalUrl } from '@renderer/lib/open-external';
 import { appState } from '@renderer/lib/stores/app-state';
 import { menuCheckForUpdatesChannel } from '@shared/events/appEvents';
 import {
@@ -334,12 +335,7 @@ export class UpdateStore {
 
   /** Open this update's GitHub release page in the user's browser. */
   async openReleasePage(): Promise<void> {
-    const url = this.releaseUrl;
-    try {
-      await rpc.app.openExternal(url);
-    } catch {
-      toast.error('Could not open the release page', { description: url });
-    }
+    await openExternalUrl(this.releaseUrl, 'Could not open the release page');
   }
 
   /**

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-rooms/channel-links.test.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-rooms/channel-links.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { browserUrlForChannelLink } from './channel-links';
+
+describe('browserUrlForChannelLink', () => {
+  it('rebases a Mattermost deeplink onto the origin switchdash reaches it on', () => {
+    // A managed stack publishes Mattermost on a port switchdash chose, so the
+    // host the gateway baked into the deeplink is not the one that works here.
+    expect(
+      browserUrlForChannelLink(
+        'mattermost://mattermost:8065/switch/channels/town-square',
+        'http://127.0.0.1:51002'
+      )
+    ).toBe('http://127.0.0.1:51002/switch/channels/town-square');
+  });
+
+  it('falls back to the host the Mattermost deeplink names', () => {
+    // Somebody else's deployment: we do not run it and have no origin to
+    // substitute, but the deeplink names the public host the web app serves.
+    expect(
+      browserUrlForChannelLink('mattermost://chat.example.com/switch/channels/town-square', null)
+    ).toBe('https://chat.example.com/switch/channels/town-square');
+  });
+
+  it('serves a loopback Mattermost host over http', () => {
+    // Inferring https for a local stack would fail the TLS handshake, which is
+    // a worse failure than the one being fixed.
+    expect(browserUrlForChannelLink('mattermost://localhost:8065/switch/channels/x', null)).toBe(
+      'http://localhost:8065/switch/channels/x'
+    );
+  });
+
+  it('maps a Mattermost workspace link with no channel path to the origin', () => {
+    expect(browserUrlForChannelLink('mattermost://chat.example.com', null)).toBe(
+      'https://chat.example.com'
+    );
+  });
+
+  it('tolerates a trailing slash on the origin', () => {
+    expect(
+      browserUrlForChannelLink('mattermost://host/switch/channels/x', 'http://127.0.0.1:8065/')
+    ).toBe('http://127.0.0.1:8065/switch/channels/x');
+  });
+
+  it('addresses a Slack channel through the web client', () => {
+    expect(browserUrlForChannelLink('slack://channel?team=T123&id=C456', null)).toBe(
+      'https://app.slack.com/client/T123/C456'
+    );
+  });
+
+  it('addresses a Slack workspace with no channel', () => {
+    // The bridge-level "open the workspace" link, which names no channel.
+    expect(browserUrlForChannelLink('slack://open?team=T123', null)).toBe(
+      'https://app.slack.com/client/T123'
+    );
+  });
+
+  it('gives up on a Slack link naming no workspace', () => {
+    // The web client addresses a channel positionally under its workspace, so
+    // a channel id alone cannot be turned into a URL.
+    expect(browserUrlForChannelLink('slack://channel?id=C456', null)).toBeNull();
+  });
+
+  it('passes an https link through untouched', () => {
+    // Discord and Teams already hand out web URLs their apps claim; they were
+    // never broken and must not become a special case.
+    expect(
+      browserUrlForChannelLink('https://discord.com/channels/123/456', 'http://127.0.0.1:8065')
+    ).toBe('https://discord.com/channels/123/456');
+  });
+
+  it('gives up on a scheme it does not know', () => {
+    expect(browserUrlForChannelLink('zulip://stream/general', null)).toBeNull();
+  });
+});

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-rooms/channel-links.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-rooms/channel-links.ts
@@ -1,0 +1,89 @@
+/**
+ * Translating a bridge's channel link into one that opens anywhere.
+ *
+ * Each bridge hands out whichever link its platform prefers. Discord and Teams
+ * use ordinary https URLs, which their desktop clients register for — the app
+ * catches them when installed, the browser serves them when not. Mattermost and
+ * Slack instead use a private scheme that only their desktop app answers, so on
+ * a machine without that app the click reaches nobody and nothing happens.
+ *
+ * Both of those have a web address for the same channel, so build that instead.
+ * It is the one form that works either way: an installed app still claims its
+ * own web links, and a machine without one falls back to the browser.
+ */
+
+/** Slack's web client, where a workspace/channel pair addresses a channel. */
+const SLACK_WEB_CLIENT = 'https://app.slack.com/client';
+
+/**
+ * Hosts served over plain http. A deeplink carries a host but no scheme, so the
+ * scheme has to be inferred when we have no better origin to graft it onto;
+ * loopback is a local stack, anything else is a real deployment on https.
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '0.0.0.0']);
+
+/**
+ * The web address for a bridge channel or workspace link, or null when the link
+ * is not one we know how to translate.
+ *
+ * `mattermostOrigin` is where switchdash can actually reach this server's
+ * Mattermost, which it only knows for stacks it runs itself. Pass null
+ * otherwise and the host named by the deeplink is used.
+ */
+export function browserUrlForChannelLink(
+  link: string,
+  mattermostOrigin: string | null
+): string | null {
+  if (/^https?:\/\//i.test(link)) return link;
+  if (link.startsWith('mattermost://')) return mattermostWebUrl(link, mattermostOrigin);
+  if (link.startsWith('slack://')) return slackWebUrl(link);
+  return null;
+}
+
+/**
+ * `mattermost://<host>/<team>/channels/<name>` addresses the same path the web
+ * app serves, so only the origin has to change.
+ */
+function mattermostWebUrl(deeplink: string, mattermostOrigin: string | null): string | null {
+  const parsed = parseDeeplink(deeplink);
+  if (!parsed) return null;
+
+  const origin = mattermostOrigin?.replace(/\/+$/, '') ?? webOriginOf(parsed);
+  if (!origin) return null;
+
+  const path = parsed.pathname.replace(/^\/+/, '');
+  return path ? `${origin}/${path}` : origin;
+}
+
+/**
+ * `slack://channel?team=<workspace>&id=<channel>` names the workspace and
+ * channel that Slack's web client addresses positionally. The workspace alone
+ * still resolves — that is the shape of the bridge-level "open the workspace"
+ * link — but a channel id without one does not.
+ */
+function slackWebUrl(deeplink: string): string | null {
+  const parsed = parseDeeplink(deeplink);
+  if (!parsed) return null;
+
+  const team = parsed.searchParams.get('team');
+  if (!team) return null;
+
+  const channel = parsed.searchParams.get('id');
+  return channel ? `${SLACK_WEB_CLIENT}/${team}/${channel}` : `${SLACK_WEB_CLIENT}/${team}`;
+}
+
+function parseDeeplink(deeplink: string): URL | null {
+  try {
+    // `new URL` on a custom scheme parses the authority as the host, leaving
+    // the path and query after it verbatim.
+    return new URL(deeplink);
+  } catch {
+    return null;
+  }
+}
+
+function webOriginOf(parsed: URL): string | null {
+  if (!parsed.host) return null;
+  const scheme = LOOPBACK_HOSTS.has(parsed.hostname) ? 'http' : 'https';
+  return `${scheme}://${parsed.host}`;
+}


### PR DESCRIPTION
## What was wrong

The per-room channel icon handed the OS the native deeplink the gateway builds — `mattermost://…` or `slack://…`. On a machine with no desktop app registered for that scheme, nothing answers it: the click does nothing, and nobody is told.

Reported for Mattermost, but Slack is broken identically on the same path. Three UI entry points shared it (sidebar room row, room titlebar icon, the room pane's "Open in …" button), plus the Slack bridge card's Open button. The Mattermost bridge card only worked because its home URL is already pre-substituted for a managed stack.

## The fix

Translate the link to the web address for the same channel before opening it. That form works either way — an installed desktop app claims its own web links, and a machine without one falls back to the browser.

- New shared converter (`browserUrlForChannelLink`) covering both app schemes. Discord and Teams already hand out `https://` URLs their clients claim, so they pass through untouched rather than becoming a special case.
- Mattermost resolution runs in the main process behind a new `switchRooms.openRoomChannel` RPC, because the origin a managed stack publishes Mattermost on is only known there. Without one, the host the deeplink itself names is used (loopback over http, everything else https).
- Same treatment for bridge-level workspace links, which fixes Slack's Open button.

## Failures are no longer invisible

Every renderer caller discarded the result of `openExternal`, so a refusal looked exactly like a success. That silent discard is what turned a broken link into an invisible one.

All opens now go through a helper that surfaces a failure to whoever clicked. This also revives `confirmOpenExternalLink`'s `onError` callback, which hung off a rejection the controller never produced — it could not previously fire.

## Behaviour changes worth a look

- A non-managed Mattermost's workspace link is now opened on the host its deeplink names instead of via the app scheme.
- A managed stack that is not running still yields a web link. Both forms are unreachable in that state; the web one at least fails visibly in the browser instead of reaching no handler at all.

## Testing

- New: `channel-links.test.ts` (10 cases across both schemes, https passthrough, unknown scheme) and `open-channel.test.ts` (7 cases including the refusal-to-open path).
- Updated `bridge-home-url.test.ts` for the intentional changes above.
- `pnpm lint` and `pnpm typecheck` clean; `pnpm vitest run --project node --project main-db` — 2256 passed.

No version bumps — left to the releaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)