### PR TITLE
feat(connectors): make agents write like room participants

### DIFF
--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/skills/switch/SKILL.md
+++ b/connectors/claude-code-plugin/skills/switch/SKILL.md
@@ -15,6 +15,41 @@ travel that same connection — you never talk to the Switch server directly.
 now; it stays true until the session ends. The later sections are reference —
 consult them when the work calls for them, and otherwise get on with it.
 
+## How to write in a room
+
+A room is a chat channel, not a report. People read it in Slack, Mattermost or
+the console, often on a phone, in between everything else. Write for that, not
+for a terminal transcript. **Default to a few sentences.**
+
+- **Answer first.** Then only the detail that changes what someone does next.
+  No preamble, no restating the question, no recap of the steps you took, no
+  closing offer of further help.
+- **Plain words.** Say what happened in the room's terms. Leave out the
+  vocabulary of your own run — file paths, tool names, step-by-step narration —
+  unless someone needs it to act.
+- **One message, one point.** Do not spread a single thought across a burst of
+  posts, and do not bundle five topics into one wall of text.
+- **Shorter, not thinner.** Say everything that has to be said — the caveat,
+  the number, the thing that will bite them — and nothing else. Cutting content
+  to be brief is worse than being long.
+
+## Say something before you go quiet
+
+Silence in a chat room reads as absence. If answering will take more than a
+moment — you are about to read a codebase, run a build, wait on another agent,
+or work through several steps — post a one-line heads-up first, do the work,
+then post the result.
+
+- "On it — checking the deploy logs." That is the whole acknowledgement; do not
+  pad it with a plan.
+- Acknowledge once. A long job earns an interim update when the picture changes
+  or your estimate slips, not a commentary on every step.
+- For tracked work the task protocol already does this: `accept_task` tells the
+  room you have it, `update_task` records progress, `finalise_task` reports the
+  outcome — no parallel narration in messages.
+- The heads-up is not the answer. Always come back with the result, in the same
+  thread.
+
 ## Entering a room
 
 1. **`list_rooms`** — the rooms you are assigned to. Skip it if you were given

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/codex-plugin/skills/switch/SKILL.md
+++ b/connectors/codex-plugin/skills/switch/SKILL.md
@@ -18,6 +18,41 @@ guessing.
 now; it stays true until the session ends. The later sections are reference —
 consult them when the work calls for them, and otherwise get on with it.
 
+## How to write in a room
+
+A room is a chat channel, not a report. People read it in Slack, Mattermost or
+the console, often on a phone, in between everything else. Write for that, not
+for a terminal transcript. **Default to a few sentences.**
+
+- **Answer first.** Then only the detail that changes what someone does next.
+  No preamble, no restating the question, no recap of the steps you took, no
+  closing offer of further help.
+- **Plain words.** Say what happened in the room's terms. Leave out the
+  vocabulary of your own run — file paths, tool names, step-by-step narration —
+  unless someone needs it to act.
+- **One message, one point.** Do not spread a single thought across a burst of
+  posts, and do not bundle five topics into one wall of text.
+- **Shorter, not thinner.** Say everything that has to be said — the caveat,
+  the number, the thing that will bite them — and nothing else. Cutting content
+  to be brief is worse than being long.
+
+## Say something before you go quiet
+
+Silence in a chat room reads as absence. If answering will take more than a
+moment — you are about to read a codebase, run a build, wait on another agent,
+or work through several steps — post a one-line heads-up first, do the work,
+then post the result.
+
+- "On it — checking the deploy logs." That is the whole acknowledgement; do not
+  pad it with a plan.
+- Acknowledge once. A long job earns an interim update when the picture changes
+  or your estimate slips, not a commentary on every step.
+- For tracked work the task protocol already does this: `accept_task` tells the
+  room you have it, `update_task` records progress, `finalise_task` reports the
+  outcome — no parallel narration in messages.
+- The heads-up is not the answer. Always come back with the result, in the same
+  thread.
+
 ## Entering a room
 
 1. **`list_rooms`** — the rooms you are assigned to. Skip it if you were given


### PR DESCRIPTION
Agents connected to Switch default to terminal-length prose. A Switch room is
not a terminal — it is a chat channel, read on Slack or Mattermost or a phone,
in between everything else. Two new sections at the top of both room-workflow
skills, before any room action is taken:

**How to write in a room** — default to a few sentences. Answer first, no
preamble or recap or closing offer of help; plain words instead of the
vocabulary of the agent's own run; one message, one point. The last bullet is
the guard rail: *shorter, not thinner* — say the caveat and the number and the
thing that will bite them, and nothing else. Cutting content to be brief is
worse than being long.

**Say something before you go quiet** — silence in a chat room reads as
absence. Before anything slow (reading a codebase, a build, waiting on another
agent), post a one-line heads-up, then the result. Acknowledge once, not per
step; the task protocol already covers tracked work, so no parallel narration;
and the heads-up never substitutes for the answer.

Both skills carry the identical text — the only differences between the two
files remain the pre-existing host-specific ones. Both connector plugins are
bumped (`switch-connector` 0.8.1 → 0.9.0, `switch-connector-codex` 0.2.3 →
0.3.0), since an install picks up a skill change only on a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)