### PR TITLE
release: switch-console 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,18 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.22.0] - 2026-08-12
+
+#### Added
+- Linux **arm64** desktop artifacts are now built and published alongside x64 —
+  AppImage, deb, and rpm (#202).
+- **Windows x64** releases are now built and published (unsigned) (CHOO-1468).
+
+#### Changed
+- The Codex session runtime version is now derived from the artifact registry
+  rather than a hand-maintained `SWITCH_AGENT_RUNTIME_VERSION` constant; the
+  constant and its parity test are removed (#198).
+
 ### [0.21.0] - 2026-08-11
 
 #### Changed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.21.0
+    version: 0.22.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.13.1',
-  'switch-console': '0.21.0',
+  'switch-console': '0.22.0',
   'agent-runtime': '0.3.0',
   sidecar: '1.9.0',
   gateway: '0.13.1',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.13.1',
-  'switch-console': '0.21.0',
+  'switch-console': '0.22.0',
   'agent-runtime': '0.3.0',
   sidecar: '1.9.0',
   gateway: '0.13.1',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,7 +21,7 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.13.1",
-    "switch-console": "0.21.0",
+    "switch-console": "0.22.0",
     "agent-runtime": "0.3.0",
     "sidecar": "1.9.0",
     "gateway": "0.13.1",


### PR DESCRIPTION
Cuts `## switch-console [0.22.0]` ahead of tagging `switch-console-v0.22.0`. Three changes since `v0.21.0`:

- **Linux arm64** desktop artifacts, built + published alongside x64 (#202)
- **Windows x64** releases, built + published unsigned (CHOO-1468, #204)
- Codex session runtime version now derives from the artifact registry; dropped the `SWITCH_AGENT_RUNTIME_VERSION` constant + parity test (#198)

Release now produces: macOS arm64 (signed+notarized) · Linux x64 + arm64 (AppImage/deb/rpm) · Windows x64 (unsigned).

Version mirrored in `artifacts.yaml`; derived modules regenerated; `just artifacts-check` passes. No contract revisions changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)