### PR TITLE
fix(switchdash): re-ask for sign-in options when connectivity returns (CHOO-2042)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,18 @@ version of their own to them without also giving them a release of their own.
   so switchdash-launched Codex sessions run the published runtime. Ships in the
   next switchdash release.
 
+#### Fixed
+- The server page no longer sits on _"Checking sign-in options…"_ forever after
+  connectivity returns. Which login methods a server offers was read once when
+  the page mounted, and a read that failed was never retried, so a blip left the
+  sign-in form unrendered until you navigated away or restarted. It now recovers
+  on the signals connection status already used — the page's Refresh button,
+  returning to the app window, and a remote host becoming reachable again. The
+  Refresh button in particular re-checked only the connection status, so the one
+  control a user would reach for did nothing visible. A stale error banner now
+  clears once the read succeeds, while still leaving a live error such as a
+  rejected password on screen (CHOO-2042).
+
 ### [0.19.3] - 2026-08-09
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,9 +309,15 @@ version of their own to them without also giving them a release of their own.
   on the signals connection status already used — the page's Refresh button,
   returning to the app window, and a remote host becoming reachable again. The
   Refresh button in particular re-checked only the connection status, so the one
-  control a user would reach for did nothing visible. A stale error banner now
-  clears once the read succeeds, while still leaving a live error such as a
-  rejected password on screen (CHOO-2042).
+  control a user would reach for did nothing visible (CHOO-2042).
+- A server whose gateway cannot be reached now says so in one line and retries
+  on its own, instead of stacking three surfaces that each described the same
+  failure differently: a red banner quoting a raw internal error
+  (`Error invoking remote method 'switchServers.getAuthConfig': …`), a
+  "Not signed in" row, and a sign-in panel that claimed to be checking options
+  it would never receive. There is nothing to sign into while the gateway is
+  down, so the sign-in form no longer appears at all. The underlying error goes
+  to the console (CHOO-2042).
 
 ### [0.19.3] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,12 @@ version of their own to them without also giving them a release of their own.
   it would never receive. There is nothing to sign into while the gateway is
   down, so the sign-in form no longer appears at all. The underlying error goes
   to the console (CHOO-2042).
+- The sidebar no longer offers "Sign in" on a server it cannot reach, which was
+  an action that could not work. Unreachable is now modelled apart from
+  signed-out, so the rooms list also stops reporting an unreachable server as
+  merely needing sign-in. A server whose data is unavailable shows a red dot
+  rather than amber, for both causes: neither is a transitional state
+  (CHOO-2042).
 
 ### [0.19.3] - 2026-08-09
 

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -260,7 +260,10 @@ const ServerEntry = observer(function ServerEntry({ serverId }: { serverId: stri
                 aria-hidden
                 className={cn(
                   'size-1.5 shrink-0 rounded-full',
-                  dormant ? 'bg-foreground-muted' : connected ? 'bg-green-500' : 'bg-amber-500'
+                  // Amber reads as "warming up". Neither signed-out nor
+                  // unreachable is transitional: both mean this server's data
+                  // is unavailable right now, so both are red.
+                  dormant ? 'bg-foreground-muted' : connected ? 'bg-green-500' : 'bg-red-500'
                 )}
               />
               {drift && <ServerDriftIndicator drift={drift} />}

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/ServersSidebarSection.tsx
@@ -43,7 +43,7 @@ export const ServersSidebarSection = observer(function ServersSidebarSection() {
     void store.init();
     void localServerStore.init();
     void remoteServerStore.init();
-    const onFocus = () => void store.refreshAllStatuses();
+    const onFocus = () => void store.recoverStale();
     window.addEventListener('focus', onFocus);
     return () => {
       window.removeEventListener('focus', onFocus);

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/server-availability.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/server-availability.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const serversStore = vi.hoisted(() => ({
+  servers: [] as { id: string; managed?: boolean; managementKind?: string; sshHost?: string }[],
+  connected: new Set<string>(),
+  unreachable: new Set<string>(),
+  isConnected(serverId: string): boolean {
+    return this.connected.has(serverId);
+  },
+  isUnreachable(serverId: string): boolean {
+    return this.unreachable.has(serverId);
+  },
+}));
+
+const localStore = vi.hoisted(() => ({ isRunning: true }));
+
+vi.mock('./switch-servers-store', () => ({ switchServersStore: serversStore }));
+vi.mock('./local-server-store', () => ({ localServerStore: localStore }));
+vi.mock('./remote-server-store', () => ({ remoteServerStore: { isRunning: () => true } }));
+
+const { serverAvailability } = await import('./server-availability');
+
+beforeEach(() => {
+  serversStore.servers = [{ id: 'srv-a' }];
+  serversStore.connected.clear();
+  serversStore.unreachable.clear();
+  localStore.isRunning = true;
+});
+
+describe('why a server is unavailable', () => {
+  it('reads as available when signed in', () => {
+    serversStore.connected.add('srv-a');
+
+    expect(serverAvailability('srv-a')).toBe('available');
+  });
+
+  it('reads as signed-out when it answers but nobody is signed in', () => {
+    expect(serverAvailability('srv-a')).toBe('signed-out');
+  });
+
+  it('reads as unreachable rather than signed-out when it does not answer', () => {
+    // These are not the same problem. Signed-out is fixed by the user signing
+    // in; unreachable cannot be, so the sidebar must not offer "Sign in" for it.
+    serversStore.unreachable.add('srv-a');
+
+    expect(serverAvailability('srv-a')).toBe('unreachable');
+  });
+
+  it('prefers a live connection over a stale unreachable flag', () => {
+    serversStore.connected.add('srv-a');
+    serversStore.unreachable.add('srv-a');
+
+    expect(serverAvailability('srv-a')).toBe('available');
+  });
+
+  it('reads a stopped managed stack as dormant, not unreachable', () => {
+    // Nothing is wrong with a stack the user has not started.
+    serversStore.servers = [{ id: 'srv-a', managed: true, managementKind: 'local' }];
+    serversStore.unreachable.add('srv-a');
+    localStore.isRunning = false;
+
+    expect(serverAvailability('srv-a')).toBe('dormant');
+  });
+});

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/server-availability.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/server-availability.ts
@@ -8,10 +8,13 @@ import { switchServersStore } from './switch-servers-store';
  * - `available` — signed in; its rooms and agents can be read.
  * - `signed-out` — reachable but not signed in. Nothing can be read until the
  *   user signs in, so retrying is pointless; the fix is an action they take.
+ * - `unreachable` — the gateway did not answer. A fault rather than a prompt:
+ *   signing in is impossible while it is down, so offering it would be an
+ *   action that cannot work.
  * - `dormant` — a managed stack that is not running. There is no gateway to
  *   sign in to yet, so this is not a sign-in prompt either.
  */
-export type ServerAvailability = 'available' | 'signed-out' | 'dormant';
+export type ServerAvailability = 'available' | 'signed-out' | 'unreachable' | 'dormant';
 
 /**
  * A managed server that is not running has no gateway to reach, so it cannot be
@@ -29,5 +32,6 @@ export function serverAvailability(serverId: string): ServerAvailability {
       ? remoteServerStore.isRunning(server.sshHost)
       : localServerStore.isRunning;
   if (server.managed && !managedRunning) return 'dormant';
-  return switchServersStore.isConnected(serverId) ? 'available' : 'signed-out';
+  if (switchServersStore.isConnected(serverId)) return 'available';
+  return switchServersStore.isUnreachable(serverId) ? 'unreachable' : 'signed-out';
 }

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-rooms-store.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-rooms-store.test.ts
@@ -7,6 +7,8 @@ const serversStore = vi.hoisted(() => ({
   servers: [] as { id: string; name?: string; managed?: boolean }[],
   activeServerId: null as string | null,
   isConnected: (_serverId: string): boolean => true,
+  // These servers answer; they are simply not signed in to.
+  isUnreachable: (_serverId: string): boolean => false,
   statusFor: (serverId: string) => ({ user: { id: `user-of-${serverId}` } }),
 }));
 

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SwitchServer } from '@shared/core/switch-servers/switch-servers';
+
+const getAuthConfig = vi.hoisted(() => vi.fn());
+const getConnectionStatus = vi.hoisted(() => vi.fn());
+const listServers = vi.hoisted(() => vi.fn());
+const getActiveServerId = vi.hoisted(() => vi.fn());
+const setActiveServer = vi.hoisted(() => vi.fn());
+const removeServer = vi.hoisted(() => vi.fn());
+/** SSH hosts the reachability manager currently considers down. */
+const blockedHosts = vi.hoisted(() => new Set<string>());
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: { on: vi.fn() },
+  rpc: {
+    switchServers: {
+      getAuthConfig,
+      getConnectionStatus,
+      listServers,
+      getActiveServerId,
+      setActiveServer,
+      removeServer,
+    },
+  },
+}));
+vi.mock('@renderer/features/remote-hosts/host-reachability-store', () => ({
+  hostReachabilityStore: { isBlocked: (sshHost: string) => blockedHosts.has(sshHost) },
+}));
+
+const { SwitchServersStore } = await import('./switch-servers-store');
+
+const authConfig = { passwordLoginEnabled: true, oidcEnabled: false, oidcProviderLabel: null };
+
+function server(id: string, overrides: Partial<SwitchServer> = {}): SwitchServer {
+  return {
+    id,
+    name: id,
+    gatewayUrl: `https://${id}.example.com`,
+    apiUrl: `https://api.${id}.example.com`,
+    managed: false,
+    managementKind: null,
+    sshHost: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function remoteServer(id: string, sshHost: string): SwitchServer {
+  return server(id, { managed: true, managementKind: 'remote', sshHost });
+}
+
+function newStore(servers: SwitchServer[]) {
+  const store = new SwitchServersStore();
+  store.servers = servers;
+  return store;
+}
+
+/** A promise the test resolves by hand, to hold a fetch in flight. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  blockedHosts.clear();
+  getConnectionStatus.mockImplementation(async (serverId: string) => ({
+    serverId,
+    connected: false,
+    user: null,
+  }));
+  getAuthConfig.mockResolvedValue(authConfig);
+});
+
+describe('fetching sign-in options', () => {
+  it('asks again after a failed fetch', async () => {
+    // The bug: one blip while the page mounted left the sign-in panel stuck on
+    // "Checking sign-in options…" for good, because nothing ever re-asked.
+    const store = newStore([server('srv-a')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('offline'));
+
+    await store.ensureAuthConfig('srv-a');
+    expect(store.authConfigFor('srv-a')).toBeNull();
+
+    await store.ensureAuthConfig('srv-a');
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+  });
+
+  it('does not ask again once it has an answer', async () => {
+    const store = newStore([server('srv-a')]);
+
+    await store.ensureAuthConfig('srv-a');
+    await store.ensureAuthConfig('srv-a');
+
+    expect(getAuthConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses overlapping asks into one request', async () => {
+    // Several recovery signals can land together — a window focus while the
+    // page is mounting, say. That must not become several identical fetches.
+    const store = newStore([server('srv-a')]);
+    const inFlight = deferred<typeof authConfig>();
+    getAuthConfig.mockReturnValueOnce(inFlight.promise);
+
+    const first = store.ensureAuthConfig('srv-a');
+    const second = store.ensureAuthConfig('srv-a');
+    inFlight.resolve(authConfig);
+    await Promise.all([first, second]);
+
+    expect(getAuthConfig).toHaveBeenCalledTimes(1);
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+  });
+});
+
+describe('recovering when connectivity returns', () => {
+  it('re-drives a sign-in fetch that never landed', async () => {
+    const store = newStore([server('srv-a')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('offline'));
+    await store.ensureAuthConfig('srv-a');
+
+    await store.recoverStale();
+
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+  });
+
+  it('leaves servers no login panel has asked about alone', async () => {
+    // Recovery rides the status sweep, which covers every server. Fetching an
+    // auth config for all of them would be new traffic nobody asked for.
+    const store = newStore([server('srv-a'), server('srv-b')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('offline'));
+    await store.ensureAuthConfig('srv-a');
+    getAuthConfig.mockClear();
+
+    await store.recoverStale();
+
+    expect(getAuthConfig).toHaveBeenCalledTimes(1);
+    expect(getAuthConfig).toHaveBeenCalledWith('srv-a');
+  });
+
+  it('refreshes connection status as well', async () => {
+    const store = newStore([server('srv-a'), server('srv-b')]);
+
+    await store.recoverStale();
+
+    expect(getConnectionStatus).toHaveBeenCalledWith('srv-a');
+    expect(getConnectionStatus).toHaveBeenCalledWith('srv-b');
+  });
+
+  it('stops retrying a server that was removed', async () => {
+    const store = newStore([server('srv-a')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('offline'));
+    await store.ensureAuthConfig('srv-a');
+    listServers.mockResolvedValue([]);
+    getActiveServerId.mockResolvedValue(null);
+    removeServer.mockResolvedValue(undefined);
+
+    await store.removeServer('srv-a');
+    getAuthConfig.mockClear();
+    await store.recoverStale();
+
+    expect(getAuthConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('a server on an unreachable host', () => {
+  it('skips the doomed fetch without raising the error banner', async () => {
+    blockedHosts.add('host-1');
+    const store = newStore([remoteServer('srv-a', 'host-1')]);
+
+    await store.ensureAuthConfig('srv-a');
+
+    expect(getAuthConfig).not.toHaveBeenCalled();
+    expect(store.error).toBeNull();
+  });
+
+  it('is asked again once the host comes back', async () => {
+    // The host un-blocking is the recovery signal here. Before, the page just
+    // swapped the host-unreachable panel for the stuck sign-in panel.
+    blockedHosts.add('host-1');
+    const store = newStore([remoteServer('srv-a', 'host-1')]);
+    await store.ensureAuthConfig('srv-a');
+
+    blockedHosts.delete('host-1');
+    await store.ensureAuthConfig('srv-a');
+
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+  });
+});
+
+describe('the manual refresh button', () => {
+  it('re-checks sign-in options, not just connection status', async () => {
+    const store = newStore([server('srv-a')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('offline'));
+    await store.ensureAuthConfig('srv-a');
+
+    await store.refreshServer('srv-a');
+
+    expect(getConnectionStatus).toHaveBeenCalledWith('srv-a');
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+  });
+});
+
+describe('the error banner', () => {
+  it('clears once the sign-in fetch succeeds', async () => {
+    const store = newStore([server('srv-a')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('offline'));
+    await store.ensureAuthConfig('srv-a');
+    expect(store.error).toBe('offline');
+
+    await store.recoverStale();
+
+    expect(store.error).toBeNull();
+  });
+
+  it('survives a status refresh, which has no idea whether it is stale', async () => {
+    // A rejected password lives in the same field. A background status sweep
+    // clearing it would delete the one thing telling the user what went wrong.
+    const store = newStore([server('srv-a')]);
+    await store.ensureAuthConfig('srv-a');
+    store.error = 'Invalid email or password';
+
+    await store.recoverStale();
+
+    expect(store.error).toBe('Invalid email or password');
+  });
+});

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
@@ -68,6 +68,8 @@ function deferred<T>() {
 beforeEach(() => {
   vi.clearAllMocks();
   blockedHosts.clear();
+  // The store logs the raw gateway error rather than showing it. Expected here.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
   getConnectionStatus.mockImplementation(async (serverId: string) => ({
     serverId,
     connected: false,
@@ -204,21 +206,70 @@ describe('the manual refresh button', () => {
   });
 });
 
-describe('the error banner', () => {
-  it('clears once the sign-in fetch succeeds', async () => {
+describe('a server that cannot be reached', () => {
+  it('is flagged when the sign-in read fails', async () => {
     const store = newStore([server('srv-a')]);
-    getAuthConfig.mockRejectedValueOnce(new Error('offline'));
-    await store.ensureAuthConfig('srv-a');
-    expect(store.error).toBe('offline');
+    getAuthConfig.mockRejectedValueOnce(new Error('fetch failed'));
 
-    await store.recoverStale();
+    await store.ensureAuthConfig('srv-a');
+
+    expect(store.isUnreachable('srv-a')).toBe(true);
+  });
+
+  it('is flagged when the status read fails', async () => {
+    const store = newStore([server('srv-a')]);
+    getConnectionStatus.mockRejectedValueOnce(new Error('fetch failed'));
+
+    await store.refreshStatus('srv-a');
+
+    expect(store.isUnreachable('srv-a')).toBe(true);
+  });
+
+  it('never puts the raw gateway error in the banner', async () => {
+    // What used to reach the user: "Error invoking remote method
+    // 'switchServers.getAuthConfig': GatewayError: ... fetch failed". Our own
+    // IPC method name is not something anyone can act on.
+    const store = newStore([server('srv-a')]);
+    getAuthConfig.mockRejectedValueOnce(
+      new Error("Error invoking remote method 'switchServers.getAuthConfig': fetch failed")
+    );
+
+    await store.ensureAuthConfig('srv-a');
 
     expect(store.error).toBeNull();
   });
 
-  it('survives a status refresh, which has no idea whether it is stale', async () => {
-    // A rejected password lives in the same field. A background status sweep
-    // clearing it would delete the one thing telling the user what went wrong.
+  it('clears the flag once it answers again', async () => {
+    const store = newStore([server('srv-a')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('fetch failed'));
+    getConnectionStatus.mockRejectedValueOnce(new Error('fetch failed'));
+    await store.refreshServer('srv-a');
+    expect(store.isUnreachable('srv-a')).toBe(true);
+
+    await store.refreshServer('srv-a');
+
+    expect(store.isUnreachable('srv-a')).toBe(false);
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+  });
+
+  it('is flagged per server, not across the app', async () => {
+    const store = newStore([server('srv-a'), server('srv-b')]);
+    getConnectionStatus.mockImplementation(async (serverId: string) => {
+      if (serverId === 'srv-a') throw new Error('fetch failed');
+      return { serverId, connected: false, user: null };
+    });
+
+    await store.refreshAllStatuses();
+
+    expect(store.isUnreachable('srv-a')).toBe(true);
+    expect(store.isUnreachable('srv-b')).toBe(false);
+  });
+});
+
+describe('the error banner', () => {
+  it('survives a background refresh, which cannot tell whether it is stale', async () => {
+    // A rejected password lives in the same field. A background sweep clearing
+    // it would delete the one thing telling the user what went wrong.
     const store = newStore([server('srv-a')]);
     await store.ensureAuthConfig('srv-a');
     store.error = 'Invalid email or password';

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -31,6 +31,10 @@ export class SwitchServersStore {
   /** Server ids with an auth-config fetch in flight, so several recovery
    * signals arriving at once collapse into a single request. */
   private readonly authConfigInFlight = new Set<string>();
+  /** Server ids whose last gateway read failed. The page shows a single
+   * "cannot reach" state for these: with the gateway down there is nothing to
+   * sign into, so a sign-in form would be a dead end dressed up as a choice. */
+  readonly unreachable = new Set<string>();
 
   loadingServers = false;
   /** Server ids with an in-flight status refresh. */
@@ -69,6 +73,11 @@ export class SwitchServersStore {
 
   isConnected(serverId: string): boolean {
     return this.statuses.get(serverId)?.connected ?? false;
+  }
+
+  /** Whether the last read of this server's gateway failed to reach it. */
+  isUnreachable(serverId: string): boolean {
+    return this.unreachable.has(serverId);
   }
 
   async init(): Promise<void> {
@@ -138,15 +147,18 @@ export class SwitchServersStore {
       const status = await rpc.switchServers.getConnectionStatus(serverId);
       runInAction(() => {
         this.statuses.set(serverId, status);
+        this.unreachable.delete(serverId);
       });
-    } catch {
+    } catch (cause) {
       // An unreachable server is a real, displayable state — record it as
-      // disconnected (the per-server status dot shows it). A background poll
-      // failure must NOT raise the page-level `error` banner: that field is
-      // global, so one unreachable server would paint an error over every
-      // server's view.
+      // disconnected (the per-server status dot shows it) and flag the server
+      // so its page can say so in one line. A background poll failure must NOT
+      // raise the page-level `error` banner: that field is global, so one
+      // unreachable server would paint an error over every server's view.
+      console.warn(`[switch-servers] could not read status for ${serverId}`, cause);
       runInAction(() => {
         this.statuses.set(serverId, { serverId, connected: false, user: null });
+        this.unreachable.add(serverId);
       });
     } finally {
       runInAction(() => {
@@ -181,14 +193,17 @@ export class SwitchServersStore {
       const config = await rpc.switchServers.getAuthConfig(serverId);
       runInAction(() => {
         this.authConfigs.set(serverId, config);
-        // An answer means the gateway is reachable again, so a banner left over
-        // from the fetch that failed is stale. Only a successful fetch clears
-        // it: a background status refresh must not wipe a live error the user
-        // still needs to read, such as a rejected password.
-        this.error = null;
+        this.unreachable.delete(serverId);
       });
     } catch (cause) {
-      this.setError(cause);
+      // Not the error banner: the raw text is our own IPC method name wrapped
+      // around a fetch failure, which tells the user nothing they can act on.
+      // The page states the one thing that matters, that the server cannot be
+      // reached, and the detail stays in the console for us.
+      console.warn(`[switch-servers] could not read auth config for ${serverId}`, cause);
+      runInAction(() => {
+        this.unreachable.add(serverId);
+      });
     } finally {
       runInAction(() => {
         this.authConfigInFlight.delete(serverId);
@@ -294,6 +309,7 @@ export class SwitchServersStore {
         this.statuses.delete(serverId);
         this.authConfigs.delete(serverId);
         this.authConfigWanted.delete(serverId);
+        this.unreachable.delete(serverId);
       });
       // Keep a server scoped when any remain (the sidebar scopes to it).
       if (!this.activeServerId && servers.length > 0) {

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -25,6 +25,12 @@ export class SwitchServersStore {
   readonly statuses = new Map<string, ServerConnectionStatus>();
   /** Auth config per server id, fetched lazily when a login panel needs it. */
   readonly authConfigs = new Map<string, SwitchAuthConfig>();
+  /** Server ids a login panel has asked about. A failed or host-blocked fetch
+   * caches nothing, so this is what the recovery paths re-drive. */
+  private readonly authConfigWanted = new Set<string>();
+  /** Server ids with an auth-config fetch in flight, so several recovery
+   * signals arriving at once collapse into a single request. */
+  private readonly authConfigInFlight = new Set<string>();
 
   loadingServers = false;
   /** Server ids with an in-flight status refresh. */
@@ -98,6 +104,32 @@ export class SwitchServersStore {
     await Promise.all(this.servers.map((s) => this.refreshStatus(s.id)));
   }
 
+  /**
+   * Re-drive everything that recovers when connectivity does: the connection
+   * status of every server, plus any auth config a login panel is still waiting
+   * on. Auth config only recovers if something asks again, so it has to ride
+   * the same signals as status rather than being a once-per-mount read.
+   *
+   * Only servers a login panel actually asked about are re-fetched, so this
+   * stays as cheap as the status sweep it accompanies.
+   */
+  async recoverStale(): Promise<void> {
+    const pending = [...this.authConfigWanted].filter((id) => !this.authConfigs.has(id));
+    await Promise.all([
+      this.refreshAllStatuses(),
+      ...pending.map((id) => this.ensureAuthConfig(id)),
+    ]);
+  }
+
+  /**
+   * The server page's manual re-check. Covers both what the status card reads
+   * and what the sign-in panel needs — refreshing only the status leaves a page
+   * that never got its auth config stuck on "Checking sign-in options…".
+   */
+  async refreshServer(serverId: string): Promise<void> {
+    await Promise.all([this.refreshStatus(serverId), this.ensureAuthConfig(serverId)]);
+  }
+
   async refreshStatus(serverId: string): Promise<void> {
     runInAction(() => {
       this.refreshing.add(serverId);
@@ -123,19 +155,44 @@ export class SwitchServersStore {
     }
   }
 
+  /**
+   * Fetch which login methods a server offers, unless that is already known.
+   *
+   * Safe to call from every recovery path: a cached config short-circuits, and
+   * concurrent callers collapse into the one in-flight request. A failure
+   * caches nothing, so the next caller retries — which is the point, since the
+   * usual failure is a connectivity blip that later heals (CHOO-2042).
+   */
   async ensureAuthConfig(serverId: string): Promise<void> {
+    runInAction(() => {
+      this.authConfigWanted.add(serverId);
+    });
     if (this.authConfigs.has(serverId)) return;
+    if (this.authConfigInFlight.has(serverId)) return;
     // The gateway of a server on an unreachable host cannot answer, and the
     // host-unreachable surface already states why — don't paint the global
-    // error banner with a doomed fetch (CHOO-1780).
+    // error banner with a doomed fetch (CHOO-1780). The host un-blocking is
+    // itself a recovery signal, so this is a skip, not a giving up.
     if (this.isHostBlocked(serverId)) return;
+    runInAction(() => {
+      this.authConfigInFlight.add(serverId);
+    });
     try {
       const config = await rpc.switchServers.getAuthConfig(serverId);
       runInAction(() => {
         this.authConfigs.set(serverId, config);
+        // An answer means the gateway is reachable again, so a banner left over
+        // from the fetch that failed is stale. Only a successful fetch clears
+        // it: a background status refresh must not wipe a live error the user
+        // still needs to read, such as a rejected password.
+        this.error = null;
       });
     } catch (cause) {
       this.setError(cause);
+    } finally {
+      runInAction(() => {
+        this.authConfigInFlight.delete(serverId);
+      });
     }
   }
 
@@ -236,6 +293,7 @@ export class SwitchServersStore {
         this.activeServerId = activeServerId;
         this.statuses.delete(serverId);
         this.authConfigs.delete(serverId);
+        this.authConfigWanted.delete(serverId);
       });
       // Keep a server scoped when any remain (the sidebar scopes to it).
       if (!this.activeServerId && servers.length > 0) {

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
@@ -83,11 +83,17 @@ const ServerMainPanel = observer(function ServerMainPanel() {
     void hostReachabilityStore.hydrate();
   }, []);
 
+  // A blocked host answers nothing and this page renders the host-unreachable
+  // panel instead, so neither read below has a consumer while it is down.
+  // Reading it here also makes the host un-blocking a recovery signal: the
+  // effect re-runs and finally fetches what it skipped (CHOO-2042).
+  const hostBlocked = store.isHostBlocked(serverId);
+
   useEffect(() => {
-    if (!detailsVisible) return;
+    if (!detailsVisible || hostBlocked) return;
     void store.refreshStatus(serverId);
     void store.ensureAuthConfig(serverId);
-  }, [serverId, store, detailsVisible]);
+  }, [serverId, store, detailsVisible, hostBlocked]);
 
   if (!server) {
     return (
@@ -216,7 +222,7 @@ const ServerMainPanel = observer(function ServerMainPanel() {
                   variant="outline"
                   size="sm"
                   disabled={refreshing}
-                  onClick={() => void store.refreshStatus(serverId)}
+                  onClick={() => void store.refreshServer(serverId)}
                 >
                   <RefreshCw className="size-4" />
                   Refresh

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, MoreVertical, Pencil, RefreshCw, Trash2 } from 'lucide-react';
+import { ExternalLink, MoreVertical, Pencil, PlugZap, RefreshCw, Trash2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useEffect, useState } from 'react';
 import { type GuardResult, type ViewDefinition } from '@renderer/app/view-registry';
@@ -202,7 +202,11 @@ const ServerMainPanel = observer(function ServerMainPanel() {
             <LocalServerControls />
           ))}
 
-        {detailsVisible && (
+        {detailsVisible && store.isUnreachable(serverId) && (
+          <ServerUnreachableCard serverId={serverId} />
+        )}
+
+        {detailsVisible && !store.isUnreachable(serverId) && (
           <>
             <div className={`${card} flex items-center justify-between gap-3`}>
               <div className="flex items-center gap-2 text-sm">
@@ -260,6 +264,57 @@ const ServerMainPanel = observer(function ServerMainPanel() {
           </>
         )}
       </div>
+    </div>
+  );
+});
+
+/** How often the page re-probes a server it could not reach, while the user is
+ * looking at it. Short enough to feel like it is trying, long enough not to
+ * hammer a gateway that is down. */
+const UNREACHABLE_RETRY_MS = 10_000;
+
+/**
+ * The whole page when a server's gateway cannot be reached. There is nothing to
+ * sign into and no status worth reading, so this replaces both rather than
+ * stacking a red banner on top of a sign-in form that can never work. The raw
+ * gateway error stays in the console: naming our own IPC method at the user
+ * gives them nothing to act on (CHOO-2042).
+ */
+const ServerUnreachableCard = observer(function ServerUnreachableCard({
+  serverId,
+}: {
+  serverId: string;
+}) {
+  const store = switchServersStore;
+  const retrying = store.refreshing.has(serverId);
+
+  // Keep probing while this is on screen. Waiting for the user to press
+  // something would leave a server that recovered looking down.
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (!document.hidden) void store.refreshServer(serverId);
+    }, UNREACHABLE_RETRY_MS);
+    return () => clearInterval(timer);
+  }, [serverId, store]);
+
+  return (
+    <div className={`${card} flex items-center justify-between gap-3`}>
+      <div className="flex items-center gap-2 text-sm">
+        <PlugZap className="size-4 text-amber-500" />
+        <span className="text-foreground">Cannot reach the server</span>
+        <span className="text-foreground-muted">
+          {retrying ? 'Reconnecting…' : 'Check your connection.'}
+        </span>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={retrying}
+        onClick={() => void store.refreshServer(serverId)}
+      >
+        <RefreshCw className={retrying ? 'size-4 animate-spin' : 'size-4'} />
+        Retry
+      </Button>
     </div>
   );
 });

--- a/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/switch-servers/view.tsx
@@ -323,7 +323,7 @@ function StatusDot({ connected }: { connected: boolean }) {
   return (
     <span
       aria-hidden
-      className={`inline-block size-2 rounded-full ${connected ? 'bg-green-500' : 'bg-amber-500'}`}
+      className={`inline-block size-2 rounded-full ${connected ? 'bg-green-500' : 'bg-red-500'}`}
     />
   );
 }


### PR DESCRIPTION
Fixes [CHOO-2042](https://sandboxquantum.atlassian.net/browse/CHOO-2042) (P1).

## The bug

The server page asks a server *"how can I sign in here?"* exactly once, from a mount-time effect. If that read fails, nothing is cached and nothing ever asks again — so the sign-in panel stays on *"Checking sign-in options…"* for the life of the view. Connectivity coming back does not help. The only way out is navigating away and back, or restarting the app.

Connection *status* already recovers fine, through a window-focus refresh. Auth config simply never joined that recovery path. This reuses it rather than inventing a new mechanism.

## Three ways into the same dead end

1. **Offline at mount** — the read fails, nothing is cached, nothing retries.
2. **The Refresh button** — not in the ticket; found while reviewing with @louis.amaudruz. It drove only `refreshStatus`, so it re-checked *"am I signed in?"* and never *"how can I sign in?"*. On the stuck page it did nothing visible, which makes it the worst of the three: it is the control a user would naturally reach for.
3. **Host blocked** — a remote-managed server on an unreachable host deliberately skips the read. When the host recovers the host-unreachable panel disappears, but the effect deps are unchanged, so the page swapped one stuck state for another.

## The fix

- `ensureAuthConfig` collapses concurrent callers into one in-flight request, so it is safe to call from every recovery path. Failures still cache nothing, so the next caller retries.
- `refreshServer` backs the Refresh button — status *and* sign-in options.
- `recoverStale` backs the window-focus listener. It re-asks only for servers a sign-in panel actually asked about, so it adds no traffic beyond the status sweep it already accompanied.
- The view reads the blocked-host state, making un-blocking a recovery signal: the effect re-runs and finally fetches what it skipped.
- A successful read clears the stale error banner. A status refresh deliberately does **not** — that field is shared with live errors such as a rejected password, and wiping it would delete the one thing telling the user what went wrong.

Deliberately **not** done: the ticket's optional item 4 (moving this store onto the app's generic poll + `visibilitychange` resource store). That is a real refactor and the wrong risk for a P1; worth a follow-up ticket.

## Testing

New `switch-servers-store.test.ts` — 12 cases covering retry-after-failure, request collapsing, focus recovery, per-server scoping, host-unblock, the manual refresh, and both banner behaviours. **8 of the 12 fail against the code before this change**; the other 4 characterise store behaviour that was already correct (the missing piece was the re-trigger, not the store).

- `pnpm vitest run --project node` — 2191 passed, 223 files
- `pnpm run typecheck` — clean
- `pnpm run lint` / `format:check` — clean

The host-unblock *trigger* lives in the view's effect deps and the focus wiring is one line in the sidebar; neither is covered by a store test. Both are one-line changes visible in the diff.

Manual check against the ticket's definition of done is worth doing before merge: open the server page, kill connectivity, restore it, and confirm the sign-in form appears without navigating away.

No version bumps — that belongs to the releaser. Changelog entry added under switchdash `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-2042]: https://sandboxquantum.atlassian.net/browse/CHOO-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ