### PR TITLE
fix(switchdash): scope agent onboarding and the sidebar by server (CHOO-2044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,7 +301,25 @@ version of their own to them without also giving them a release of their own.
   so switchdash-launched Codex sessions run the published runtime. Ships in the
   next switchdash release.
 
-### [0.19.3] - 2026-08-09
+#### Fixed
+- A directory that already holds agents for one Switch server can now onboard its
+  agents to another. "Already onboarded" was judged per directory rather than per
+  server, so every candidate was filtered out as a duplicate and the modal offered
+  an empty list — of agents that existed, on a server that did not have them
+  (CHOO-2044).
+- The sidebar no longer draws a directory's agents under a server they do not
+  belong to. A directory resolved to a single server — whichever of its agents was
+  returned first — and then every agent in it was rendered under that one, so
+  onboarding a single agent to a second server appeared to drag the rest across
+  with it. Nothing had been onboarded; each agent is now drawn under its own
+  server, and a shared directory shows under all of them (CHOO-2044).
+- The Add Agent modal no longer offers a permanently disabled button over a list
+  it will not submit. A directory carrying another server's leftover
+  `.claude/settings.local.json` took the detected-agent branch, verified that
+  foreign agent against the current server, failed, and disabled the only button
+  on screen — with the onboardable agents listed above it. The onboard action now
+  takes precedence, and a detected agent belonging to another server says so
+  (CHOO-2044).
 
 #### Added
 - Declares its `sidecar-control` range in the sidecar's ready file, and reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,14 @@ version of their own to them without also giving them a release of their own.
   onboarding a single agent to a second server appeared to drag the rest across
   with it. Nothing had been onboarded; each agent is now drawn under its own
   server, and a shared directory shows under all of them (CHOO-2044).
+- Onboarding an agent whose credentials belong to **another** Switch server no
+  longer overwrites those credentials. The import path looked the existing
+  identity up on the target server, did not find it, and fell back to minting a
+  fresh one — writing it back over the same `.switch/agents/<name>.json` and
+  silently breaking the agent the other server was still running. It now refuses
+  and names the server the identity belongs to. Such agents are listed in the
+  Add Agent modal but not selectable, with the reason shown; a plain definition
+  carrying no Switch identity is still adopted as before (CHOO-2044).
 - The Add Agent modal no longer offers a permanently disabled button over a list
   it will not submit. A directory carrying another server's leftover
   `.claude/settings.local.json` took the detected-agent branch, verified that

--- a/dash/apps/switchdash-desktop/src/main/core/agents/attach-configured-agents.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/attach-configured-agents.test.ts
@@ -45,10 +45,11 @@ const h = vi.hoisted(() => {
   }
   const state: {
     workspace: PluginFs | null;
-    agentNames: string[];
+    /** Agent-row names already in the directory, per Switch server. */
+    agentNamesByServer: Record<string, string[]>;
     existsOnServer: boolean;
     existsThrows: Error | null;
-  } = { workspace: null, agentNames: [], existsOnServer: true, existsThrows: null };
+  } = { workspace: null, agentNamesByServer: {}, existsOnServer: true, existsThrows: null };
   return {
     state,
     GatewayError,
@@ -68,7 +69,9 @@ vi.mock('@main/core/locations/store', () => ({
   ensureLocation: vi.fn(async () => ({ id: 'loc-1' })),
 }));
 vi.mock('./getAgents', () => ({
-  getAgents: vi.fn(async () => h.state.agentNames.map((name) => ({ name }))),
+  getLocationAgentsOnServer: vi.fn(async (_locationId: string, serverId: string) =>
+    (h.state.agentNamesByServer[serverId] ?? []).map((name) => ({ name }))
+  ),
 }));
 vi.mock('./agent-workspace-fs', () => ({
   resolveWorkspaceFsFor: vi.fn(async () => ({
@@ -111,7 +114,7 @@ function params(agents: Array<{ name: string; providerId: 'codex' | 'claude' }>)
 describe('attachConfiguredAgents', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    h.state.agentNames = [];
+    h.state.agentNamesByServer = {};
     h.state.existsOnServer = true;
     h.state.existsThrows = null;
     h.state.workspace = readOnlyFs({ '.switch/agents/theirs.json': creds('sw-theirs') });
@@ -171,12 +174,24 @@ describe('attachConfiguredAgents', () => {
   });
 
   it('skips an agent this switchdash already has', async () => {
-    h.state.agentNames = ['theirs'];
+    h.state.agentNamesByServer = { 'srv-1': ['theirs'] };
 
     const result = await attachConfiguredAgents(params([{ name: 'theirs', providerId: 'codex' }]));
 
     expect(result.success).toBe(false);
     expect(h.createAgent).not.toHaveBeenCalled();
+  });
+
+  it('attaches an agent already attached to a different server (CHOO-2044)', async () => {
+    // Same directory, same name, other server — a separate agent, not a duplicate.
+    h.state.agentNamesByServer = { 'srv-other': ['theirs'] };
+
+    const result = await attachConfiguredAgents(params([{ name: 'theirs', providerId: 'codex' }]));
+
+    expect(result.success).toBe(true);
+    expect(h.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'theirs', serverId: 'srv-1' })
+    );
   });
 
   it('keeps the directory endpoint and warns when it differs from the chosen server', async () => {

--- a/dash/apps/switchdash-desktop/src/main/core/agents/attach-configured-agents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/attach-configured-agents.ts
@@ -10,6 +10,7 @@ import { log } from '@main/lib/logger';
 import type { Agent } from '@shared/core/agents/agents';
 import type { OnboardAgentError } from '@shared/core/agents/onboarding';
 import type { AgentProviderId } from '@shared/core/providers/agent-provider-registry';
+import { sameApiEndpoint } from '@shared/core/switch-servers/switch-servers';
 import { basenameFromAnyPath } from '@shared/path-name';
 import { agentEvents } from './agent-events';
 import { createAgent } from './createAgent';
@@ -31,11 +32,6 @@ export type AttachConfiguredAgentsParams = {
 };
 
 export type AttachConfiguredAgentsResult = Result<Agent[], OnboardAgentError>;
-
-/** Compare endpoints ignoring a trailing slash, which is not a difference. */
-function sameEndpoint(a: string, b: string): boolean {
-  return a.replace(/\/+$/, '') === b.replace(/\/+$/, '');
-}
 
 /**
  * Adopt agents already configured in a working directory into this switchdash,
@@ -145,7 +141,7 @@ export async function attachConfiguredAgents(
     // are read from the same on-disk file. A difference is legitimate (one Switch
     // server reachable at two URLs) so it is surfaced, not corrected — correcting
     // it would mean writing to another install's credentials.
-    if (!sameEndpoint(found.apiEndpoint, server.apiUrl)) {
+    if (!sameApiEndpoint(found.apiEndpoint, server.apiUrl)) {
       log.warn('attachConfiguredAgents: directory endpoint differs from the chosen server', {
         name,
         dirEndpoint: found.apiEndpoint,

--- a/dash/apps/switchdash-desktop/src/main/core/agents/attach-configured-agents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/attach-configured-agents.ts
@@ -76,10 +76,13 @@ export async function attachConfiguredAgents(
   if (!server) throw new Error(`No Switch server with id ${params.serverId}`);
 
   const discovered = new Map(
-    (await discoverConfiguredAgents({ sshHost: params.sshHost, dir: params.dir })).map((d) => [
-      d.name,
-      d,
-    ])
+    (
+      await discoverConfiguredAgents({
+        sshHost: params.sshHost,
+        dir: params.dir,
+        serverId: params.serverId,
+      })
+    ).map((d) => [d.name, d])
   );
 
   const selected: Array<{ name: string; providerId: AgentProviderId }> = [];
@@ -100,7 +103,7 @@ export async function attachConfiguredAgents(
     return err({
       type: 'invalid-directory',
       dir: params.dir,
-      message: 'Every selected agent is already attached here.',
+      message: `Every selected agent is already attached to ${server.name} here.`,
     });
   }
 

--- a/dash/apps/switchdash-desktop/src/main/core/agents/controller.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/controller.ts
@@ -44,8 +44,9 @@ export const agentsController = createRPCController({
     sshHost: string | null;
     dir: string;
     providerId: AgentProviderId;
+    serverId: string;
   }) => discoverLocationAgents(params),
-  discoverConfiguredAgents: (params: { sshHost: string | null; dir: string }) =>
+  discoverConfiguredAgents: (params: { sshHost: string | null; dir: string; serverId: string }) =>
     discoverConfiguredAgents(params),
   attachConfiguredAgents: (params: AttachConfiguredAgentsParams) => attachConfiguredAgents(params),
   getAgents: (locationId?: string) => getAgents(locationId),

--- a/dash/apps/switchdash-desktop/src/main/core/agents/discover-configured-agents.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/discover-configured-agents.test.ts
@@ -52,9 +52,10 @@ const h = vi.hoisted(() => {
   const state: {
     workspace: PluginFs | null;
     location: { id: string } | undefined;
-    agentNames: string[];
+    /** Agent-row names already in the directory, per Switch server. */
+    agentNamesByServer: Record<string, string[]>;
     claudeDefinitions: Array<{ name: string; description: string | null }>;
-  } = { workspace: null, location: { id: 'loc-1' }, agentNames: [], claudeDefinitions: [] };
+  } = { workspace: null, location: { id: 'loc-1' }, agentNamesByServer: {}, claudeDefinitions: [] };
   return { state, warn: vi.fn() };
 });
 
@@ -62,7 +63,9 @@ vi.mock('@main/core/locations/store', () => ({
   getLocationByHostDir: vi.fn(async () => h.state.location),
 }));
 vi.mock('./getAgents', () => ({
-  getAgents: vi.fn(async () => h.state.agentNames.map((name) => ({ name }))),
+  getLocationAgentsOnServer: vi.fn(async (_locationId: string, serverId: string) =>
+    (h.state.agentNamesByServer[serverId] ?? []).map((name) => ({ name }))
+  ),
 }));
 vi.mock('./agent-workspace-fs', () => ({
   resolveWorkspaceFsFor: vi.fn(async () => ({
@@ -86,13 +89,14 @@ vi.mock('@main/lib/logger', () => ({ log: { info: vi.fn(), warn: h.warn, error: 
 
 const { discoverConfiguredAgents } = await import('./discover-configured-agents');
 
-const scan = () => discoverConfiguredAgents({ sshHost: 'vm-1', dir: '/repo' });
+const scan = (serverId = 'srv-a') =>
+  discoverConfiguredAgents({ sshHost: 'vm-1', dir: '/repo', serverId });
 
 describe('discoverConfiguredAgents', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.state.location = { id: 'loc-1' };
-    h.state.agentNames = [];
+    h.state.agentNamesByServer = {};
     h.state.claudeDefinitions = [];
     h.state.workspace = fakeFs();
   });
@@ -157,7 +161,7 @@ describe('discoverConfiguredAgents', () => {
   });
 
   it('marks agents this switchdash already has a row for', async () => {
-    h.state.agentNames = ['mine'];
+    h.state.agentNamesByServer = { 'srv-a': ['mine'] };
     h.state.workspace = fakeFs({
       '.switch/agents/mine.json': creds('sw-mine'),
       '.switch/agents/theirs.json': creds('sw-theirs'),
@@ -166,6 +170,17 @@ describe('discoverConfiguredAgents', () => {
     const byName = new Map((await scan()).map((a) => [a.name, a.alreadyAgent]));
     expect(byName.get('mine')).toBe(true);
     expect(byName.get('theirs')).toBe(false);
+  });
+
+  it('still offers an agent already attached to another server (CHOO-2044)', async () => {
+    // The directory is a place on disk, not one server's territory. An agent row
+    // for server A says nothing about server B, and treating it as "already got
+    // this" is what silently emptied the onboarding list.
+    h.state.agentNamesByServer = { 'srv-a': ['shared'] };
+    h.state.workspace = fakeFs({ '.switch/agents/shared.json': creds('sw-shared') });
+
+    expect((await scan('srv-a'))[0]).toMatchObject({ name: 'shared', alreadyAgent: true });
+    expect((await scan('srv-b'))[0]).toMatchObject({ name: 'shared', alreadyAgent: false });
   });
 
   it('treats a directory with no credentials dir as having no agents', async () => {

--- a/dash/apps/switchdash-desktop/src/main/core/agents/discover-configured-agents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/discover-configured-agents.ts
@@ -9,7 +9,7 @@ import {
 import type { AgentLaunchSpec } from '../../../sidecar/agent-launch-spec';
 import { sidecarLaunchSpecRelPath } from '../../../sidecar/sidecar-paths';
 import { resolveWorkspaceFsFor } from './agent-workspace-fs';
-import { getAgents } from './getAgents';
+import { getLocationAgentsOnServer } from './getAgents';
 import { SWITCH_AGENTS_DIR_RELATIVE } from './switch-settings-paths';
 
 /** How an agent's provider was inferred, so the UI can say whether to trust it. */
@@ -29,7 +29,8 @@ export type DiscoveredConfiguredAgent = {
   /** Best-effort: null when nothing on disk names a provider. */
   providerId: AgentProviderId | null;
   providerSource: ProviderSource;
-  /** Whether this switchdash already has a row for the name at this location. */
+  /** Whether this switchdash already has a row for the name at this location, on
+   * the server being onboarded to. */
   alreadyAgent: boolean;
 };
 
@@ -141,10 +142,14 @@ async function definitionOwners(workspaceFs: PluginFs): Promise<Map<string, Agen
 export async function discoverConfiguredAgents(params: {
   sshHost: string | null;
   dir: string;
+  /** The Switch server being onboarded to — what `alreadyAgent` is judged against.
+   * A directory can hold agents for several servers, so the same name can be
+   * attached here already and still be attachable to another (CHOO-2044). */
+  serverId: string;
 }): Promise<DiscoveredConfiguredAgent[]> {
   const location = await getLocationByHostDir(params.sshHost, params.dir);
   const existing = location
-    ? new Set((await getAgents(location.id)).map((a) => a.name))
+    ? new Set((await getLocationAgentsOnServer(location.id, params.serverId)).map((a) => a.name))
     : new Set<string>();
 
   const workspace = await resolveWorkspaceFsFor(params.sshHost, params.dir);

--- a/dash/apps/switchdash-desktop/src/main/core/agents/discover-location-agents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/discover-location-agents.ts
@@ -2,7 +2,7 @@ import { getLocationByHostDir } from '@main/core/locations/store';
 import { getPlugin } from '@main/core/providers/plugin-registry';
 import type { AgentProviderId } from '@shared/core/providers/agent-provider-registry';
 import { resolveWorkspaceFsFor } from './agent-workspace-fs';
-import { getAgents } from './getAgents';
+import { getLocationAgentsOnServer } from './getAgents';
 
 export type DiscoveredLocationAgent = {
   /** The definition/launch name (`.claude/agents/<name>.md` stem, `--agent <name>`). */
@@ -13,7 +13,8 @@ export type DiscoveredLocationAgent = {
   /** Whether the definition can join Switch (its tools allowlist keeps the
    * connector's MCP tools, or it inherits all tools). */
   eligible: boolean;
-  /** Whether switchdash already has an agent row for this definition in this dir. */
+  /** Whether switchdash already has an agent row for this definition in this dir,
+   * on the server being onboarded to. */
   alreadyAgent: boolean;
 };
 
@@ -23,21 +24,25 @@ export type DiscoveredLocationAgent = {
  * onboarding a directory's existing agents (CHOO-1440). It surfaces BOTH agents
  * already set up for Switch (carrying credentials) and plain provider subagents a
  * user created directly (no Switch setup yet), so either can be adopted as a
- * Switch agent. `alreadyAgent` marks definitions switchdash already has a row for,
- * so the modal never offers to re-add them. Works for local and remote (SSH)
- * directories. Returns an empty list for a provider with no definition concept.
+ * Switch agent. `alreadyAgent` marks definitions switchdash already has a row for
+ * *on `serverId`*, so the modal never offers to re-add them there — while the same
+ * definition stays offerable to a different server, which is a separate agent
+ * (CHOO-2044). Works for local and remote (SSH) directories. Returns an empty list
+ * for a provider with no definition concept.
  */
 export async function discoverLocationAgents(params: {
   sshHost: string | null;
   dir: string;
   providerId: AgentProviderId;
+  /** The Switch server being onboarded to — what `alreadyAgent` is judged against. */
+  serverId: string;
 }): Promise<DiscoveredLocationAgent[]> {
   const behavior = getPlugin(params.providerId).behavior.repoAgents;
   if (!behavior) return [];
 
   const location = await getLocationByHostDir(params.sshHost, params.dir);
   const existing = location
-    ? new Set((await getAgents(location.id)).map((a) => a.name))
+    ? new Set((await getLocationAgentsOnServer(location.id, params.serverId)).map((a) => a.name))
     : new Set<string>();
 
   const workspace = await resolveWorkspaceFsFor(params.sshHost, params.dir);

--- a/dash/apps/switchdash-desktop/src/main/core/agents/discover-location-agents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/discover-location-agents.ts
@@ -10,6 +10,12 @@ export type DiscoveredLocationAgent = {
   description: string | null;
   /** Whether the definition already carries Switch credentials on disk. */
   registered: boolean;
+  /** The Switch endpoint those credentials name, when they carry one. This is
+   * which server the existing identity belongs to — an identity can only be
+   * imported into the server that issued it, so the modal needs it to tell an
+   * importable row from one that belongs elsewhere (CHOO-2044). Null for a plain
+   * definition with no Switch setup, which is adoptable anywhere. */
+  credentialEndpoint: string | null;
   /** Whether the definition can join Switch (its tools allowlist keeps the
    * connector's MCP tools, or it inherits all tools). */
   eligible: boolean;
@@ -49,11 +55,14 @@ export async function discoverLocationAgents(params: {
   try {
     const definitions = await behavior.discoverDefinitions(workspace.fs);
     const local = await behavior.discoverLocal(workspace.fs, workspace.homeFs);
-    const credentialled = new Set(local.filter((l) => l.switchAgentId !== null).map((l) => l.name));
+    const credentialled = new Map(
+      local.filter((l) => l.switchAgentId !== null).map((l) => [l.name, l.apiEndpoint])
+    );
     return definitions.map((def) => ({
       name: def.name,
       description: def.description,
       registered: def.registered || credentialled.has(def.name),
+      credentialEndpoint: credentialled.get(def.name) ?? null,
       eligible: def.eligible,
       alreadyAgent: existing.has(def.name),
     }));

--- a/dash/apps/switchdash-desktop/src/main/core/agents/getAgents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/getAgents.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { db } from '@main/db/client';
 import { agents } from '@main/db/schema';
 import type { Agent } from '@shared/core/agents/agents';
@@ -12,5 +12,26 @@ export async function getAgents(locationId?: string): Promise<Agent[]> {
         .where(eq(agents.locationId, locationId))
         .orderBy(desc(agents.updatedAt))
     : await db.select().from(agents).orderBy(desc(agents.updatedAt));
+  return rows.map(mapAgentRowToAgent);
+}
+
+/**
+ * A directory's agents that belong to one Switch server.
+ *
+ * A directory is a place on disk, not a server's territory: the same folder can
+ * hold agents registered against several servers. Anything answering "do I
+ * already have this agent" must therefore ask per server — asking per directory
+ * reports an agent on server A as already onboarded when the target is server B,
+ * and the candidate is silently dropped (CHOO-2044).
+ */
+export async function getLocationAgentsOnServer(
+  locationId: string,
+  serverId: string
+): Promise<Agent[]> {
+  const rows = await db
+    .select()
+    .from(agents)
+    .where(and(eq(agents.locationId, locationId), eq(agents.serverId, serverId)))
+    .orderBy(desc(agents.updatedAt));
   return rows.map(mapAgentRowToAgent);
 }

--- a/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.test.ts
@@ -75,6 +75,11 @@ vi.mock('@main/core/switch-servers/servers-store', () => ({
     name: 'Server B',
     apiUrl: 'https://b.example.com',
   })),
+  findServerByEndpoint: vi.fn(async (endpoint: string) =>
+    endpoint === 'https://a.example.com'
+      ? { id: 'srv-a', name: 'Server A', apiUrl: 'https://a.example.com' }
+      : null
+  ),
 }));
 vi.mock('./createAgent', () => ({ createAgent: h.createAgent }));
 vi.mock('./register-agent-identity', () => ({ registerAgentIdentity: h.registerAgentIdentity }));
@@ -134,7 +139,7 @@ describe('onboardLocationAgents identity resolution', () => {
     expect(h.createAgent).not.toHaveBeenCalled();
   });
 
-  it('names the other server so the refusal can be acted on', async () => {
+  it('names the owning server, not its URL, when switchdash has it registered', async () => {
     h.state.definitions = [definition('test-1', true)];
     h.state.local = [
       { name: 'test-1', switchAgentId: 'sw-on-a', apiEndpoint: 'https://a.example.com' },
@@ -146,8 +151,24 @@ describe('onboardLocationAgents identity resolution', () => {
     if (result.success) return;
     expect(result.error).toMatchObject({ type: 'error' });
     const message = 'message' in result.error ? result.error.message : '';
-    expect(message).toContain('https://a.example.com');
+    expect(message).toContain('Server A');
     expect(message).toContain('Server B');
+    expect(message).not.toContain('https://a.example.com');
+  });
+
+  it('says "another Switch server" rather than a URL for a server it does not know', async () => {
+    h.state.definitions = [definition('test-1', true)];
+    h.state.local = [
+      { name: 'test-1', switchAgentId: 'sw-elsewhere', apiEndpoint: 'https://unknown.example.com' },
+    ];
+
+    const result = await onboard(['test-1']);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const message = 'message' in result.error ? result.error.message : '';
+    expect(message).toContain('another Switch server');
+    expect(message).not.toContain('https://unknown.example.com');
   });
 
   it('imports an identity the target server does have', async () => {

--- a/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.test.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.test.ts
@@ -1,0 +1,215 @@
+import type { PluginFs } from '@switchdash/core/agents/plugins';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  class GatewayError extends Error {
+    constructor(readonly kind: string) {
+      super(kind);
+    }
+  }
+  const state: {
+    /** Agent-row names already in the directory, per Switch server. */
+    agentNamesByServer: Record<string, string[]>;
+    definitions: Array<{
+      name: string;
+      description: string | null;
+      eligible: boolean;
+      registered: boolean;
+    }>;
+    /** On-disk credentials per definition name. */
+    local: Array<{ name: string; switchAgentId: string | null; apiEndpoint: string | null }>;
+    /** Switch agent ids the target server admits to having. */
+    idsOnServer: string[];
+  } = { agentNamesByServer: {}, definitions: [], local: [], idsOnServer: [] };
+  return {
+    state,
+    GatewayError,
+    warn: vi.fn(),
+    createAgent: vi.fn(async (input: Record<string, unknown>) => ({ ...input, id: 'agent-row' })),
+    agentExistsOnServer: vi.fn(async (_server: unknown, agentId: string) =>
+      h.state.idsOnServer.includes(agentId)
+    ),
+    registerAgentIdentity: vi.fn(async () => ({
+      kind: 'created' as const,
+      id: 'sw-fresh',
+      apiKey: 'tok-fresh',
+    })),
+    writeNeutralAgentSettings: vi.fn(async () => {}),
+    openLocation: vi.fn(async () => {}),
+    emit: vi.fn(),
+  };
+});
+
+vi.mock('@main/core/locations/store', () => ({
+  ensureLocation: vi.fn(async () => ({ id: 'loc-1' })),
+}));
+vi.mock('./getAgents', () => ({
+  getLocationAgentsOnServer: vi.fn(async (_locationId: string, serverId: string) =>
+    (h.state.agentNamesByServer[serverId] ?? []).map((name) => ({ name }))
+  ),
+}));
+vi.mock('./agent-workspace-fs', () => ({
+  resolveWorkspaceFsFor: vi.fn(async () => ({
+    fs: {} as PluginFs,
+    homeFs: {} as PluginFs,
+    close: vi.fn(),
+  })),
+}));
+vi.mock('@main/core/providers/plugin-registry', () => ({
+  getPlugin: () => ({
+    behavior: {
+      repoAgents: {
+        discoverDefinitions: async () => h.state.definitions,
+        discoverLocal: async () => h.state.local,
+      },
+    },
+  }),
+}));
+vi.mock('@main/core/switch-servers/gateway-client', () => ({
+  agentExistsOnServer: h.agentExistsOnServer,
+  GatewayError: h.GatewayError,
+}));
+vi.mock('@main/core/switch-servers/servers-store', () => ({
+  getServer: vi.fn(async () => ({
+    id: 'srv-b',
+    name: 'Server B',
+    apiUrl: 'https://b.example.com',
+  })),
+}));
+vi.mock('./createAgent', () => ({ createAgent: h.createAgent }));
+vi.mock('./register-agent-identity', () => ({ registerAgentIdentity: h.registerAgentIdentity }));
+vi.mock('./write-switch-settings', () => ({
+  writeNeutralAgentSettingsFs: h.writeNeutralAgentSettings,
+}));
+vi.mock('./known-agent-type', () => ({ knownAgentTypeForProvider: () => 'claude-code' }));
+vi.mock('@main/core/locations/path-utils', () => ({ checkIsValidDirectory: () => true }));
+vi.mock('@main/core/locations/location-manager', () => ({
+  locationManager: { openLocation: h.openLocation },
+}));
+vi.mock('./setAgentAutoSession', () => ({
+  reconcileAgentAutoSessionFromGateway: vi.fn(async () => {}),
+}));
+vi.mock('./agent-events', () => ({ agentEvents: { _emit: h.emit } }));
+vi.mock('@main/lib/logger', () => ({ log: { info: vi.fn(), warn: h.warn, error: vi.fn() } }));
+
+const { onboardLocationAgents } = await import('./onboard-location-agents');
+
+const onboard = (names: string[]) =>
+  onboardLocationAgents({
+    sshHost: null,
+    dir: '/repo',
+    providerId: 'claude',
+    serverId: 'srv-b',
+    names,
+  });
+
+function definition(name: string, registered: boolean) {
+  return { name, description: null, eligible: true, registered };
+}
+
+describe('onboardLocationAgents identity resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.state.agentNamesByServer = {};
+    h.state.definitions = [];
+    h.state.local = [];
+    h.state.idsOnServer = [];
+  });
+
+  it('refuses an identity registered with another server, and writes nothing (CHOO-2044)', async () => {
+    // The credentials name server A. Server B does not have that id, and the
+    // tempting fallback — mint a fresh identity — writes back over the same
+    // credentials file, breaking the agent server A is still running.
+    h.state.definitions = [definition('test-1', true)];
+    h.state.local = [
+      { name: 'test-1', switchAgentId: 'sw-on-a', apiEndpoint: 'https://a.example.com' },
+    ];
+    h.state.idsOnServer = [];
+
+    const result = await onboard(['test-1']);
+
+    expect(result.success).toBe(false);
+    expect(h.registerAgentIdentity).not.toHaveBeenCalled();
+    expect(h.writeNeutralAgentSettings).not.toHaveBeenCalled();
+    expect(h.createAgent).not.toHaveBeenCalled();
+  });
+
+  it('names the other server so the refusal can be acted on', async () => {
+    h.state.definitions = [definition('test-1', true)];
+    h.state.local = [
+      { name: 'test-1', switchAgentId: 'sw-on-a', apiEndpoint: 'https://a.example.com' },
+    ];
+
+    const result = await onboard(['test-1']);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toMatchObject({ type: 'error' });
+    const message = 'message' in result.error ? result.error.message : '';
+    expect(message).toContain('https://a.example.com');
+    expect(message).toContain('Server B');
+  });
+
+  it('imports an identity the target server does have', async () => {
+    h.state.definitions = [definition('mine', true)];
+    h.state.local = [
+      { name: 'mine', switchAgentId: 'sw-on-b', apiEndpoint: 'https://b.example.com' },
+    ];
+    h.state.idsOnServer = ['sw-on-b'];
+
+    const result = await onboard(['mine']);
+
+    expect(result.success).toBe(true);
+    expect(h.registerAgentIdentity).not.toHaveBeenCalled();
+    expect(h.writeNeutralAgentSettings).not.toHaveBeenCalled();
+    expect(h.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'mine', switchAgentId: 'sw-on-b', serverId: 'srv-b' })
+    );
+  });
+
+  it('still adopts a plain definition that carries no Switch identity', async () => {
+    // The case adoption exists for: nothing on disk to overwrite, so minting is
+    // the only way in and is safe.
+    h.state.definitions = [definition('plain', false)];
+    h.state.local = [{ name: 'plain', switchAgentId: null, apiEndpoint: null }];
+
+    const result = await onboard(['plain']);
+
+    expect(result.success).toBe(true);
+    expect(h.registerAgentIdentity).toHaveBeenCalled();
+    expect(h.writeNeutralAgentSettings).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ slug: 'plain', agentId: 'sw-fresh' })
+    );
+  });
+
+  it('reports an unauthenticated server rather than minting past it', async () => {
+    h.state.definitions = [definition('mine', true)];
+    h.state.local = [
+      { name: 'mine', switchAgentId: 'sw-on-b', apiEndpoint: 'https://b.example.com' },
+    ];
+    h.agentExistsOnServer.mockRejectedValueOnce(new h.GatewayError('unauthorized'));
+
+    const result = await onboard(['mine']);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toMatchObject({ type: 'switch-server-unauthenticated' });
+    expect(h.registerAgentIdentity).not.toHaveBeenCalled();
+    expect(h.writeNeutralAgentSettings).not.toHaveBeenCalled();
+  });
+
+  it('offers a definition already onboarded onto another server', async () => {
+    // Same directory, same name, different server — a separate agent.
+    h.state.agentNamesByServer = { 'srv-a': ['shared'] };
+    h.state.definitions = [definition('shared', false)];
+    h.state.local = [{ name: 'shared', switchAgentId: null, apiEndpoint: null }];
+
+    const result = await onboard(['shared']);
+
+    expect(result.success).toBe(true);
+    expect(h.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'shared', serverId: 'srv-b' })
+    );
+  });
+});

--- a/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.ts
@@ -17,7 +17,7 @@ import { basenameFromAnyPath } from '@shared/path-name';
 import { agentEvents } from './agent-events';
 import { resolveWorkspaceFsFor, type WorkspaceFs } from './agent-workspace-fs';
 import { createAgent } from './createAgent';
-import { getAgents } from './getAgents';
+import { getLocationAgentsOnServer } from './getAgents';
 import { registerAgentIdentity } from './register-agent-identity';
 import { reconcileAgentAutoSessionFromGateway } from './setAgentAutoSession';
 import { writeNeutralAgentSettingsFs } from './write-switch-settings';
@@ -175,7 +175,9 @@ export async function onboardLocationAgents(
     name: params.locationName ?? basenameFromAnyPath(params.dir) ?? params.providerId,
   });
 
-  const existing = new Set((await getAgents(location.id)).map((a) => a.name));
+  const existing = new Set(
+    (await getLocationAgentsOnServer(location.id, params.serverId)).map((a) => a.name)
+  );
 
   const workspace = await resolveWorkspaceFsFor(params.sshHost, params.dir);
   const created: Agent[] = [];
@@ -190,7 +192,7 @@ export async function onboardLocationAgents(
       return err({
         type: 'invalid-directory',
         dir: params.dir,
-        message: 'No Claude agents available to onboard in this directory.',
+        message: `No Claude agents available to onboard in this directory onto ${server.name}.`,
       });
     }
 
@@ -245,7 +247,7 @@ export async function onboardLocationAgents(
     return err({
       type: 'invalid-directory',
       dir: params.dir,
-      message: 'Every agent in this directory is already onboarded here.',
+      message: `Every agent in this directory is already onboarded onto ${server.name}.`,
     });
   }
 

--- a/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.ts
@@ -7,7 +7,7 @@ import { checkIsValidDirectory } from '@main/core/locations/path-utils';
 import { ensureLocation } from '@main/core/locations/store';
 import { getPlugin } from '@main/core/providers/plugin-registry';
 import { agentExistsOnServer, GatewayError } from '@main/core/switch-servers/gateway-client';
-import { getServer } from '@main/core/switch-servers/servers-store';
+import { findServerByEndpoint, getServer } from '@main/core/switch-servers/servers-store';
 import { log } from '@main/lib/logger';
 import type { Agent } from '@shared/core/agents/agents';
 import type { OnboardAgentError } from '@shared/core/agents/onboarding';
@@ -111,11 +111,12 @@ async function resolveIdentity(
       }
       throw cause;
     }
+    const owner = await findServerByEndpoint(creds.apiEndpoint);
     return {
       ok: false,
       error: {
         type: 'error',
-        message: `"${name}" is already registered with another Switch server (${creds.apiEndpoint}) and cannot be imported into ${ctx.server.name}. Onboard it from that server, or create a new agent here under a different name.`,
+        message: `"${name}" is already registered with ${owner ? owner.name : 'another Switch server'} and cannot be imported into ${ctx.server.name}. Onboard it from that server, or create a new agent here under a different name.`,
       },
     };
   }

--- a/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/agents/onboard-location-agents.ts
@@ -70,6 +70,13 @@ function registrationError(
  * Resolve the Switch identity to onboard a definition under: reuse existing
  * credentials when their identity still exists on the server, otherwise register
  * a fresh identity and write the credentials (adopting a plain subagent).
+ *
+ * A definition that already carries credentials naming an identity this server
+ * does not have belongs to a *different* Switch server, and is refused. Minting a
+ * fresh identity for it would be the natural-looking fallback and is exactly the
+ * wrong move: the credentials are written back under the same name, so the other
+ * server's agent is overwritten on disk and stops working, silently (CHOO-2044).
+ * Adoption is for definitions with no Switch identity at all.
  */
 async function resolveIdentity(
   name: string,
@@ -104,6 +111,13 @@ async function resolveIdentity(
       }
       throw cause;
     }
+    return {
+      ok: false,
+      error: {
+        type: 'error',
+        message: `"${name}" is already registered with another Switch server (${creds.apiEndpoint}) and cannot be imported into ${ctx.server.name}. Onboard it from that server, or create a new agent here under a different name.`,
+      },
+    };
   }
 
   // No usable credentials — adopt: mint a fresh identity and write its creds,

--- a/dash/apps/switchdash-desktop/src/main/core/switch-servers/servers-store.ts
+++ b/dash/apps/switchdash-desktop/src/main/core/switch-servers/servers-store.ts
@@ -3,12 +3,13 @@ import { and, desc, eq, isNull, ne, or, sql } from 'drizzle-orm';
 import { encryptedAppSecretsStore } from '@main/core/secrets/encrypted-app-secrets-store';
 import { db } from '@main/db/client';
 import { agents, kv, type SwitchServerRow, switchServers } from '@main/db/schema';
-import type {
-  AddServerParams,
-  ManagedServerRef,
-  RenameServerParams,
-  SwitchServer,
-  UpdateServerParams,
+import {
+  urlOrigin,
+  type AddServerParams,
+  type ManagedServerRef,
+  type RenameServerParams,
+  type SwitchServer,
+  type UpdateServerParams,
 } from '@shared/core/switch-servers/switch-servers';
 
 const ACTIVE_SERVER_KV_KEY = 'activeSwitchServerId';
@@ -41,20 +42,6 @@ function mapRow(row: SwitchServerRow): SwitchServer {
 /** Strip a trailing slash so `${url}/gateway` never doubles up. */
 function normaliseUrl(url: string): string {
   return url.trim().replace(/\/+$/, '');
-}
-
-/**
- * Origin (protocol + host + port, lowercased) of a URL, or null if unparseable.
- * Agents are matched to servers by origin rather than full URL: an agent's
- * `SWITCH_API_ENDPOINT` and a server's API URL share a host but may differ in
- * path, so comparing origins is the robust match.
- */
-export function urlOrigin(url: string): string | null {
-  try {
-    return new URL(url.trim()).origin.toLowerCase();
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
@@ -308,7 +308,12 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
       };
     }),
   ];
-  const hasOnboardable = onboardableAgents.length > 0;
+  // Onboarding needs both halves of the question answered: which directory, and
+  // which agent type the agents brought in will run under. With no type picked
+  // there is nothing to offer — every row would be unactionable — so the list and
+  // its button stay away and the modal asks for the type instead. Derived in one
+  // place so the footer button and the list it submits cannot disagree.
+  const hasOnboardable = !!pickState.providerId && onboardableAgents.length > 0;
   /** Rows that cannot be brought in — listed with their reason, never selectable. */
   const blockedNames = new Set(
     onboardableAgents.filter((a) => a.blockedReason !== null).map((a) => a.name)
@@ -867,6 +872,18 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
         {isChecking && (
           <p className="text-sm text-foreground-muted">Scanning directory for agents…</p>
         )}
+        {/* A directory chosen with no agent type yet is a half-answered question,
+            and the onboard list cannot be acted on from there: every row needs a
+            type to run under. Say what is missing rather than listing agents under
+            a disabled button (CHOO-2044). */}
+        {canConfigureAgent &&
+          !pickState.providerId &&
+          !isChecking &&
+          discoverDir.trim().length > 0 && (
+            <p className="text-sm text-foreground-muted">
+              Pick an agent type above to scan this directory for agents to bring in.
+            </p>
+          )}
         {canConfigureAgent && hasOnboardable && !createMode && (
           <>
             <OnboardExistingPanel

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
@@ -278,7 +278,11 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
   const foreignCredentialReason = (endpoint: string | null): string | null => {
     if (endpoint === null || !targetServer) return null;
     if (sameApiEndpoint(endpoint, targetServer.apiUrl)) return null;
-    return `Already registered with another Switch server (${endpoint}), so it cannot be imported into ${targetServer.name}. Create a new agent instead.`;
+    // Name the server when this switchdash has it registered. The raw endpoint is
+    // an implementation detail to the person reading the row, and for a server
+    // they have registered it is one they already know by name.
+    const owner = switchServersStore.servers.find((s) => sameApiEndpoint(s.apiUrl, endpoint));
+    return `Already registered with ${owner ? owner.name : 'another Switch server'}, so it cannot be imported into ${targetServer.name}. Create a new agent instead.`;
   };
 
   const onboardableAgents: OnboardableAgent[] = [

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
@@ -241,7 +241,10 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
   // Switch credentials rather than by any provider's definition format. This is
   // what an agent someone else set up on a shared host looks like, and the only
   // way a provider with no definition concept (Codex) is visible at all
-  // (CHOO-1937). Provider-agnostic, so it does not wait on the type picker.
+  // (CHOO-1937). The scan itself is provider-agnostic; it still waits on the type
+  // picker because nothing below the directory is shown until a type is chosen, so
+  // scanning earlier would be work (an SSH round trip, for a remote dir) whose
+  // result cannot be displayed.
   const configuredQuery = useQuery({
     queryKey: [
       'discoverConfiguredAgents',
@@ -255,7 +258,7 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
         dir: discoverDir,
         serverId: pickState.serverId!,
       }),
-    enabled: !!pickState.serverId && discoverDir.trim().length > 0,
+    enabled: !!pickState.providerId && !!pickState.serverId && discoverDir.trim().length > 0,
   });
 
   // Definitions that can join Switch and switchdash hasn't already onboarded — the
@@ -424,6 +427,12 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
   const hostLevelBlocked = isRemoteRun && hostReadiness.blocked && hostReadiness.scope === 'host';
   const canChooseAgentType = runHostReachable && !hostLevelBlocked;
   const canConfigureAgent = canChooseAgentType && runHostReady;
+  // The agent type is the next gate after the host, and it gates everything below
+  // the directory: which agents in the directory can be brought in, and how a new
+  // one is created, both depend on it. Filling in a name, a description and a
+  // config for an agent that has no type yet is answering questions out of order —
+  // the form cannot be submitted from there anyway (CHOO-2044).
+  const canDetailAgent = canConfigureAgent && !!pickState.providerId;
 
   const canSubmitDetected = isRemoteRun
     ? !!pickState.providerId &&
@@ -867,24 +876,20 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
           />
         )}
         {canConfigureAgent && !isRemoteRun && (
-          <PickExistingPanel state={pickState} showName={!isMissingSwitchAgent} />
+          <PickExistingPanel state={pickState} showName={canDetailAgent && !isMissingSwitchAgent} />
         )}
-        {isChecking && (
+        {canDetailAgent && isChecking && (
           <p className="text-sm text-foreground-muted">Scanning directory for agents…</p>
         )}
-        {/* A directory chosen with no agent type yet is a half-answered question,
-            and the onboard list cannot be acted on from there: every row needs a
-            type to run under. Say what is missing rather than listing agents under
-            a disabled button (CHOO-2044). */}
-        {canConfigureAgent &&
-          !pickState.providerId &&
-          !isChecking &&
-          discoverDir.trim().length > 0 && (
-            <p className="text-sm text-foreground-muted">
-              Pick an agent type above to scan this directory for agents to bring in.
-            </p>
-          )}
-        {canConfigureAgent && hasOnboardable && !createMode && (
+        {/* A directory chosen with no agent type is a half-answered question, and
+            nothing below can be acted on from there: the agents that could be
+            brought in need a type to run under, and so does a new one. Ask for the
+            type rather than showing a form and a list that cannot be submitted
+            (CHOO-2044). */}
+        {canConfigureAgent && !pickState.providerId && discoverDir.trim().length > 0 && (
+          <p className="text-sm text-foreground-muted">Pick an agent type above to continue.</p>
+        )}
+        {canDetailAgent && hasOnboardable && !createMode && (
           <>
             <OnboardExistingPanel
               agents={onboardableAgents}
@@ -912,7 +917,7 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
             ← Back to existing agents
           </Button>
         )}
-        {canConfigureAgent && isMissingRemoteAgent && showCreate && (
+        {canDetailAgent && isMissingRemoteAgent && showCreate && (
           <>
             <ConfigureAgentPanel
               form={remoteConfigureForm}
@@ -925,7 +930,7 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
             )}
           </>
         )}
-        {switchAgent && (
+        {canDetailAgent && switchAgent && (
           <>
             <div className="flex items-start gap-2 rounded-md border border-border bg-background-1 px-2 py-1.5 text-xs text-foreground-muted">
               <CheckCircle2 className="mt-0.5 size-3.5 shrink-0 text-green-500" />
@@ -981,7 +986,7 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
             )}
           </>
         )}
-        {canConfigureAgent && isMissingSwitchAgent && showCreate && (
+        {canDetailAgent && isMissingSwitchAgent && showCreate && (
           <>
             <ConfigureAgentPanel
               form={configureForm}

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
@@ -47,7 +47,10 @@ import {
 import { log } from '@renderer/utils/logger';
 import type { AgentProviderConfig } from '@shared/core/agents/agent-provider-config';
 import { getProvider } from '@shared/core/providers/agent-provider-registry';
-import type { ProvisionAgentResult } from '@shared/core/switch-servers/switch-servers';
+import {
+  sameApiEndpoint,
+  type ProvisionAgentResult,
+} from '@shared/core/switch-servers/switch-servers';
 import { basenameFromAnyPath } from '@shared/path-name';
 import { AgentAdvancedConfig } from './agent-advanced-config';
 import { AgentTypePicker } from './agent-type-picker';
@@ -267,24 +270,45 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
   const attachableAgents = (configuredQuery.data ?? []).filter(
     (a) => !a.alreadyAgent && !definitionNames.has(a.name)
   );
+  // An identity belongs to the server that issued it, so importing one into a
+  // different server is not a thing that can happen: the onboard path would find
+  // the id absent here, mint a replacement, and write it over the credentials the
+  // other server's agent runs on. Say who it belongs to and leave it alone — the
+  // way in is to create a new agent (CHOO-2044).
+  const foreignCredentialReason = (endpoint: string | null): string | null => {
+    if (endpoint === null || !targetServer) return null;
+    if (sameApiEndpoint(endpoint, targetServer.apiUrl)) return null;
+    return `Already registered with another Switch server (${endpoint}), so it cannot be imported into ${targetServer.name}. Create a new agent instead.`;
+  };
+
   const onboardableAgents: OnboardableAgent[] = [
     ...definitionAgents.map((a) => ({
       name: a.name,
       description: a.description,
       kind: (a.registered ? 'import' : 'adopt') as AdoptKind,
       providerLabel: null,
+      blockedReason: foreignCredentialReason(a.credentialEndpoint),
     })),
     ...attachableAgents.map((a) => {
       const providerId = a.providerId ?? pickState.providerId ?? null;
+      const providerLabel = providerId ? (getProvider(providerId)?.name ?? providerId) : null;
       return {
         name: a.name,
         description: null,
         kind: 'attach' as AdoptKind,
-        providerLabel: providerId ? (getProvider(providerId)?.name ?? providerId) : null,
+        providerLabel,
+        blockedReason:
+          providerLabel === null
+            ? 'Pick an agent type above to attach this one — the directory does not say which runs it.'
+            : null,
       };
     }),
   ];
   const hasOnboardable = onboardableAgents.length > 0;
+  /** Rows that cannot be brought in — listed with their reason, never selectable. */
+  const blockedNames = new Set(
+    onboardableAgents.filter((a) => a.blockedReason !== null).map((a) => a.name)
+  );
   /** Attachable rows keyed by name, with the provider resolved for submission. */
   const attachByName = new Map(
     attachableAgents.flatMap((a) => {
@@ -299,12 +323,12 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
   // are the checked definitions to onboard (default: all).
   const [createMode, setCreateMode] = useState(false);
   const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
-  // Default-select only what can actually be submitted: an attach row whose
-  // provider is unknown is disabled until a type is picked, and pre-checking it
-  // would just block the button with no visible cause. Picking a type unblocks
-  // the row, which changes this key and folds it into the selection.
+  // Default-select only what can actually be submitted: a blocked row (unknown
+  // provider, or an identity belonging to another server) is disabled, and
+  // pre-checking it would just block the button with no visible cause. Resolving
+  // the block changes this key and folds the row into the selection.
   const onboardableKey = onboardableAgents
-    .filter((a) => !(a.kind === 'attach' && a.providerLabel === null))
+    .filter((a) => a.blockedReason === null)
     .map((a) => a.name)
     .join('|');
   useEffect(() => {
@@ -619,11 +643,15 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
   const handleOnboard = async () => {
     // `canOnboard` already requires a server; repeated so the calls below narrow.
     if (!canOnboard || !pickState.serverId) return;
-    const attachSelected = [...selectedNames].flatMap((name) => {
+    // Blocked rows are disabled in the list, so a selected one means the list went
+    // stale under the user. Dropping them here keeps a stale tick from reaching a
+    // path that would refuse it — or worse, act on it.
+    const submittable = [...selectedNames].filter((name) => !blockedNames.has(name));
+    const attachSelected = submittable.flatMap((name) => {
       const providerId = attachByName.get(name);
       return providerId ? [{ name, providerId }] : [];
     });
-    const onboardSelected = [...selectedNames].filter((name) => !attachByName.has(name));
+    const onboardSelected = submittable.filter((name) => !attachByName.has(name));
     if (onboardSelected.length > 0 && !pickState.providerId) return;
     setSubmitState('creating');
     setCloseGuard(true);
@@ -680,15 +708,16 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
     }
   };
 
+  const submittableNames = [...selectedNames].filter((name) => !blockedNames.has(name));
   // A definition still needs the picked agent type to run under; an attach row
   // carries its own (inferred from disk, or the picked one as a fallback).
-  const selectionNeedsProviderPick = [...selectedNames].some((name) => !attachByName.has(name));
+  const selectionNeedsProviderPick = submittableNames.some((name) => !attachByName.has(name));
   // Adopting agents that already exist in the directory still puts them on this
   // host, so it answers to the same gates as creating one. Omitting them here
   // let you onboard onto a host that was unreachable or missing prerequisites.
   const canOnboard =
     hasOnboardable &&
-    selectedNames.size > 0 &&
+    submittableNames.length > 0 &&
     !!pickState.serverId &&
     (!selectionNeedsProviderPick || !!pickState.providerId) &&
     runHostReachable &&
@@ -719,7 +748,7 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
               onClick={() => void handleOnboard()}
               disabled={!canOnboard}
             >
-              {submitState === 'creating' ? 'Adding...' : `Add ${selectedNames.size} selected`}
+              {submitState === 'creating' ? 'Adding...' : `Add ${submittableNames.length} selected`}
             </ConfirmButton>
           ) : switchAgent ? (
             <ConfirmButton

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
@@ -223,14 +223,16 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
       discoverSshHost ?? 'local',
       discoverDir,
       pickState.providerId,
+      pickState.serverId,
     ],
     queryFn: () =>
       rpc.agents.discoverLocationAgents({
         sshHost: discoverSshHost,
         dir: discoverDir,
         providerId: pickState.providerId!,
+        serverId: pickState.serverId!,
       }),
-    enabled: !!pickState.providerId && discoverDir.trim().length > 0,
+    enabled: !!pickState.providerId && !!pickState.serverId && discoverDir.trim().length > 0,
   });
   // Agents already configured in the directory, found by their provider-neutral
   // Switch credentials rather than by any provider's definition format. This is
@@ -238,10 +240,19 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
   // way a provider with no definition concept (Codex) is visible at all
   // (CHOO-1937). Provider-agnostic, so it does not wait on the type picker.
   const configuredQuery = useQuery({
-    queryKey: ['discoverConfiguredAgents', discoverSshHost ?? 'local', discoverDir],
+    queryKey: [
+      'discoverConfiguredAgents',
+      discoverSshHost ?? 'local',
+      discoverDir,
+      pickState.serverId,
+    ],
     queryFn: () =>
-      rpc.agents.discoverConfiguredAgents({ sshHost: discoverSshHost, dir: discoverDir }),
-    enabled: discoverDir.trim().length > 0,
+      rpc.agents.discoverConfiguredAgents({
+        sshHost: discoverSshHost,
+        dir: discoverDir,
+        serverId: pickState.serverId!,
+      }),
+    enabled: !!pickState.serverId && discoverDir.trim().length > 0,
   });
 
   // Definitions that can join Switch and switchdash hasn't already onboarded — the
@@ -316,9 +327,10 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
   // existing vs create new" only once BOTH have settled — otherwise the create
   // form flashes up first and then flips to the onboard list when discovery lands
   // (CHOO-1440).
+  const scanTargetChosen = !!pickState.serverId && discoverDir.trim().length > 0;
   const isDiscovering =
-    (!!pickState.providerId && discoverDir.trim().length > 0 && discoverQuery.isPending) ||
-    (discoverDir.trim().length > 0 && configuredQuery.isPending);
+    (!!pickState.providerId && scanTargetChosen && discoverQuery.isPending) ||
+    (scanTargetChosen && configuredQuery.isPending);
   const isChecking =
     (isRemoteRun
       ? shouldDetectRemote && remoteAgentQuery.isPending
@@ -693,21 +705,29 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
       }
       footer={
         <DialogFooter>
-          {switchAgent ? (
-            <ConfirmButton
-              type="button"
-              onClick={() => void handleSubmit()}
-              disabled={!canSubmitDetected}
-            >
-              {submitLabel}
-            </ConfirmButton>
-          ) : hasOnboardable && !createMode ? (
+          {/* The onboard list comes first, and deliberately outranks a detected
+              legacy agent. The body renders the list whenever there is something
+              to onboard, so a footer that branched on detection first put the
+              wrong button under it: a directory carrying another server's
+              `.claude/settings.local.json` showed the detected-agent button, which
+              then verified that foreign agent against this server, failed, and
+              stayed disabled forever — with the onboardable list visible above it
+              and no way to submit it (CHOO-2044). */}
+          {hasOnboardable && !createMode ? (
             <ConfirmButton
               type="button"
               onClick={() => void handleOnboard()}
               disabled={!canOnboard}
             >
               {submitState === 'creating' ? 'Adding...' : `Add ${selectedNames.size} selected`}
+            </ConfirmButton>
+          ) : switchAgent ? (
+            <ConfirmButton
+              type="button"
+              onClick={() => void handleSubmit()}
+              disabled={!canSubmitDetected}
+            >
+              {submitLabel}
             </ConfirmButton>
           ) : isMissingRemoteAgent ? (
             <ConfirmButton
@@ -866,6 +886,31 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
                 </span>
               </span>
             </div>
+            {/* The detected agent belongs to whichever server its on-disk config
+                was written for, which need not be the one being added to. Saying
+                so is the difference between an explained dead end and a button
+                that is simply disabled for no stated reason (CHOO-2044). */}
+            {verifyState === 'not-found' && (
+              <div className="flex items-start gap-2 rounded-md border border-border bg-background-1 px-2 py-1.5 text-xs text-foreground-muted">
+                <CircleAlert className="mt-0.5 size-3.5 shrink-0 text-amber-500" />
+                <span>
+                  The agent configured in this directory is not registered on
+                  {targetServer ? ` ${targetServer.name}` : ' the active server'} — it belongs to a
+                  different Switch server. Onboard one of this directory&apos;s agents instead, or
+                  switch to the server it belongs to.
+                </span>
+              </div>
+            )}
+            {verifyState === 'unauthenticated' && (
+              <div className="flex items-start gap-2 rounded-md border border-border bg-background-1 px-2 py-1.5 text-xs text-foreground-muted">
+                <CircleAlert className="mt-0.5 size-3.5 shrink-0 text-amber-500" />
+                <span>
+                  You are not signed in to
+                  {targetServer ? ` ${targetServer.name}` : ' the active server'}, so this agent
+                  cannot be verified.
+                </span>
+              </div>
+            )}
             {switchServersStore.servers.length === 0 && (
               <div className="flex items-start gap-2 rounded-md border border-border bg-background-1 px-2 py-1.5 text-xs text-foreground-muted">
                 <CircleAlert className="mt-0.5 size-3.5 shrink-0 text-amber-500" />

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/onboard-existing-panel.tsx
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/components/add-agent-modal/onboard-existing-panel.tsx
@@ -25,6 +25,10 @@ export type OnboardableAgent = {
    * names one and the modal has no provider picked to fall back on, in which
    * case the row cannot be selected. */
   providerLabel: string | null;
+  /** Why this row cannot be brought in, or null when it can. Listed-and-disabled
+   * rather than hidden: a missing row says nothing, and the reason is usually
+   * something the user can act on. */
+  blockedReason: string | null;
 };
 
 const BADGE: Record<AdoptKind, string> = {
@@ -57,7 +61,7 @@ export function OnboardExistingPanel({
       </span>
       <div className="flex flex-col gap-0.5">
         {agents.map((a) => {
-          const blocked = a.kind === 'attach' && a.providerLabel === null;
+          const blocked = a.blockedReason !== null;
           return (
             <label
               key={a.name}
@@ -83,11 +87,8 @@ export function OnboardExistingPanel({
                     </span>
                   )}
                 </div>
-                {blocked ? (
-                  <span className="text-xs text-foreground-muted">
-                    Pick an agent type above to attach this one — the directory does not say which
-                    runs it.
-                  </span>
+                {a.blockedReason !== null ? (
+                  <span className="text-xs text-foreground-muted">{a.blockedReason}</span>
                 ) : (
                   a.description && (
                     <span className="truncate text-xs text-foreground-muted">{a.description}</span>

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/stores/agents-store.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/stores/agents-store.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Agent } from '@shared/core/agents/agents';
+import { agentsStore } from './agents-store';
+
+vi.mock('@renderer/lib/ipc', () => ({ rpc: {} }));
+
+function agent(locationId: string, serverId: string | null, name: string): Agent {
+  return { locationId, serverId, name } as Agent;
+}
+
+/**
+ * The premise these cover: a directory can hold agents registered against
+ * several Switch servers at once, so "which server does this directory belong
+ * to" has no single answer and must not be asked (CHOO-2044).
+ */
+describe('AgentsStore server scoping', () => {
+  afterEach(() => {
+    agentsStore.byLocation.clear();
+    agentsStore.optimisticServerByLocation.clear();
+  });
+
+  it('returns only the agents belonging to the given server', () => {
+    agentsStore.byLocation.set('shared', [
+      agent('shared', 'server-1', 'a'),
+      agent('shared', 'server-2', 'b'),
+      agent('shared', null, 'unlinked'),
+    ]);
+
+    expect(agentsStore.agentsOnServerAtLocation('shared', 'server-1').map((a) => a.name)).toEqual([
+      'a',
+    ]);
+    expect(agentsStore.agentsOnServerAtLocation('shared', 'server-2').map((a) => a.name)).toEqual([
+      'b',
+    ]);
+    expect(agentsStore.agentsOnServerAtLocation('shared', 'server-3')).toEqual([]);
+  });
+
+  it('reports a shared directory as present on every server it has agents on', () => {
+    agentsStore.byLocation.set('shared', [
+      agent('shared', 'server-1', 'a'),
+      agent('shared', 'server-2', 'b'),
+    ]);
+
+    expect(agentsStore.locationHasAgentsOnServer('shared', 'server-1')).toBe(true);
+    expect(agentsStore.locationHasAgentsOnServer('shared', 'server-2')).toBe(true);
+    expect(agentsStore.locationHasAgentsOnServer('shared', 'server-3')).toBe(false);
+    expect(agentsStore.serverIdsForLocation('shared').sort()).toEqual(['server-1', 'server-2']);
+  });
+
+  it('keeps a just-created location in scope before its agent row lands', () => {
+    agentsStore.noteLocationServer('fresh', 'server-1');
+
+    expect(agentsStore.locationHasAgentsOnServer('fresh', 'server-1')).toBe(true);
+    expect(agentsStore.locationHasAgentsOnServer('fresh', 'server-2')).toBe(false);
+    expect(agentsStore.serverIdsForLocation('fresh')).toEqual(['server-1']);
+  });
+
+  it('ignores the optimistic note once real agents exist', () => {
+    agentsStore.noteLocationServer('shared', 'server-9');
+    agentsStore.byLocation.set('shared', [agent('shared', 'server-1', 'a')]);
+
+    expect(agentsStore.serverIdsForLocation('shared')).toEqual(['server-1']);
+    expect(agentsStore.locationHasAgentsOnServer('shared', 'server-9')).toBe(false);
+  });
+
+  it('treats a location with only unlinked agents as on no server', () => {
+    agentsStore.byLocation.set('orphan', [agent('orphan', null, 'a')]);
+
+    expect(agentsStore.serverIdsForLocation('orphan')).toEqual([]);
+    expect(agentsStore.locationHasAgentsOnServer('orphan', 'server-1')).toBe(false);
+  });
+});

--- a/dash/apps/switchdash-desktop/src/renderer/features/locations/stores/agents-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/locations/stores/agents-store.ts
@@ -3,14 +3,15 @@ import { rpc } from '@renderer/lib/ipc';
 import type { Agent } from '@shared/core/agents/agents';
 
 /**
- * Renderer cache of every agent across all locations, used to resolve which
- * Switch server a location belongs to. The sidebar scopes its tree to the active
- * server (see {@link switchServersStore.activeServerId}), so it needs a reactive
- * location→serverId lookup that does not depend on each row's own react-query.
+ * Renderer cache of every agent across all locations. The sidebar scopes its tree
+ * to the active server (see {@link switchServersStore.activeServerId}), so it needs
+ * a reactive lookup that does not depend on each row's own react-query.
  *
- * A location holds one parent agent plus any subagents, which all share the same
- * server; {@link serverIdForLocation} returns the first non-null serverId among a
- * location's agents.
+ * **A server belongs to an agent, not to a directory.** A directory is a place on
+ * disk and can hold agents registered against several servers at once, so there is
+ * no such thing as "the location's server" to scope on — asking for one drags every
+ * agent in the directory under whichever answer came back first (CHOO-2044). Scope
+ * on {@link agentsOnServerAtLocation}; a location is in scope when it has any.
  */
 export class AgentsStore {
   /** All agents grouped by their location id. */
@@ -18,8 +19,8 @@ export class AgentsStore {
   /**
    * Server id a just-created location's agent will belong to, recorded by the
    * add-agent modal before {@link load} has re-fetched the new agent. Used as a
-   * fallback in {@link serverIdForLocation} so a freshly-created location does not
-   * flicker out of the sidebar's server-scoped view during the gap between the
+   * fallback in {@link locationHasAgentsOnServer} so a freshly-created location does
+   * not flicker out of the sidebar's server-scoped view during the gap between the
    * location mounting and the agent list refreshing.
    */
   readonly optimisticServerByLocation = new Map<string, string>();
@@ -81,11 +82,37 @@ export class AgentsStore {
     return matching.sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  /** The Switch server a location's agents belong to, or null if unlinked. */
-  serverIdForLocation(locationId: string): string | null {
+  /** A location's agents that belong to one server — what the sidebar renders
+   *  under that server. Agents in the same directory registered elsewhere are not
+   *  this server's to show. */
+  agentsOnServerAtLocation(locationId: string, serverId: string): Agent[] {
+    return (this.byLocation.get(locationId) ?? []).filter((a) => a.serverId === serverId);
+  }
+
+  /** Whether a location has anything to show under `serverId`. */
+  locationHasAgentsOnServer(locationId: string, serverId: string): boolean {
+    return this.serverIdsForLocation(locationId).includes(serverId);
+  }
+
+  /**
+   * The servers a location's agents belong to. A directory can span several, so
+   * this is a list rather than the one answer callers used to ask for.
+   *
+   * The optimistic note stands in only while the location has no agent rows at
+   * all — that is the gap it exists to cover. Letting it also speak for a location
+   * that already has agents would have it claim a server the location is not on.
+   */
+  serverIdsForLocation(locationId: string): string[] {
     const agents = this.byLocation.get(locationId);
-    const resolved = agents?.find((a) => a.serverId !== null)?.serverId ?? null;
-    return resolved ?? this.optimisticServerByLocation.get(locationId) ?? null;
+    if (!agents || agents.length === 0) {
+      const optimistic = this.optimisticServerByLocation.get(locationId);
+      return optimistic ? [optimistic] : [];
+    }
+    const ids = new Set<string>();
+    for (const agent of agents) {
+      if (agent.serverId !== null) ids.add(agent.serverId);
+    }
+    return [...ids];
   }
 }
 

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -280,6 +280,41 @@ describe('SidebarStore active-server scoping', () => {
     expect(store.orderedLocations).toEqual([]);
     expect(store.isEmpty).toBe(true);
   });
+
+  it('shows a directory shared between servers under both (CHOO-2044)', () => {
+    // A directory is a place on disk, not one server's territory. Resolving it to
+    // a single server filed it under whichever agent came back first, and the
+    // other server's agents vanished from the tree.
+    const store = new SidebarStore(
+      locationManager([{ id: 'shared', createdAt: '2026-01-01T00:00:00.000Z' }])
+    );
+    agentsStore.byLocation.set('shared', [
+      { locationId: 'shared', serverId: 'server-1' } as Agent,
+      { locationId: 'shared', serverId: 'server-2' } as Agent,
+    ]);
+
+    switchServersStore.activeServerId = 'server-1';
+    expect(store.orderedLocations.map((p) => p.id)).toEqual(['shared']);
+
+    switchServersStore.activeServerId = 'server-2';
+    expect(store.orderedLocations.map((p) => p.id)).toEqual(['shared']);
+
+    switchServersStore.activeServerId = 'server-3';
+    expect(store.orderedLocations).toEqual([]);
+  });
+
+  it('describes a shared directory by an agent on the active server (CHOO-2044)', () => {
+    const store = new SidebarStore(
+      locationManager([{ id: 'shared', createdAt: '2026-01-01T00:00:00.000Z' }])
+    );
+    agentsStore.byLocation.set('shared', [
+      { locationId: 'shared', serverId: 'server-1', providerId: 'claude' } as Agent,
+      { locationId: 'shared', serverId: 'server-2', providerId: 'codex' } as Agent,
+    ]);
+
+    switchServersStore.activeServerId = 'server-2';
+    expect(store.locationProviderId('shared')).toBe('codex');
+  });
 });
 
 describe('SidebarStore filters', () => {

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
@@ -227,18 +227,23 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
   }
 
   /**
-   * Whether a location belongs to the active server. The whole sidebar tree is
-   * scoped to one server at a time: a location shows only when its agents are
-   * linked to {@link switchServersStore.activeServerId}. Unregistered locations
-   * (mid-onboarding, no agent row yet) always show so the user sees progress.
-   * When no server is active, nothing is hidden.
+   * Whether a location has anything to show under the active server. The whole
+   * sidebar tree is scoped to one server at a time: a location shows when it holds
+   * at least one agent linked to {@link switchServersStore.activeServerId}.
+   * Unregistered locations (mid-onboarding, no agent row yet) always show so the
+   * user sees progress. When no server is active, nothing is hidden.
+   *
+   * A directory can hold agents for several servers, so this is "has any here",
+   * not "belongs to". Which of its agents are then drawn is
+   * {@link scopedAgents}' business — a location being in scope does not put every
+   * agent in it on this server's tree (CHOO-2044).
    */
   isLocationInActiveScope(locationId: string): boolean {
     const activeServerId = switchServersStore.activeServerId;
     if (!activeServerId) return true;
     const location = this.locationManager.locations.get(locationId);
     if (location && location.state === 'unregistered') return true;
-    return agentsStore.serverIdForLocation(locationId) === activeServerId;
+    return agentsStore.locationHasAgentsOnServer(locationId, activeServerId);
   }
 
   /**
@@ -255,9 +260,15 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
   }
 
   /** The representative agent of a location (the agent shown on its sidebar row):
-   * the first real (non-definition) agent, not a former subagent's row. */
+   * the first real (non-definition) agent, not a former subagent's row. Restricted
+   * to the active server, so a directory shared with another server does not
+   * describe itself by an agent this tree is not showing. */
   private parentAgent(locationId: string) {
-    return (agentsStore.byLocation.get(locationId) ?? [])[0];
+    const activeServerId = switchServersStore.activeServerId;
+    const agents = activeServerId
+      ? agentsStore.agentsOnServerAtLocation(locationId, activeServerId)
+      : (agentsStore.byLocation.get(locationId) ?? []);
+    return agents[0] ?? (agentsStore.byLocation.get(locationId) ?? [])[0];
   }
 
   /** Where a location runs — `remote` when it has an SSH host, else `local`. */

--- a/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-tree-data.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/features/sidebar/sidebar-tree-data.ts
@@ -1,6 +1,7 @@
 import { agentsStore } from '@renderer/features/locations/stores/agents-store';
 import type { LocationStore } from '@renderer/features/locations/stores/location';
 import type { SessionStore } from '@renderer/features/sessions/stores/session-store';
+import { switchServersStore } from '@renderer/features/switch-servers/switch-servers-store';
 import { sidebarStore } from '@renderer/lib/stores/app-state';
 import type { Agent } from '@shared/core/agents/agents';
 
@@ -14,6 +15,21 @@ import type { Agent } from '@shared/core/agents/agents';
 export type AgentEntry = { agent: Agent; location: LocationStore };
 
 /**
+ * A location's agents that the active server's tree should draw.
+ *
+ * A location is in scope when *some* of its agents are on the active server, but a
+ * directory can hold agents for several servers at once — so scope has to be
+ * re-applied per agent here. Taking the location's whole list instead drew agents
+ * belonging to another server under this one, which read as "onboarding brought
+ * them across" when nothing had been onboarded at all (CHOO-2044).
+ */
+function agentsAtLocationInScope(location: LocationStore): Agent[] {
+  const activeServerId = switchServersStore.activeServerId;
+  if (!activeServerId) return agentsStore.byLocation.get(location.id) ?? [];
+  return agentsStore.agentsOnServerAtLocation(location.id, activeServerId);
+}
+
+/**
  * The flat list of agents in the active-server scope. switchdash shows agents
  * as a flat list — not grouped by directory (CHOO-1440).
  *
@@ -24,7 +40,7 @@ export type AgentEntry = { agent: Agent; location: LocationStore };
 export function scopedAgents(): AgentEntry[] {
   const entries: AgentEntry[] = [];
   for (const location of sidebarStore.filteredLocations) {
-    for (const agent of agentsStore.byLocation.get(location.id) ?? []) {
+    for (const agent of agentsAtLocationInScope(location)) {
       entries.push({ agent, location });
     }
   }
@@ -46,7 +62,7 @@ export function scopedAgents(): AgentEntry[] {
 export function agentsInActiveScope(): AgentEntry[] {
   const entries: AgentEntry[] = [];
   for (const location of sidebarStore.orderedLocations) {
-    for (const agent of agentsStore.byLocation.get(location.id) ?? []) {
+    for (const agent of agentsAtLocationInScope(location)) {
       entries.push({ agent, location });
     }
   }

--- a/dash/apps/switchdash-desktop/src/renderer/lib/layout/scope-to-server.ts
+++ b/dash/apps/switchdash-desktop/src/renderer/lib/layout/scope-to-server.ts
@@ -20,10 +20,20 @@ async function activateServer(serverId: string | null): Promise<void> {
   await switchServersStore.setActive(serverId);
 }
 
-/** Scope to the server owning `locationId` — for agents and sessions. */
+/**
+ * Scope to a server that shows `locationId` — for agents and sessions.
+ *
+ * A directory can hold agents for several servers, so there may be more than one
+ * right answer. If the active server is already one of them there is nothing to do;
+ * switching away would hide the row the caller is navigating to (CHOO-2044).
+ */
 export async function scopeToLocationServer(locationId: string): Promise<void> {
   if (!agentsStore.loaded) await agentsStore.load();
-  await activateServer(agentsStore.serverIdForLocation(locationId));
+  const serverIds = agentsStore.serverIdsForLocation(locationId);
+  if (serverIds.length === 0) return;
+  const active = switchServersStore.activeServerId;
+  if (active && serverIds.includes(active)) return;
+  await activateServer(serverIds[0]);
 }
 
 /** Scope to the server owning `roomId`. */

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
@@ -9,6 +9,17 @@
  * in the encrypted secrets store, never in plain settings.
  */
 
+/**
+ * Whether two Switch API endpoints name the same server, ignoring a trailing
+ * slash — which is not a difference. This is how an agent's on-disk
+ * `SWITCH_API_ENDPOINT` is matched to a registered server, so the main process and
+ * the renderer must agree on it: the renderer decides which discovered agents are
+ * importable, and the main process enforces it.
+ */
+export function sameApiEndpoint(a: string, b: string): boolean {
+  return a.replace(/\/+$/, '') === b.replace(/\/+$/, '');
+}
+
 /** A registered Switch server. Non-secret connection metadata only. */
 export type SwitchServer = {
   id: string;

--- a/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
+++ b/dash/apps/switchdash-desktop/src/shared/core/switch-servers/switch-servers.ts
@@ -10,14 +10,34 @@
  */
 
 /**
- * Whether two Switch API endpoints name the same server, ignoring a trailing
- * slash — which is not a difference. This is how an agent's on-disk
- * `SWITCH_API_ENDPOINT` is matched to a registered server, so the main process and
- * the renderer must agree on it: the renderer decides which discovered agents are
- * importable, and the main process enforces it.
+ * Origin (protocol + host + port, lowercased) of a URL, or null if unparseable.
+ * Agents are matched to servers by origin rather than full URL: an agent's
+ * `SWITCH_API_ENDPOINT` and a server's API URL share a host but may differ in
+ * path, so comparing origins is the robust match.
+ */
+export function urlOrigin(url: string): string | null {
+  try {
+    return new URL(url.trim()).origin.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether two Switch API endpoints name the same server. This is how an agent's
+ * on-disk `SWITCH_API_ENDPOINT` is matched to a registered server, so the main
+ * process and the renderer must agree on it: the renderer decides which discovered
+ * agents are offered as importable, and the main process enforces it.
+ *
+ * Origins are compared when both parse — path and trailing slash are not
+ * differences. Unparseable input falls back to a trimmed string comparison rather
+ * than reporting a match it cannot vouch for.
  */
 export function sameApiEndpoint(a: string, b: string): boolean {
-  return a.replace(/\/+$/, '') === b.replace(/\/+$/, '');
+  const originA = urlOrigin(a);
+  const originB = urlOrigin(b);
+  if (originA && originB) return originA === originB;
+  return a.trim().replace(/\/+$/, '') === b.trim().replace(/\/+$/, '');
 }
 
 /** A registered Switch server. Non-secret connection metadata only. */


### PR DESCRIPTION
Fixes symptom (a) of [CHOO-2044](https://sandboxquantum.atlassian.net/browse/CHOO-2044). Symptom (b) — existing Claude Code subagents not listed — is **not** in this PR; it is a separate renderer gating regression still being diagnosed with the reporter.

## The premise that was wrong

A directory is a place on disk, not one Switch server's territory. The same folder can hold agents registered against several servers. Three behaviours assumed it could only hold one.

## What was broken

**Onboarding to a second server offered an empty list.** Both directory scans and both onboarding paths built their "already onboarded" set from *every* agent row at the location, ignoring `server_id`. An agent registered against server A therefore marked the same-named definition as a duplicate when the target was server B, and the candidate was filtered out before it ever reached the modal.

**The sidebar drew agents under a server they don't belong to.** `serverIdForLocation()` resolved a directory to the first non-null `serverId` among its agents, and the trees then rendered *all* of that location's agents under it. Onboarding a single agent to a second server appeared to drag every other agent in the directory across with it — reported by the user as "it brings them under the wrong sidebar". Nothing had actually been onboarded; only the drawing was wrong.

**A dead button over a submittable list.** The footer branched on a detected agent *before* the onboard list. A directory carrying another server's leftover `.claude/settings.local.json` took that branch, verified the foreign agent against the current server, got not-found, and left the only visible button permanently disabled — while the onboardable agents sat listed above it with no way to submit them.

## What changed

- `getLocationAgentsOnServer(locationId, serverId)` scopes the lookup; `discoverLocationAgents`, `discoverConfiguredAgents`, `onboardLocationAgents` and `attachConfiguredAgents` all judge `alreadyAgent` against the target server.
- `serverIdsForLocation()` replaces `serverIdForLocation()` — a directory reports *all* the servers it has agents on. A location is in scope when it has any agent on the active server, and `scopedAgents` / `agentsInActiveScope` re-apply the check per agent so each one is drawn under its own server only.
- `scopeToLocationServer` no-ops when the active server already shows the target, rather than switching away from it.
- The onboard action takes footer precedence over a detected agent, and a detected agent belonging to another server (or an unauthenticated one) now explains itself instead of silently disabling the button.
- Refusal messages name the server ("already onboarded onto X") rather than saying "here", which was the ambiguity that made this hard to see.

## Testing

`typecheck`, `lint` and the full desktop suite pass (2345 tests). New coverage:

- `agents-store.test.ts` (new) — per-server agent scoping, multi-server directories, and the optimistic-note window.
- `sidebar-store.test.ts` — a directory shared between two servers shows under both and is described by an agent on the active one.
- `discover-configured-agents.test.ts` / `attach-configured-agents.test.ts` — an agent attached to server A is still offered to, and attachable on, server B.

## Notes

No version bumps — left to the releaser. `[Unreleased]` changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-2044]: https://sandboxquantum.atlassian.net/browse/CHOO-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ