### PR TITLE
release: agent-runtime 0.2.0 (CHOO-1962)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -844,6 +844,27 @@ The Switch protocol client and MCP runtime
 
 ### [Unreleased]
 
+### [0.2.0] - 2026-08-10
+
+#### Added
+- Resolves its own Switch identity and credentials from the local agent store
+  (`./.switch/agents/`), not only from the environment — so a connector-plugin
+  session that is handed the server but no identity can start standalone instead
+  of exiting before the handshake (CHOO-1962).
+- `select_agent` tool: when the store names several agents on one server,
+  identity is left open and `select_agent` binds it; the event stream and
+  heartbeat start on bind rather than at boot (CHOO-1962).
+- Degraded startup: on a resolution failure — no credentials, an ambiguous
+  multi-server store, or an unreachable Switch — the runtime starts anyway and
+  serves a single `switch_unavailable` tool whose result is the diagnostic,
+  instead of vanishing so Switch tools read as silently missing (CHOO-1962).
+
+#### Changed
+- An unexpanded `${SWITCH_*}` placeholder now counts as absent rather than as a
+  value, so a Claude connector session falls through to the store instead of
+  dying on its own placeholder. Half a set of vars still refuses to start
+  (CHOO-1962).
+
 ### [0.1.6] - 2026-08-09
 
 #### Added


### PR DESCRIPTION
Cuts the `## agent-runtime` changelog `[0.2.0]` section for **CHOO-1962** ahead of tagging `switch-agent-runtime-v0.2.0`.

`package.json` and `artifacts.yaml` were already at `0.2.0` on main; `just artifacts-check` agrees (registry + generated modules + declared versions). This PR is changelog-only.

**Highlights (CHOO-1962):**
- Resolves its own Switch identity/credentials from the local agent store (`./.switch/agents/`), not only the environment — connector-plugin sessions can start standalone.
- New `select_agent` tool for a store naming several agents on one server.
- Degraded startup serving a `switch_unavailable` diagnostic tool instead of vanishing on a resolution failure.
- Unexpanded `${SWITCH_*}` counts as absent, so a Claude connector session falls through to the store.

Connector plugin pin catch-up (pins → 0.2.0, plugin changelogs) follows **after** this tag publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)