### PR TITLE
release: batch — core 0.13.2 · console 0.22.1 · runtime 0.3.1 · sidecar 1.9.1 · plugins 0.9.1/0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.13.2] - 2026-08-12
+
 #### Fixed
 - `read_context`'s own documentation no longer tells agents to page by passing
   `oldest_timestamp` back as `before`. The first is epoch milliseconds and the
@@ -354,7 +356,22 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.22.1] - 2026-08-12
+
+#### Changed
+- Local-server mode now bundles and pulls **switch-core `0.13.2`** (was
+  `0.13.1`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release.
+
 #### Fixed
+- Windows builds now actually work — path handling, process spawning, the PTY,
+  executable resolution, and Docker / managed-server invocation are corrected for
+  Windows, so the x64 build introduced in `0.22.0` is functional rather than
+  nominal (#207).
+- Settings is reachable again. A retired Settings tab left in the view registry
+  could be selected and then render nothing, stranding the whole Settings page;
+  the retired tab is now handled and navigation falls back to a valid tab
+  (CHOO-2106).
 - The unread tally injected into a session no longer claims to count "since
   your last read_context". Nothing here can observe a session reading, so the
   tally is cleared per delivered line; it now says so, rather than inviting an
@@ -1033,6 +1050,8 @@ The Switch protocol client and MCP runtime
 
 ### [Unreleased]
 
+### [0.3.1] - 2026-08-12
+
 #### Changed
 - The MCP server instructions no longer tell the agent to `read_context` on
   every message event, or to connect before every call. Reading is now
@@ -1109,6 +1128,14 @@ The remote runtime Switch Console deploys to an agent host. Versioned in
 `console/apps/switch-console-desktop/src/sidecar/sidecar-version.ts` and deployed
 by Switch Console rather than published on its own.
 
+### [1.9.1]
+
+#### Changed
+- Windows-compatible path and process handling in the session spawner, matching
+  the desktop app's Windows fixes (#207). Behavior change only — the
+  client↔sidecar wire (ready line, endpoints, on-disk layout) is unchanged, so
+  the major stays at `1`.
+
 ### [1.9.0]
 
 #### Changed
@@ -1152,13 +1179,15 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
-#### Fixed
-- The channel's unread tally now resets when the agent reads the room. The
-  `PostToolUse` matcher never included `read_context`, so the reset the hook
-  already implemented was unreachable and the count only ever climbed from the
-  moment a session connected.
+### [0.9.1] - 2026-08-12
 
 #### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.1` (was `0.3.0`) — picks up the
+  runtime's conditional-read MCP instructions; the plugin version bumps so
+  installs re-download.
+- Skill: how to write in a room — answer first, plain words, a few sentences, one
+  point per message — and post a one-line heads-up before going quiet for a long
+  task, then return with the result in the same thread (#210).
 - Skill: document the room-document and room-admin tools it had never
   mentioned — `load_internal_documents` (without which an agent cannot read a
   document attached to its own room), `list_references`, the
@@ -1175,6 +1204,12 @@ compatibility signal. History for those is in the git log.
   `oldest_timestamp` straight back as `before`, but the first is epoch
   milliseconds and the second is parsed as an ISO-8601 string, so the call
   raised instead of paging.
+
+#### Fixed
+- The channel's unread tally now resets when the agent reads the room. The
+  `PostToolUse` matcher never included `read_context`, so the reset the hook
+  already implemented was unreachable and the count only ever climbed from the
+  moment a session connected.
 
 ### [0.8.1] - 2026-08-11
 
@@ -1213,7 +1248,15 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.3.1] - 2026-08-12
+
 #### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.1` (was `0.3.0`) — picks up the
+  runtime's conditional-read MCP instructions; the plugin version bumps so
+  installs re-download.
+- Skill: how to write in a room — answer first, plain words, a few sentences, one
+  point per message — and post a one-line heads-up before going quiet for a long
+  task, then return with the result in the same thread (#210).
 - Skill: document the room-document and room-admin tools it had never
   mentioned — `load_internal_documents` (without which an agent cannot read a
   document attached to its own room), `list_references`, the

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.13.1
+    version: 0.13.2
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.22.0
+    version: 0.22.1
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,11 +78,11 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.13.1
+      switch-core: 0.13.2
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
-    version: 0.3.0
+    version: 0.3.1
     declared_in: console/packages/switch-agent-runtime/package.json
 
   sidecar:
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.8.1
+    version: 0.9.1
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.2.3
+    version: 0.3.1
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/.mcp.json
+++ b/connectors/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.0"]
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.1"]
     }
   }
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/codex-plugin/.mcp.json
+++ b/connectors/codex-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.0"],
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.1"],
       "env_vars": [
         "SWITCH_API_ENDPOINT",
         "SWITCH_API_TOKEN",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.13.1';
+export const COMPATIBLE_SWITCH_VERSION = '0.13.2';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.13.1';
+export const COMPATIBLE_SWITCH_VERSION = '0.13.2';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,16 +20,16 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.13.1',
-  'switch-console': '0.22.0',
-  'agent-runtime': '0.3.0',
+  'switch-core': '0.13.2',
+  'switch-console': '0.22.1',
+  'agent-runtime': '0.3.1',
   sidecar: '1.9.1',
-  gateway: '0.13.1',
-  setup: '0.13.1',
-  'helm-chart': '0.13.1',
-  compose: '0.13.1',
-  'switch-connector': '0.8.1',
-  'switch-connector-codex': '0.2.3',
+  gateway: '0.13.2',
+  setup: '0.13.2',
+  'helm-chart': '0.13.2',
+  compose: '0.13.2',
+  'switch-connector': '0.9.1',
+  'switch-connector-codex': '0.3.1',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/package.json
+++ b/console/packages/switch-agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sandboxaq/switch-agent-runtime",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Switch agent protocol client, and the local MCP runtime built on it",
   "license": "Apache-2.0",
   "author": {

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,16 +20,16 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.13.1',
-  'switch-console': '0.22.0',
-  'agent-runtime': '0.3.0',
+  'switch-core': '0.13.2',
+  'switch-console': '0.22.1',
+  'agent-runtime': '0.3.1',
   sidecar: '1.9.1',
-  gateway: '0.13.1',
-  setup: '0.13.1',
-  'helm-chart': '0.13.1',
-  compose: '0.13.1',
-  'switch-connector': '0.8.1',
-  'switch-connector-codex': '0.2.3',
+  gateway: '0.13.2',
+  setup: '0.13.2',
+  'helm-chart': '0.13.2',
+  compose: '0.13.2',
+  'switch-connector': '0.9.1',
+  'switch-connector-codex': '0.3.1',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.13.1"
+version = "0.13.2"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,16 +20,16 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.13.1",
-    "switch-console": "0.22.0",
-    "agent-runtime": "0.3.0",
+    "switch-core": "0.13.2",
+    "switch-console": "0.22.1",
+    "agent-runtime": "0.3.1",
     "sidecar": "1.9.1",
-    "gateway": "0.13.1",
-    "setup": "0.13.1",
-    "helm-chart": "0.13.1",
-    "compose": "0.13.1",
-    "switch-connector": "0.8.1",
-    "switch-connector-codex": "0.2.3",
+    "gateway": "0.13.2",
+    "setup": "0.13.2",
+    "helm-chart": "0.13.2",
+    "compose": "0.13.2",
+    "switch-connector": "0.9.1",
+    "switch-connector-codex": "0.3.1",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2433,7 +2433,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Combined batch. Tags off the merge commit: `switch-agent-runtime-v0.3.1` (publish first, gated), `switch-v0.13.2` (ungated), `switch-console-v0.22.1` (gated macOS). Sidecar + plugins ride in this PR.

- **switch-core `0.13.2`** — `read_context` tool-doc paging fix (#186).
- **switch-console `0.22.1`** — Windows paths now work (#207), Settings reachable again (CHOO-2106, #209), unread-tally wording (#186); **bundle pin → core `0.13.2`**; bundles sidecar `1.9.1`.
- **sidecar `1.9.1`** — Windows-compatible session spawner (#207). (Version was bumped in #207 with no changelog entry — added here.)
- **agent-runtime `0.3.1`** — MCP-server instructions read conditionally, not per-event (#186).
- **plugins Claude `0.9.1` / Codex `0.3.1`** — runtime pin → `@sandboxaq/switch-agent-runtime@0.3.1`; state-aware skills (#186) + write-like-a-participant guidance (#210).

**Also fixes a drift on main:** `artifacts.yaml` had the plugins at `0.8.1`/`0.2.3` while the manifests were `0.9.0`/`0.3.0` (#186/#210 bumped the manifests without the registry), so `artifacts-check` was red on main. This brings them back into agreement at `0.9.1`/`0.3.1`.

Derived modules regenerated; `just artifacts-check` passes. **No contract revisions changed** (verified). PR #129 still excluded (open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)