### PR TITLE
release: batch — core 0.13.1 · console 0.21.0 · sidecar 1.9.0 · plugins 0.8.1/0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.13.1] - 2026-08-11
+
+#### Fixed
+- The first message bridged from a channel member is no longer dropped when that
+  member's puppet had joined the room in an earlier run (#199). `wait_joined`
+  only resolved on a join it observed live, so a puppet already in the room from
+  a previous process never satisfied the wait and the send was skipped. It now
+  checks current membership up front and returns immediately when the puppet is
+  already joined.
+
 ### [0.13.0] - 2026-08-10
 
 #### Added
@@ -339,6 +349,25 @@ version of their own to them without also giving them a release of their own.
 ## switch-console
 
 ### [Unreleased]
+
+### [0.21.0] - 2026-08-11
+
+#### Changed
+- The private-repo machinery is gone now that the repository and its packages are
+  public (CHOO-2023). The updater no longer gates on a `gh` token or a private
+  feed, so every user receives updates and the `auth-required` state is removed;
+  managed-server image pulls drop `docker login ghcr.io` and the remote
+  `.ghcr-token` forwarding; remote-host setup drops its interactive `gh:auth`
+  step (a persisted plan still carrying a `gh-auth` step drops it on read); agent
+  onboarding no longer withholds every agent type when `gh` cannot reach a
+  registry; and Switch no longer installs, probes, or forwards credentials to
+  `gh` on a remote host at all.
+- Local-server mode now bundles and pulls **switch-core `0.13.1`** (was
+  `0.13.0`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release.
+- Codex sessions launched by Switch Console now run
+  `@sandboxaq/switch-agent-runtime@0.3.0` (`SWITCH_AGENT_RUNTIME_VERSION`, was
+  `0.1.6`), matching the runtime's move to public npmjs.
 
 ### [0.20.0] - 2026-08-10
 
@@ -1046,9 +1075,18 @@ reconstructed here: an invented history reads exactly like a real one.
 
 ## sidecar
 
-The remote runtime switchdash deploys to an agent host. Versioned in
-`dash/apps/switchdash-desktop/src/sidecar/sidecar-version.ts` and deployed by
-switchdash rather than published on its own.
+The remote runtime Switch Console deploys to an agent host. Versioned in
+`console/apps/switch-console-desktop/src/sidecar/sidecar-version.ts` and deployed
+by Switch Console rather than published on its own.
+
+### [1.9.0]
+
+#### Changed
+- Dropped the npm-registry-auth machinery (`npm-registry-auth.ts`): now that the
+  agent runtime is published to public npmjs (CHOO-2021, CHOO-2023), the sidecar
+  no longer needs a token to `npx` it. Behavior change only — the
+  client↔sidecar wire (ready line, endpoints, on-disk layout) is unchanged, so
+  the major stays at `1`.
 
 ### [1.8.0]
 
@@ -1084,10 +1122,21 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
+### [0.8.1] - 2026-08-11
+
 #### Changed
-- Document `read_context`'s new response shape — `truncated` /
+- Pin `@sandboxaq/switch-agent-runtime@0.3.0` — the runtime moved to public
+  npmjs under the `@sandboxaq` scope (CHOO-2021), so `npx` no longer needs a
+  GitHub token. The scope change had shipped without a plugin version bump and so
+  never reached installs; this release carries it and bumps the plugin version so
+  installs re-download.
+- Skill: document `read_context`'s new response shape — `truncated` /
   `oldest_timestamp` and the per-entry `kind` — and tell the agent not to
   conclude anything from a truncated read (CHOO-2034).
+
+#### Removed
+- Dropped the bundled `configure` skill as part of removing the private-repo /
+  `gh` setup machinery now that the repository is public (CHOO-2023).
 
 ### [0.7.9] - 2026-08-09
 
@@ -1110,7 +1159,16 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.2.3] - 2026-08-11
+
 #### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.0` — the runtime moved to public
+  npmjs under the `@sandboxaq` scope (CHOO-2021); the scope change had shipped
+  without a plugin version bump and never reached installs, so this release
+  carries it and bumps the plugin version to force re-download.
+- Drop `SWITCHDASH_GITHUB_TOKEN` and `npm_config_userconfig` from the forwarded
+  `env_vars` in `.mcp.json` — `npx` no longer needs a GitHub token now that the
+  runtime is on public npmjs (CHOO-2023).
 - Skill updated for `read_context`'s new response shape — `truncated` /
   `oldest_timestamp` and the per-entry `kind` (CHOO-2034).
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.13.0
+    version: 0.13.1
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.20.0
+    version: 0.21.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.13.0
+      switch-core: 0.13.1
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -90,7 +90,7 @@ artifacts:
       The remote runtime Switch Console deploys to an agent host. Deployed rather
       than published, so nothing else declares its version — this file is its
       only source and the constant is generated from it.
-    version: 1.8.0
+    version: 1.9.0
 
   # ── Published under the switch-core release ────────────────────────────────
   # No version of their own: `helm package` and the image build stamp them with
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.8.0
+    version: 0.8.1
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.2.2
+    version: 0.2.3
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/.mcp.json
+++ b/connectors/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.1.6"]
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.0"]
     }
   }
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/codex-plugin/.mcp.json
+++ b/connectors/codex-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.1.6"],
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.0"],
       "env_vars": [
         "SWITCH_API_ENDPOINT",
         "SWITCH_API_TOKEN",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.13.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.13.1';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.13.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.13.1';

--- a/console/apps/switch-console-desktop/src/shared/core/switch-rooms/switch-agent-runtime.ts
+++ b/console/apps/switch-console-desktop/src/shared/core/switch-rooms/switch-agent-runtime.ts
@@ -18,7 +18,7 @@ export const SWITCH_AGENT_RUNTIME_PACKAGE = '@sandboxaq/switch-agent-runtime';
  * `connectors/claude-code-plugin/.mcp.json`; `switch-agent-runtime.test.ts`
  * fails if the two drift. Bump both together when the runtime is republished.
  */
-export const SWITCH_AGENT_RUNTIME_VERSION = '0.1.6';
+export const SWITCH_AGENT_RUNTIME_VERSION = '0.3.0';
 
 /**
  * The credentials switchdash injects into a session it launches. The runtime

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,16 +20,16 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.13.0',
-  'switch-console': '0.20.0',
+  'switch-core': '0.13.1',
+  'switch-console': '0.21.0',
   'agent-runtime': '0.3.0',
-  sidecar: '1.8.0',
-  gateway: '0.13.0',
-  setup: '0.13.0',
-  'helm-chart': '0.13.0',
-  compose: '0.13.0',
-  'switch-connector': '0.8.0',
-  'switch-connector-codex': '0.2.2',
+  sidecar: '1.9.0',
+  gateway: '0.13.1',
+  setup: '0.13.1',
+  'helm-chart': '0.13.1',
+  compose: '0.13.1',
+  'switch-connector': '0.8.1',
+  'switch-connector-codex': '0.2.3',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,16 +20,16 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.13.0',
-  'switch-console': '0.20.0',
+  'switch-core': '0.13.1',
+  'switch-console': '0.21.0',
   'agent-runtime': '0.3.0',
-  sidecar: '1.8.0',
-  gateway: '0.13.0',
-  setup: '0.13.0',
-  'helm-chart': '0.13.0',
-  compose: '0.13.0',
-  'switch-connector': '0.8.0',
-  'switch-connector-codex': '0.2.2',
+  sidecar: '1.9.0',
+  gateway: '0.13.1',
+  setup: '0.13.1',
+  'helm-chart': '0.13.1',
+  compose: '0.13.1',
+  'switch-connector': '0.8.1',
+  'switch-connector-codex': '0.2.3',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.13.0"
+version = "0.13.1"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,16 +20,16 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.13.0",
-    "switch-console": "0.20.0",
+    "switch-core": "0.13.1",
+    "switch-console": "0.21.0",
     "agent-runtime": "0.3.0",
-    "sidecar": "1.8.0",
-    "gateway": "0.13.0",
-    "setup": "0.13.0",
-    "helm-chart": "0.13.0",
-    "compose": "0.13.0",
-    "switch-connector": "0.8.0",
-    "switch-connector-codex": "0.2.2",
+    "sidecar": "1.9.0",
+    "gateway": "0.13.1",
+    "setup": "0.13.1",
+    "helm-chart": "0.13.1",
+    "compose": "0.13.1",
+    "switch-connector": "0.8.1",
+    "switch-connector-codex": "0.2.3",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2433,7 +2433,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Combined batch release. Tags `switch-v0.13.1` + `switch-console-v0.21.0` will be pushed off the merge commit; sidecar + plugins ride in this PR (no tags).

**switch-core `0.13.1`** — fix(bridge): don't drop a bridged message when the puppet joined in an earlier run (#199).

**switch-console `0.21.0`**
- CHOO-2023: remove the private-repo machinery now the repo is public (updater no longer needs `gh`; GHCR pulls + remote-host setup drop auth; Switch no longer installs/probes `gh`).
- Bundle pin → **switch-core `0.13.1`** (`pins.switch-core` + both `COMPATIBLE_SWITCH_VERSION` literals).
- Codex `SWITCH_AGENT_RUNTIME_VERSION` → **`@sandboxaq/switch-agent-runtime@0.3.0`**.

**sidecar `1.9.0`** — dropped npm-registry-auth (runtime now on public npmjs); behaviour change, wire unchanged, major stays `1`.

**connector plugins** — Claude **`0.8.1`** / Codex **`0.2.3`**: runtime pins → `@sandboxaq/switch-agent-runtime@0.3.0` (fresh versions so installs re-download — the `@sandboxaq` scope move had shipped without a bump); CHOO-2034 skill updates cut; Claude `configure` skill removed (CHOO-2023); Codex `.mcp.json` drops `SWITCHDASH_GITHUB_TOKEN`/`npm_config_userconfig`.

Versions mirrored in `artifacts.yaml`; derived modules regenerated; `just artifacts-check` passes. **No contract revisions changed** (verified `speaks`/`accepts` unchanged). agent-runtime unchanged since `0.3.0`; PR #129 excluded (still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)