### PR TITLE
fix(console): stop a retired Settings tab making Settings unreachable (CHOO-2106)

### DIFF
--- a/console/apps/switch-console-desktop/src/renderer/app/view-registry.ts
+++ b/console/apps/switch-console-desktop/src/renderer/app/view-registry.ts
@@ -57,7 +57,23 @@ export type WrapParams<TId extends ViewId> = Views[TId] extends {
 
 export type GuardResult =
   | { ok: true }
-  | { ok: false; redirect: ViewId; params?: Record<string, unknown> };
+  | {
+      ok: false;
+      redirect: ViewId;
+      params?: Record<string, unknown>;
+      /**
+       * Set when the params themselves are stale — naming something a newer
+       * build retired — rather than the destination merely being unavailable
+       * right now. Stored params are then dropped, so the fallback in
+       * `navigate()` cannot feed them back to the guard on the next attempt and
+       * leave the view permanently unreachable.
+       *
+       * Guards that reject on runtime state must leave this unset: their params
+       * are still good, and a rejection while that state loads would discard
+       * them.
+       */
+      discardParams?: boolean;
+    };
 
 export function setupNavigationGuards(): void {
   for (const [viewId, view] of Object.entries(views) as Array<

--- a/console/apps/switch-console-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -85,6 +85,27 @@ function InterfaceSettingsPage() {
 // SettingsPage
 // ---------------------------------------------------------------------------
 
+/**
+ * The tabs that have a pane to show. `docs` is an external link, and several
+ * `SettingsPageTab` values are hidden in v0, so this is a subset.
+ */
+const TAB_CONTENT: Partial<Record<SettingsPageTab, () => React.ReactNode>> = {
+  general: () => <GeneralSettingsPage />,
+  'clis-models': () => <AgentsSettingsPage />,
+  interface: () => <InterfaceSettingsPage />,
+};
+
+/**
+ * A persisted snapshot can name a tab this build no longer renders — one hidden
+ * in v0, or retired outright. Showing Settings with an empty pane and no tab
+ * selected reads as broken, so fall back to General.
+ */
+export function resolveSettingsTab(tab: unknown): SettingsPageTab {
+  return typeof tab === 'string' && Object.hasOwn(TAB_CONTENT, tab)
+    ? (tab as SettingsPageTab)
+    : 'general';
+}
+
 export function SettingsPage({
   tab: activeTab,
   onTabChange,
@@ -111,13 +132,7 @@ export function SettingsPage({
     { id: 'docs', label: 'Docs', isExternal: true },
   ];
 
-  const tabContent: Record<string, React.ReactNode> = {
-    general: <GeneralSettingsPage />,
-    'clis-models': <AgentsSettingsPage />,
-    interface: <InterfaceSettingsPage />,
-  };
-
-  const currentContent = tabContent[activeTab];
+  const currentContent = TAB_CONTENT[activeTab]?.();
 
   return (
     <PageLayout

--- a/console/apps/switch-console-desktop/src/renderer/features/settings/settings-view.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/settings/settings-view.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, type ReactNode } from 'react';
 import type { GuardResult } from '@renderer/app/view-registry';
 import {
+  resolveSettingsTab,
   SettingsPage,
   type SettingsPageTab,
 } from '@renderer/features/settings/components/SettingsPage';
@@ -15,7 +16,7 @@ const SettingsTabContext = createContext<{
 /** Minimal passthrough — exists so the registry can infer WrapParams<'settings'>. */
 export function SettingsViewWrapper({
   children,
-  tab = 'general',
+  tab,
 }: {
   children: ReactNode;
   tab?: SettingsPageTab;
@@ -28,7 +29,9 @@ export function SettingsViewWrapper({
     [setParams]
   );
   return (
-    <SettingsTabContext.Provider value={{ tab, onTabChange: handleTabChange }}>
+    <SettingsTabContext.Provider
+      value={{ tab: resolveSettingsTab(tab), onTabChange: handleTabChange }}
+    >
       {children}
     </SettingsTabContext.Provider>
   );
@@ -67,13 +70,17 @@ export const settingsView = {
   MainPanel: SettingsMainPanel,
   /**
    * Remote hosts moved out of Settings to their own view (CHOO-1809). A
-   * persisted snapshot from an older build can still name that tab, which would
-   * otherwise render Settings with nothing selected — send it to the new view.
+   * persisted snapshot from an older build can still name that tab, so send it
+   * to the new view once. `discardParams` is what keeps that to once: without
+   * it the stale tab stays in the store, `navigate('settings')` falls back to
+   * it, and every later attempt to open Settings redirects here too.
    */
   canActivate: (params: unknown): GuardResult => {
     const tab =
       typeof params === 'object' && params !== null ? (params as { tab?: unknown }).tab : undefined;
-    if (tab === 'remote-hosts') return { ok: false, redirect: 'remoteHosts' };
+    if (tab === 'remote-hosts') {
+      return { ok: false, redirect: 'remoteHosts', discardParams: true };
+    }
     return { ok: true };
   },
 };

--- a/console/apps/switch-console-desktop/src/renderer/lib/stores/navigation-store.ts
+++ b/console/apps/switch-console-desktop/src/renderer/lib/stores/navigation-store.ts
@@ -37,9 +37,19 @@ export class NavigationStore implements Snapshottable<NavigationSnapshot> {
     return this._guards.get(viewId)?.(params) ?? { ok: true };
   }
 
+  private _clearViewParams(viewId: ViewId): void {
+    if (this.viewParamsStore[viewId] === undefined) return;
+    const next = { ...this.viewParamsStore };
+    delete next[viewId];
+    this.viewParamsStore = next;
+  }
+
   revalidate(): void {
     const result = this._runGuard(this.currentViewId, this.viewParamsStore[this.currentViewId]);
-    if (!result.ok) this._applyNavigation(result.redirect, result.params as WrapParams<ViewId>);
+    if (!result.ok) {
+      if (result.discardParams) this._clearViewParams(this.currentViewId);
+      this._applyNavigation(result.redirect, result.params as WrapParams<ViewId>);
+    }
   }
 
   navigate<T extends ViewId>(viewId: T, params?: WrapParams<T>): void {
@@ -52,6 +62,7 @@ export class NavigationStore implements Snapshottable<NavigationSnapshot> {
     const resolvedParams = params ?? this.viewParamsStore[viewId];
     const guard = this._runGuard(viewId, resolvedParams);
     if (!guard.ok) {
+      if (guard.discardParams && params === undefined) this._clearViewParams(viewId);
       this._applyNavigation(guard.redirect, guard.params as WrapParams<typeof guard.redirect>);
       return;
     }
@@ -105,6 +116,7 @@ export class NavigationStore implements Snapshottable<NavigationSnapshot> {
     // Validate after params are loaded so the guard has full context.
     const guard = this._runGuard(this.currentViewId, this.viewParamsStore[this.currentViewId]);
     if (!guard.ok) {
+      if (guard.discardParams) this._clearViewParams(this.currentViewId);
       this.currentViewId = guard.redirect;
       if (guard.redirect !== 'settings') {
         this.lastNonSettingsView = guard.redirect as NonSettingsViewId;

--- a/console/apps/switch-console-desktop/src/renderer/tests/navigation-store.test.ts
+++ b/console/apps/switch-console-desktop/src/renderer/tests/navigation-store.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GuardResult, ViewId } from '@renderer/app/view-registry';
+
+vi.mock('@renderer/lib/stores/app-state', () => ({
+  appState: { history: { push: vi.fn() } },
+}));
+
+vi.mock('@renderer/lib/modal/modal-store', () => ({
+  modalStore: { closeModal: vi.fn() },
+}));
+
+const { NavigationStore } = await import('@renderer/lib/stores/navigation-store');
+
+/** The retired Settings tab that CHOO-1809 moved out to its own view. */
+const staleTab = { tab: 'remote-hosts' };
+
+/** Mirrors `settingsView.canActivate`: the params name something retired. */
+function staleParamGuard(params: unknown): GuardResult {
+  const tab =
+    typeof params === 'object' && params !== null ? (params as { tab?: unknown }).tab : undefined;
+  return tab === 'remote-hosts'
+    ? { ok: false, redirect: 'remoteHosts', discardParams: true }
+    : { ok: true };
+}
+
+function makeStore(guards: Partial<Record<ViewId, (params: unknown) => GuardResult>>) {
+  const store = new NavigationStore();
+  for (const viewId of ['home', 'settings', 'remoteHosts', 'session'] as ViewId[]) {
+    store.registerView(viewId);
+  }
+  for (const [viewId, guard] of Object.entries(guards)) {
+    store.registerGuard(viewId as ViewId, guard);
+  }
+  return store;
+}
+
+describe('NavigationStore stale-param guards', () => {
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    store = makeStore({ settings: staleParamGuard });
+  });
+
+  it('redirects away from params naming a retired value', () => {
+    store.restoreSnapshot({ currentViewId: 'settings', viewParams: { settings: staleTab } });
+
+    expect(store.currentViewId).toBe('remoteHosts');
+  });
+
+  it('does not strand the view: a second attempt reaches it', () => {
+    store.restoreSnapshot({ currentViewId: 'settings', viewParams: { settings: staleTab } });
+
+    // The redirect is a one-time migration, so the stale tab must not survive to
+    // be handed back to the guard by navigate()'s fallback to stored params.
+    store.navigate('settings');
+
+    expect(store.currentViewId).toBe('settings');
+  });
+
+  it('reaches the view when navigating from elsewhere with no params', () => {
+    // The trap this covers: currentViewId is something else entirely, so restore
+    // never runs the guard, and the stale tab sits in the store until the first
+    // click on Settings — which then bounces, and every click after it.
+    store.restoreSnapshot({ currentViewId: 'home', viewParams: { settings: staleTab } });
+
+    store.navigate('settings');
+    expect(store.currentViewId).toBe('remoteHosts');
+
+    store.navigate('settings');
+    expect(store.currentViewId).toBe('settings');
+  });
+
+  it('drops only the offending view params', () => {
+    store.restoreSnapshot({
+      currentViewId: 'home',
+      viewParams: { settings: staleTab, session: { sessionId: 's1' } },
+    });
+
+    store.navigate('settings');
+
+    expect(store.snapshot.viewParams.settings).toBeUndefined();
+    expect(store.snapshot.viewParams.session).toEqual({ sessionId: 's1' });
+  });
+
+  it('keeps params for a guard that rejects on runtime state', () => {
+    // sessionView and locationView reject while their location is still loading.
+    // Those params are good; discarding them would lose the restored session.
+    let loaded = false;
+    const runtimeGuard = (): GuardResult =>
+      loaded ? { ok: true } : { ok: false, redirect: 'home' };
+    store = makeStore({ session: runtimeGuard });
+    store.restoreSnapshot({
+      currentViewId: 'session',
+      viewParams: { session: { sessionId: 's1' } },
+    });
+    expect(store.currentViewId).toBe('home');
+
+    loaded = true;
+    store.navigate('session');
+
+    expect(store.currentViewId).toBe('session');
+    expect(store.snapshot.viewParams.session).toEqual({ sessionId: 's1' });
+  });
+});


### PR DESCRIPTION
## The bug

Settings became permanently unreachable: clicking it navigated to **Remote hosts** every time. Reproduced from a real install, whose persisted snapshot held

```json
"viewParams": { "settings": { "tab": "remote-hosts" } }
```

`remote-hosts` is the Settings tab CHOO-1809 moved out to its own view. `settingsView.canActivate` rejects it and redirects, which is meant as a **one-time** migration — but `navigate('settings')` falls back to the *stored* params when called with none, and nothing ever cleared them, so the guard kept re-reading the same stale value. The sidebar button, `Cmd+,`, the menu item and the command palette all route through it, so every path bounced.

Anyone whose snapshot predates CHOO-1809 and last had that tab selected is stuck the same way.

## The fix

The trap generalises to any param-validating guard, so it's fixed at the store — but carefully, because **guards reject for two different reasons and only one is about the params**:

- `settingsView` rejects because the params are *stale*.
- `locationView` and `sessionView` reject on *runtime state*, while their location is still loading. Their params are fine.

Clearing params on every rejection would discard a good restored session during boot. So `GuardResult` now names the distinction: `discardParams: true` marks a stale-value rejection, and only those params get dropped. Runtime guards leave it unset and are unaffected.

Also fixes a sibling bug found on the way: `integrations`, `connections`, `browser` and `docs` are valid `SettingsPageTab` values with no content pane, so a snapshot naming one rendered Settings **completely blank** with no tab selected. `resolveSettingsTab()` now derives the valid set from the content map itself — so the two can't drift — and falls back to General.

## Verification

New `navigation-store.test.ts` (there were no navigation-store tests). Confirmed non-vacuous: with the store fix stashed, 3 of the 5 fail with exactly the reported symptom (`expected 'remoteHosts' to be 'settings'`), and the runtime-guard regression test passes both with and without it.

Full gate green: `typecheck`, `lint`, `format:check`, and **2205 tests across 228 files**.

## Note for anyone already stuck

This fixes new snapshots; an already-trapped install still needs its stale value cleared. Quit the app first — the running app re-saves it — then:

```bash
sqlite3 "$HOME/Library/Application Support/switchdash/switchdash.db" <<'SQL'
UPDATE kv SET value = json_remove(value, '$.viewParams.settings')
WHERE key = 'view-state:navigation';
SQL
```

Tested against a backup: the stale param goes and session, location, room and server params all survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)