### PR TITLE
feat(switchdash): build unsigned Windows releases (CHOO-1468)

### DIFF
--- a/.github/workflows/switch-console-release.yml
+++ b/.github/workflows/switch-console-release.yml
@@ -336,9 +336,13 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: switch-console-windows-x64
+          # latest.yml rides along so a dispatch run shows whether the channel
+          # manifest was produced — publish-release refuses to publish a tagged
+          # Release without it, and a dispatch run is where that should surface.
           path: |
             console/apps/switch-console-desktop/release/*.exe
             console/apps/switch-console-desktop/release/*.msi
+            console/apps/switch-console-desktop/release/latest.yml
           if-no-files-found: error
 
   # Flips the draft to a published Release, once — and only once — every platform

--- a/.github/workflows/switch-console-release.yml
+++ b/.github/workflows/switch-console-release.yml
@@ -5,8 +5,9 @@ name: Switch Console release
 # so the release assets are too — no token, no ACL.
 #
 # macOS (arm64) is signed + notarized. Linux (x64) builds AppImage, deb and rpm,
-# unsigned. Windows is not built yet (needs an Authenticode / Azure Trusted
-# Signing identity — tracked as a follow-up).
+# unsigned. Windows (x64) builds nsis and msi, also unsigned — there is no
+# Authenticode identity for this app, so SmartScreen warns on first run
+# (CHOO-1468).
 #
 # Trigger by pushing a tag like `switch-console-v1.1.34` (the version after
 # `switch-console-v` MUST match apps/switch-console-desktop/package.json `version`).
@@ -260,6 +261,86 @@ jobs:
             console/apps/switch-console-desktop/release/*.rpm
           if-no-files-found: error
 
+  build-windows:
+    name: Build & release (Windows x64)
+    runs-on: windows-latest
+    # Waits only for the Release to exist, not for the other platform builds.
+    # Windows is unsigned, so this job takes no secrets — which is also why it is
+    # not gated to `main` the way the macOS job is: it is safe to dispatch from a
+    # branch.
+    needs: create-release
+    if: ${{ !cancelled() && needs.create-release.result != 'failure' }}
+    # windows-latest defaults to pwsh; the scripted steps below are bash.
+    defaults:
+      run:
+        shell: bash
+        working-directory: console
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: 11.5.3
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: console/.nvmrc
+          cache: pnpm
+          cache-dependency-path: console/pnpm-lock.yaml
+
+      - name: Verify tag matches package.json version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          tag_version="${GITHUB_REF_NAME#switch-console-v}"
+          pkg_version="$(node -p "require('./apps/switch-console-desktop/package.json').version")"
+          echo "tag=$tag_version package.json=$pkg_version"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag version ($tag_version) does not match apps/switch-console-desktop/package.json version ($pkg_version). Bump package.json and re-tag."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Rebuild native modules for Electron
+        # better-sqlite3 and node-pty compile from source here, against the MSVC
+        # toolchain preinstalled on the runner.
+        run: pnpm --filter @switch-console/desktop run rebuild
+
+      - name: Build workspace packages + app
+        run: pnpm run build
+
+      - name: Package (windows x64, no publish)
+        working-directory: console/apps/switch-console-desktop
+        run: pnpm exec electron-builder --win --publish never --config electron-builder.config.ts
+
+      - name: Upload to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: console/apps/switch-console-desktop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Attach the Windows installers + the electron-updater channel manifest
+          # (latest.yml) and the blockmaps that differentialPackage emits.
+          shopt -s nullglob
+          assets=(release/*.exe release/*.msi release/*.blockmap release/latest.yml)
+          gh release upload "$GITHUB_REF_NAME" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+      - name: Upload build artifacts (dispatch runs, no Release)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: switch-console-windows-x64
+          path: |
+            console/apps/switch-console-desktop/release/*.exe
+            console/apps/switch-console-desktop/release/*.msi
+          if-no-files-found: error
+
   # Flips the draft to a published Release, once — and only once — every platform
   # job has uploaded. `needs` with no `if: !cancelled()` is the gate: if either
   # build fails, is cancelled or is never approved, this job is skipped and the
@@ -267,7 +348,7 @@ jobs:
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [create-release, build-macos, build-linux]
+    needs: [create-release, build-macos, build-linux, build-windows]
     if: startsWith(github.ref, 'refs/tags/')
     # This job never checks out, so the workflow-level `console` working directory
     # does not exist for it.
@@ -285,7 +366,7 @@ jobs:
           assets="$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
           echo "$assets"
           missing=""
-          for required in latest-mac.yml latest-linux.yml; do
+          for required in latest-mac.yml latest-linux.yml latest.yml; do
             printf '%s\n' "$assets" | grep -qx "$required" || missing="$missing $required"
           done
           if [ -n "$missing" ]; then

--- a/console/apps/switch-console-desktop/electron-builder.canary.config.ts
+++ b/console/apps/switch-console-desktop/electron-builder.canary.config.ts
@@ -87,18 +87,14 @@ const config: Configuration = {
   rpm: {
     packageName: APP_NAME_LOWER,
   },
+  // Unsigned, like the base config — see the `win` comment there before adding
+  // any signing key here.
   win: {
     icon: 'src/assets/images/switch-console/app-icon-canary.png',
     target: [
       { target: 'nsis', arch: ['x64'] },
       { target: 'msi', arch: ['x64'] },
     ],
-    azureSignOptions: {
-      publisherName: 'General Action, Inc.',
-      endpoint: 'https://eus.codesigning.azure.net/',
-      certificateProfileName: 'switch-console-public',
-      codeSigningAccountName: 'switch-console',
-    },
   },
   msi: {
     oneClick: false,

--- a/console/apps/switch-console-desktop/electron-builder.config.ts
+++ b/console/apps/switch-console-desktop/electron-builder.config.ts
@@ -141,18 +141,28 @@ const config: Configuration = {
   rpm: {
     packageName: APP_NAME_LOWER,
   },
+  // Windows ships UNSIGNED: there is no Authenticode identity for this app
+  // (CHOO-1468), so SmartScreen warns on first run.
+  //
+  // There is deliberately no `azureSignOptions` key. electron-builder chooses its
+  // signing backend from that key's presence alone, never checking for
+  // credentials, so setting it commits the build to Azure Trusted Signing: a
+  // PowerShell call that fails on any non-Windows host and, without credentials,
+  // on Windows too. Its absence selects the signtool backend, which finds no
+  // certificate and skips signing rather than failing.
+  //
+  // Its absence also keeps `publisherName` out of app-update.yml, which is what
+  // makes auto-update work here: electron-updater verifies an installer's
+  // Authenticode signature only when app-update.yml names a publisher, so an
+  // unsigned build that named one would reject every update it downloaded.
+  //
+  // Adding signing therefore means adding both an identity and this key together.
   win: {
     icon: 'src/assets/images/switch-console/app-icon-beta.png',
     target: [
       { target: 'nsis', arch: ['x64'] },
       { target: 'msi', arch: ['x64'] },
     ],
-    azureSignOptions: {
-      publisherName: 'General Action, Inc.',
-      endpoint: 'https://eus.codesigning.azure.net/',
-      certificateProfileName: 'switch-console-public',
-      codeSigningAccountName: 'switch-console',
-    },
   },
   msi: {
     oneClick: false,

--- a/console/docs/INSTALL.md
+++ b/console/docs/INSTALL.md
@@ -4,8 +4,9 @@ Switch Console is distributed as a desktop app through **GitHub Releases on this
 repository** (`sandbox-quantum/switch`). The repo is public, so the downloads
 need no account, token or sign-up. No need to build from source.
 
-> Builds are currently **macOS arm64** (Apple Silicon) and **Linux x64**.
-> Windows is not built yet.
+> Builds are currently **macOS arm64** (Apple Silicon), **Linux x64** and
+> **Windows x64**. Windows builds are not code signed — see
+> [Install (Windows x64)](#install-windows-x64).
 
 ## Download
 
@@ -15,8 +16,9 @@ need no account, token or sign-up. No need to build from source.
    page.
 2. Find the latest release titled **`Switch Console <version>`** (tag
    `switch-console-v<version>`).
-3. Under **Assets**, download the file for your platform — `.dmg` on macOS, or
-   one of `.AppImage` / `.deb` / `.rpm` on Linux.
+3. Under **Assets**, download the file for your platform — `.dmg` on macOS, one
+   of `.AppImage` / `.deb` / `.rpm` on Linux, or `.exe` on Windows (a `.msi` is
+   also published if you deploy that way).
 
 ### Option B — command line
 
@@ -28,6 +30,9 @@ curl -fLO https://github.com/sandbox-quantum/switch/releases/download/switch-con
 
 # Linux — pick the format your distro uses:
 curl -fLO https://github.com/sandbox-quantum/switch/releases/download/switch-console-v<version>/switch-console-x86_64.AppImage
+
+# Windows:
+curl -fLO https://github.com/sandbox-quantum/switch/releases/download/switch-console-v<version>/switch-console-x64.exe
 ```
 
 With the [`gh` CLI](https://cli.github.com), if you prefer it:
@@ -73,6 +78,43 @@ Linux builds are **unsigned**. Pick the format your distro uses:
 > The app does not yet set a `desktopName`, so desktop environments may not
 > associate its windows with the installed `.desktop` entry (the icon can appear
 > as a duplicate or generic entry in the taskbar).
+
+## Install (Windows x64)
+
+1. Run the downloaded `switch-console-x64.exe`.
+2. Choose an install location if you want a non-default one, and finish the
+   installer.
+
+### First launch — SmartScreen warning
+
+Windows builds are **not code signed** — there is no Authenticode certificate for
+this app yet (CHOO-1468). Windows therefore shows a full-screen blue **"Windows
+protected your PC"** prompt the first time you run the installer:
+
+1. Click **More info**.
+2. Click **Run anyway**.
+
+This is expected, and it recurs for each new version until the app is signed. Two
+consequences worth knowing:
+
+- Antivirus software occasionally quarantines unsigned Electron installers. If
+  the download vanishes, check your AV quarantine.
+- **Managed / corporate Windows may refuse to install it outright.** AppLocker
+  and WDAC policies commonly block unsigned binaries, and there is no
+  click-through for that — the install simply fails. Signing is the only fix.
+
+The `.msi` supports the usual `msiexec` flow if you would rather not run the
+installer interactively.
+
+### Docker-backed features are not available on Windows
+
+Switch Console can manage a local or remote Switch server through Docker. That
+path is **macOS/Linux only** — Docker CLI discovery does not resolve
+`docker.exe` on Windows. Connecting to a Switch server that is already running
+elsewhere is unaffected.
+
+Windows support is new and less exercised than the other platforms; please report
+anything that misbehaves.
 
 ## Updating
 


### PR DESCRIPTION
Jira: [CHOO-1468](https://sandboxquantum.atlassian.net/browse/CHOO-1468)

First slice of the Windows umbrella: produce a Windows build that people can actually install. Signing is explicitly out of scope — the agreed tradeoff is that users click through a SmartScreen warning.

## Why there was no Windows build

Not a missing runner. The config *demanded* signing and there was nothing to sign with.

`electron-builder.config.ts` set `azureSignOptions` unconditionally — publisher `General Action, Inc.`, account `switchdash`, profile `switchdash-public`, all inherited from the upstream fork and none of them ours. electron-builder picks its signing backend from that key's *presence*, never checking whether credentials exist, so every `--win` build committed to Azure Trusted Signing and died in PowerShell.

macOS already solves the same problem (`hasDeveloperIdCert` gates notarization, ad-hoc signs otherwise). Windows never got an equivalent.

## The non-obvious part

Dropping the signing isn't sufficient on its own. `publisherName` also gets stamped into `app-update.yml`, and `NsisUpdater.verifySignature` checks a downloaded installer's Authenticode signature against it. An unsigned build that still named a publisher would reject **every** update it downloaded.

Removing the key fixes both: `computedPublisherName` resolves to `null`, so the manifest carries no publisher and the updater skips verification.

Verified against `app-builder-lib@26.15.2` rather than assumed — `WindowsSignToolManager.initialize()` is a no-op, `cscInfo` resolves to `null` without a cert, and `signFile` logs `no signing info identified, signing is skipped` and returns.

## Why remove rather than gate on an env var

An `AZURE_CLIENT_ID` gate would have kept a config that cannot work (wrong publisher, wrong account) and made build success depend on ambient environment — that variable appearing on a runner for any unrelated reason would flip the build to the Azure path and hard-fail it. Restoring signing means supplying a real identity, which means editing these lines regardless.

## Changes

- Remove `azureSignOptions` from `electron-builder.config.ts` and `electron-builder.canary.config.ts`, with a comment on why it must not return unaccompanied.
- Add a `build-windows` job on `windows-latest` to `switchdash-release.yml`, mirroring the macOS job. Publishes `.exe`, `.msi`, `.blockmap`, `latest.yml`. `shell: bash` at job level (runner defaults to pwsh).
- `INSTALL.md`: Windows install steps, the SmartScreen click-through, AV quarantine, and that AppLocker/WDAC block unsigned binaries outright with no click-through. Notes Docker-backed features stay macOS/Linux only.
- Release notes cover both platforms.

## Testing

**The Windows job has not run yet.** It can't be exercised locally — no Wine, and the `msi` target needs it off-Windows. Native module rebuild (`better-sqlite3`, `node-pty` compiling against MSVC) is the likeliest failure point. Suggest a `workflow_dispatch` run before tagging.

## Out of scope

Docker CLI resolution on Windows (per product decision — managed local/remote servers aren't needed on Windows yet), orphaned child processes on session teardown, SSH key auth, secrets file permissions. Each is a separate slice under the umbrella.

## Noticed, not fixed

- `INSTALL.md` says macOS builds are unsigned and need a Gatekeeper bypass; the workflow's release notes say signed and notarized. Contradiction predates this branch.
- The workflow header cites `VITE_SWITCHDASH_AUTOUPDATE=off` as disabling auto-update. That variable exists nowhere in the repo; auto-update is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1468]: https://sandboxquantum.atlassian.net/browse/CHOO-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ