### PR TITLE
release: agent-runtime 0.3.0 (CHOO-2021 — npmjs/@sandboxaq)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -978,9 +978,26 @@ per-release notes on their GitHub Releases (`switch-console-v*` tags).
 ## agent-runtime
 
 The Switch protocol client and MCP runtime
-(`dash/packages/switch-agent-runtime/`). Version lives in its `package.json`.
+(`console/packages/switch-agent-runtime/`). Version lives in its `package.json`.
 
 ### [Unreleased]
+
+### [0.3.0] - 2026-08-11
+
+#### Changed
+- Published to **npmjs.com** under the **`@sandboxaq`** scope (was
+  `@sandbox-quantum` on GitHub Packages), so `npx` fetches it with no login and
+  nothing on disk — anyone, inside or outside SandboxAQ, can run the connector
+  plugins. GitHub Packages required a `read:packages` token even for public
+  packages, which `gh auth login` does not grant, so external consumers hit a
+  404 naming neither the registry nor the missing credential (CHOO-2021).
+- Publishing now authenticates by **npm trusted publishing (OIDC)** and runs in
+  the `release` environment, so a pushed tag queues the publish for approval;
+  builds carry `--provenance` and no npm token is stored (CHOO-2021).
+
+The package name (`switch-agent-runtime`) and the runtime's behavior are
+unchanged — only where and under what scope it ships. Version `0.2.x` was
+skipped to `0.3.0` by request.
 
 ### [0.2.0] - 2026-08-10
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -82,7 +82,7 @@ artifacts:
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
-    version: 0.2.0
+    version: 0.3.0
     declared_in: console/packages/switch-agent-runtime/package.json
 
   sidecar:

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -22,7 +22,7 @@ export interface ContractRange {
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.13.0',
   'switch-console': '0.20.0',
-  'agent-runtime': '0.2.0',
+  'agent-runtime': '0.3.0',
   sidecar: '1.8.0',
   gateway: '0.13.0',
   setup: '0.13.0',

--- a/console/packages/switch-agent-runtime/package.json
+++ b/console/packages/switch-agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sandboxaq/switch-agent-runtime",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Switch agent protocol client, and the local MCP runtime built on it",
   "license": "Apache-2.0",
   "author": {

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -22,7 +22,7 @@ export interface ContractRange {
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.13.0',
   'switch-console': '0.20.0',
-  'agent-runtime': '0.2.0',
+  'agent-runtime': '0.3.0',
   sidecar: '1.8.0',
   gateway: '0.13.0',
   setup: '0.13.0',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -22,7 +22,7 @@ class ContractRange(NamedTuple):
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.13.0",
     "switch-console": "0.20.0",
-    "agent-runtime": "0.2.0",
+    "agent-runtime": "0.3.0",
     "sidecar": "1.8.0",
     "gateway": "0.13.0",
     "setup": "0.13.0",


### PR DESCRIPTION
Cuts the `## agent-runtime` `[0.3.0]` changelog ahead of tagging `switch-agent-runtime-v0.3.0`.

Only change since `v0.2.0` is **CHOO-2021 (#154)**: the runtime now publishes to **npmjs.com** under the **`@sandboxaq`** scope via **trusted publishing (OIDC)** (was GitHub Packages under `@sandbox-quantum`). Runtime code/behavior unchanged; `0.2.x` skipped to `0.3.0` by request.

- Version mirrored in `artifacts.yaml`; derived modules regenerated; `just artifacts-check` passes.
- No contract revisions changed (verified `agent-protocol` stays `1/1`).
- Fixes the stale `dash/` path in the changelog section header.

Follow-up (separate): move the runtime pins (`.mcp.json` + Console `SWITCH_AGENT_RUNTIME_VERSION`) from `@sandboxaq/…@0.1.6` to `0.3.0` (+ plugin version bumps) — they currently name a version that doesn't exist on npmjs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)