### PR TITLE
fix(bridges): stop the Mattermost status line leaving deletion markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+#### Fixed
+- The Mattermost bridge no longer litters a channel with "(message deleted)"
+  placeholders while an agent works. Mattermost's web client shows that
+  placeholder for any message removed while it is on screen — a permanent
+  delete looks no different to it, and no server setting turns it off — so the
+  agent's status line is now retired by editing it into a "✓ Done · 2m14s"
+  marker rather than being deleted, and it no longer moves down the channel to
+  follow the conversation (each move was a delete of its own).
+
 ### [0.13.2] - 2026-08-12
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ version of their own to them without also giving them a release of their own.
   delete looks no different to it, and no server setting turns it off — so the
   agent's status line is now retired by editing it into a "✓ Done · 2m14s"
   marker rather than being deleted, and it no longer moves down the channel to
-  follow the conversation (each move was a delete of its own).
+  follow the conversation (each move was a delete of its own). The marker
+  carries nothing else: it stays in the channel permanently, so it is kept to
+  the fact that the turn finished and how long it took.
 
 ### [0.13.2] - 2026-08-12
 

--- a/console/apps/switch-console-desktop/src/main/core/managed-switch-server/resources/standalone-docker-compose.pinned.yml
+++ b/console/apps/switch-console-desktop/src/main/core/managed-switch-server/resources/standalone-docker-compose.pinned.yml
@@ -138,10 +138,6 @@ services:
       MM_DISPLAYSETTINGS_CUSTOMURLSCHEMES: switchdash
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
       MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
-      # Lets the bridge hard-delete (permanent=true) an agent's transient
-      # "working on it…" status post instead of soft-deleting it, which would
-      # leave a "(message deleted)" tombstone. Requires Mattermost >= v10.2.
-      MM_SERVICESETTINGS_ENABLEAPIPOSTDELETION: "true"
       MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
       # Neither plugin is usable in a bundled Switch deployment: Copilot has no
       # configured provider and throws a 404 looking up its bot on every page

--- a/core/switch_core/bridges/collaboration/adapter.py
+++ b/core/switch_core/bridges/collaboration/adapter.py
@@ -27,11 +27,17 @@ class LiveRuntimeIndicator:
     reposted verbatim, in the same thread, when it is moved to follow newer
     traffic — a move has no access to the ``detail``/``deeplink_url`` the body
     was originally rendered from.
+
+    ``started_at`` is a ``time.monotonic()`` reading from when the turn's
+    indicator first went up, for adapters that report how long the turn took
+    once it ends. Monotonic because it measures an elapsed span, which a clock
+    adjustment must not distort.
     """
 
     message_ref: str
     body: str
     thread_root_id: str | None
+    started_at: float
 
 
 class CollaborationAdapter(ABC):

--- a/core/switch_core/bridges/collaboration/discord/adapter.py
+++ b/core/switch_core/bridges/collaboration/discord/adapter.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import logging
 import re
+import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import replace
@@ -594,7 +595,10 @@ class DiscordAdapter(CollaborationAdapter):
             ref = await self.send_message(channel_id, agent_name, body, thread_root_id)
             if ref is not None:
                 self._working_msg[key] = LiveRuntimeIndicator(
-                    message_ref=ref, body=body, thread_root_id=thread_root_id
+                    message_ref=ref,
+                    body=body,
+                    thread_root_id=thread_root_id,
+                    started_at=time.monotonic(),
                 )
         elif state == "awaiting-input":
             ref = await self._ping_operator(

--- a/core/switch_core/bridges/collaboration/mattermost/adapter.py
+++ b/core/switch_core/bridges/collaboration/mattermost/adapter.py
@@ -489,7 +489,7 @@ class MattermostAdapter(CollaborationAdapter):
             if ref is not None:
                 self._input_pings.setdefault(key, []).append(ref)
         else:
-            await self._dispose_working(channel_id, agent_name, deeplink_url)
+            await self._dispose_working(channel_id, agent_name)
             await self._clear_input_pings(channel_id, agent_name)
 
     async def _clear_input_pings(self, channel_id: str, agent_name: str) -> None:
@@ -516,16 +516,15 @@ class MattermostAdapter(CollaborationAdapter):
         """
         return
 
-    async def _dispose_working(
-        self, channel_id: str, agent_name: str, deeplink_url: str | None
-    ) -> None:
+    async def _dispose_working(self, channel_id: str, agent_name: str) -> None:
         """Retire the live "working on it…" message when the turn ends.
 
         Edited into a terminal marker rather than removed — see
-        ``_apply_runtime_state`` for why nothing here is ever deleted. The
-        marker carries how long the turn took, and keeps the link into Switch
-        Console when the ending event supplies one, so the line left behind
-        says something worth reading."""
+        ``_apply_runtime_state`` for why nothing here is ever deleted. Kept to
+        the bare fact that the turn finished and how long it took: this line
+        stays in the channel for good, so it earns its place by being small.
+        The session link belongs on the live indicator, where it is still
+        actionable, not on the record of a turn that is over."""
         live = self._working_msg.pop((channel_id, agent_name), None)
         if live is None:
             return
@@ -533,9 +532,7 @@ class MattermostAdapter(CollaborationAdapter):
         await self._patch_post_as(
             agent_name,
             live.message_ref,
-            self.translate_outbound(
-                f"✓ Done · {elapsed}" + self._deeplink_suffix(deeplink_url)
-            ),
+            self.translate_outbound(f"✓ Done · {elapsed}"),
         )
 
     async def _patch_post_as(self, agent_name: str, post_id: str, content: str) -> None:

--- a/core/switch_core/bridges/collaboration/mattermost/adapter.py
+++ b/core/switch_core/bridges/collaboration/mattermost/adapter.py
@@ -80,14 +80,6 @@ class MattermostAdapter(CollaborationAdapter):
         self._seen_post_ids_max = 1000
         self._seen_lock = threading.Lock()
 
-        # Mattermost's ordinary delete leaves a "(message deleted)" tombstone,
-        # so the runtime indicator (base class `_working_msg`) is never soft
-        # deleted — it is hard deleted where the server permits it, and
-        # otherwise edited in place to a terminal marker when the turn ends.
-        # Channels where the hard delete has been found unavailable, so the
-        # operator is warned once rather than on every message.
-        self._no_hard_delete_warned: set[str] = set()
-
         self._main_loop: asyncio.AbstractEventLoop | None = None
 
         # channel id -> channel name (URL slug), for building channel deeplinks.
@@ -451,18 +443,24 @@ class MattermostAdapter(CollaborationAdapter):
         deeplink_url: str | None = None,
         detail: str | None = None,
     ) -> None:
-        """Surface runtime state as a posted message that is never *soft*
-        deleted — Mattermost's soft delete leaves a "(message deleted)"
-        tombstone.
+        """Surface runtime state as a posted message that is **never deleted**.
+
+        Mattermost's web client replaces any message deleted while it is on
+        screen with a "(message deleted)" placeholder, and only drops that on
+        reload. It does so however the message was removed — a permanent delete
+        looks the same to it as a soft one — so a status line that appears and
+        vanishes each turn leaves a trail of placeholders behind it. There is no
+        server setting that turns this off. The only way not to provoke it is
+        not to delete: every status message here is retired by editing it in
+        place.
 
         - ``working`` → post "working on it…" as the agent (in-thread when the
           trigger was threaded); it stays up across intermediate replies and
           through ``awaiting-input``.
-        - ``idle`` (where ``completed`` collapses) → hard-delete the working
-          message and any pings so they vanish cleanly, falling back to an
-          in-place edit when permanent deletion is unavailable.
+        - ``idle`` (where ``completed`` collapses) → edit the working message
+          into a "done" marker, and resolve any pings the same way.
         - ``awaiting-input`` → leave the working message up; post a separate
-          operator ping (tracked for removal when the turn ends).
+          operator ping (tracked for resolution when the turn ends).
         """
         key = (channel_id, agent_name)
         if state == "working":
@@ -479,7 +477,10 @@ class MattermostAdapter(CollaborationAdapter):
             ref = await self.send_message(channel_id, agent_name, body, thread_root_id)
             if ref is not None:
                 self._working_msg[key] = LiveRuntimeIndicator(
-                    message_ref=ref, body=body, thread_root_id=thread_root_id
+                    message_ref=ref,
+                    body=body,
+                    thread_root_id=thread_root_id,
+                    started_at=time.monotonic(),
                 )
         elif state == "awaiting-input":
             ref = await self._ping_operator(
@@ -488,110 +489,54 @@ class MattermostAdapter(CollaborationAdapter):
             if ref is not None:
                 self._input_pings.setdefault(key, []).append(ref)
         else:
-            await self._dispose_working(channel_id, agent_name)
+            await self._dispose_working(channel_id, agent_name, deeplink_url)
             await self._clear_input_pings(channel_id, agent_name)
 
     async def _clear_input_pings(self, channel_id: str, agent_name: str) -> None:
-        """Remove the tracked operator pings when the turn ends.
+        """Resolve the tracked operator pings when the turn ends.
 
-        Same tombstone-avoidance as the working message: hard-delete when
-        permitted, otherwise edit the ping to a terminal marker."""
+        Edited rather than removed, for the same reason as the working message:
+        a delete would leave a placeholder in every client that had the ping on
+        screen — which, for a ping, is precisely the people it was aimed at."""
         for post_id in self._input_pings.pop((channel_id, agent_name), []):
-            if await self._permanent_delete(post_id):
-                continue
             await self._patch_post_as(
-                agent_name, post_id, self.translate_outbound("✓ input received")
+                agent_name, post_id, self.translate_outbound("✓ Input received")
             )
 
     async def _reposition_runtime_state(
         self, channel_id: str, agent_name: str, thread_root_id: str | None
     ) -> None:
-        """Move the indicator only when Mattermost will truly delete the old one.
+        """Leave the indicator where it was first posted.
 
-        This inverts the base class's post-then-delete order. Mattermost can only
-        remove a post without leaving a "(message deleted)" tombstone when the
-        server permits a hard delete (v10.2+, ``EnableAPIPostDeletion``, and a
-        system-admin account). Reposting first and discovering the delete is
-        unavailable would strand a dead marker in the channel on *every*
-        message, so the delete is attempted first and the move is abandoned —
-        loudly — when it fails.
+        Moving it means removing it from where it is, and any removal shows as
+        "(message deleted)" to everyone currently looking at the channel — once
+        per move, so an active conversation accumulates them fastest. The
+        indicator is pinned to the point the turn began instead: less precise
+        about where the agent is up to, but it costs the reader nothing.
         """
-        key = (channel_id, agent_name)
-        live = self._working_msg.get(key)
-        if live is None:
-            return
+        return
 
-        if not await self._permanent_delete(live.message_ref):
-            if channel_id not in self._no_hard_delete_warned:
-                self._no_hard_delete_warned.add(channel_id)
-                logger.warning(
-                    "Cannot move the runtime indicator in Mattermost channel %s: "
-                    "hard delete is unavailable, so the indicator would leave a "
-                    "marker behind each time it moved. It will stay where it was "
-                    "first posted. Requires Mattermost v10.2+ with "
-                    "ServiceSettings.EnableAPIPostDeletion and a system-admin "
-                    "account.",
-                    channel_id,
-                )
-            return
+    async def _dispose_working(
+        self, channel_id: str, agent_name: str, deeplink_url: str | None
+    ) -> None:
+        """Retire the live "working on it…" message when the turn ends.
 
-        ref = await self.send_message(channel_id, agent_name, live.body, thread_root_id)
-        if ref is None:
-            # The old post is already gone, so there is nothing to fall back to.
-            self._working_msg.pop(key, None)
-            logger.error(
-                "Removed the runtime indicator for %s in %s but could not repost "
-                "it; the channel now shows no indicator for this turn",
-                agent_name,
-                channel_id,
-            )
-            return
-
-        self._working_msg[key] = replace(
-            live, message_ref=ref, thread_root_id=thread_root_id
-        )
-
-    async def _dispose_working(self, channel_id: str, agent_name: str) -> None:
-        """Remove the live "working on it…" message when the turn ends.
-
-        Prefers a true hard delete (``?permanent=true``) so the message vanishes
-        with no trace. That is gated on Mattermost ≥ v10.2 with
-        ``ServiceSettings.EnableAPIPostDeletion`` enabled and a system-admin
-        account, so when it is unavailable we fall back to editing the message
-        in place — never a soft delete, which would leave a tombstone."""
+        Edited into a terminal marker rather than removed — see
+        ``_apply_runtime_state`` for why nothing here is ever deleted. The
+        marker carries how long the turn took, and keeps the link into Switch
+        Console when the ending event supplies one, so the line left behind
+        says something worth reading."""
         live = self._working_msg.pop((channel_id, agent_name), None)
         if live is None:
             return
-        if await self._permanent_delete(live.message_ref):
-            return
+        elapsed = _format_elapsed(time.monotonic() - live.started_at)
         await self._patch_post_as(
-            agent_name, live.message_ref, self.translate_outbound("✓ done")
+            agent_name,
+            live.message_ref,
+            self.translate_outbound(
+                f"✓ Done · {elapsed}" + self._deeplink_suffix(deeplink_url)
+            ),
         )
-
-    async def _permanent_delete(self, post_id: str) -> bool:
-        """Hard-delete a post via the admin (system-admin) driver.
-
-        Returns True on success; False on any failure (older server, config
-        disabled, insufficient permissions) so the caller can fall back to an
-        in-place edit rather than leave a tombstone."""
-        driver = self._admin_driver
-        loop = self._main_loop
-        if driver is None or loop is None:
-            return False
-
-        def _do() -> bool:
-            driver.client.delete(f"/posts/{post_id}", params={"permanent": "true"})
-            return True
-
-        try:
-            return await loop.run_in_executor(None, _do)
-        except Exception as e:
-            logger.debug(
-                "Permanent delete unavailable for post %s (%s); editing instead",
-                post_id,
-                e,
-            )
-            return False
 
     async def _patch_post_as(self, agent_name: str, post_id: str, content: str) -> None:
         driver = self._bot_drivers.get(agent_name) or self._admin_driver
@@ -1402,3 +1347,20 @@ class MattermostAdapter(CollaborationAdapter):
         except Exception:
             pass
         return None
+
+
+def _format_elapsed(seconds: float) -> str:
+    """How long a turn took, for the marker its status line becomes.
+
+    Rounded to whole seconds and written the way a reader skims it — "8s",
+    "2m14s", "1h03m" — rather than as a precise duration nobody reads. Sub-
+    second turns report "0s" instead of an empty string.
+    """
+    total = max(0, int(seconds))
+    if total < 60:
+        return f"{total}s"
+    minutes, secs = divmod(total, 60)
+    if minutes < 60:
+        return f"{minutes}m{secs:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m"

--- a/core/switch_core/bridges/collaboration/slack/adapter.py
+++ b/core/switch_core/bridges/collaboration/slack/adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
@@ -491,7 +492,10 @@ class SlackAdapter(CollaborationAdapter):
             ref = await self.send_message(channel_id, agent_name, body, thread_root_id)
             if ref is not None:
                 self._working_msg[key] = LiveRuntimeIndicator(
-                    message_ref=ref, body=body, thread_root_id=thread_root_id
+                    message_ref=ref,
+                    body=body,
+                    thread_root_id=thread_root_id,
+                    started_at=time.monotonic(),
                 )
         elif state == "awaiting-input":
             # Leave the working indicator up; add a ping and track it.

--- a/core/switch_core/bridges/collaboration/teams/adapter.py
+++ b/core/switch_core/bridges/collaboration/teams/adapter.py
@@ -4,6 +4,7 @@ import asyncio
 import html
 import logging
 import re
+import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
@@ -565,7 +566,10 @@ class TeamsAdapter(CollaborationAdapter):
             ref = await self.send_message(channel_id, agent_name, body, thread_root_id)
             if ref is not None:
                 self._working_msg[key] = LiveRuntimeIndicator(
-                    message_ref=ref, body=body, thread_root_id=thread_root_id
+                    message_ref=ref,
+                    body=body,
+                    thread_root_id=thread_root_id,
+                    started_at=time.monotonic(),
                 )
         elif state == "awaiting-input":
             ref = await self._ping_operator(

--- a/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
+++ b/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
@@ -1,12 +1,26 @@
+"""Mattermost's runtime indicator must never delete a post.
+
+Mattermost's web client swaps any message deleted while it is on screen for a
+"(message deleted)" placeholder, and only drops it on reload — whether the
+delete was permanent or not. A status line that appears and vanishes every turn
+therefore leaves a trail of placeholders behind it, one per removal.
+
+So the rule these tests hold the adapter to is blunt: nothing it posts is ever
+deleted. The status line is edited into a terminal marker at the end of a turn,
+and it does not move while the turn runs.
+"""
+
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 from switch_core.bridges.collaboration.adapter import LiveRuntimeIndicator
 from switch_core.bridges.collaboration.mattermost.adapter import (
     MattermostAdapter,
     MattermostConnectionConfig,
+    _format_elapsed,
 )
 
 
@@ -30,22 +44,22 @@ def _run(coro: Any) -> Any:
 
 
 class _Recorder:
-    """Records the adapter's platform calls, with a togglable hard delete."""
+    """Records the adapter's platform calls, deletes included.
 
-    def __init__(self, *, hard_delete_works: bool) -> None:
-        self.hard_delete_works = hard_delete_works
-        self.hard_deletes: list[str] = []
+    ``deletes`` exists to be asserted empty: it is the failure this whole
+    approach is designed around, so a regression that reintroduces a delete
+    should fail a test rather than merely change one.
+    """
+
+    def __init__(self) -> None:
+        self.deletes: list[str] = []
         self.patches: list[tuple[str, str]] = []
         self.sends: list[tuple[str, str, str, str | None]] = []
-        # Post ids actually handed back, so a test can assert that everything
-        # posted was also removed.
-        self.sent_ids: list[str] = []
-        self._next_id = iter(["post-2", "post-3", "post-4"])
+        self._next_id = iter(f"post-{n}" for n in range(2, 20))
 
     def install(self, adapter: MattermostAdapter) -> None:
-        async def permanent_delete(post_id: str) -> bool:
-            self.hard_deletes.append(post_id)
-            return self.hard_delete_works
+        async def delete_message(channel_id: str, message_ref: str) -> None:
+            self.deletes.append(message_ref)
 
         async def patch_post_as(agent_name: str, post_id: str, content: str) -> None:
             self.patches.append((post_id, content))
@@ -57,170 +71,49 @@ class _Recorder:
             thread_root_id: str | None = None,
         ) -> str | None:
             self.sends.append((channel_id, sender_name, content, thread_root_id))
-            ref = next(self._next_id)
-            self.sent_ids.append(ref)
-            return ref
+            return next(self._next_id)
 
-        adapter._permanent_delete = permanent_delete  # type: ignore[method-assign]
+        adapter.delete_message = delete_message  # type: ignore[method-assign]
         adapter._patch_post_as = patch_post_as  # type: ignore[method-assign]
         adapter.send_message = send_message  # type: ignore[method-assign]
 
 
 def _seed_indicator(
-    adapter: MattermostAdapter, *, thread_root_id: str | None = None
+    adapter: MattermostAdapter,
+    *,
+    thread_root_id: str | None = None,
+    age_seconds: float = 0.0,
 ) -> None:
     adapter._working_msg[("chan-1", "worker")] = LiveRuntimeIndicator(
         message_ref="post-1",
         body="⚙️ _Working on it…_",
         thread_root_id=thread_root_id,
+        started_at=time.monotonic() - age_seconds,
     )
 
 
-def test_reposition_deletes_before_reposting_when_hard_delete_works() -> None:
-    # Mattermost inverts the usual post-then-delete order: the old post must be
-    # provably gone before a replacement is posted, or a failure would strand a
-    # marker in the channel.
+def test_the_indicator_stays_put_instead_of_following_the_conversation() -> None:
+    # Moving it means deleting it from where it was, and every delete is a
+    # placeholder in every client watching. Pinned costs the reader nothing.
     adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=True)
-    recorder.install(adapter)
-    _seed_indicator(adapter, thread_root_id="root-9")
-
-    _run(adapter.reposition_runtime_state("chan-1", "worker", "root-9"))
-
-    assert recorder.hard_deletes == ["post-1"]
-    assert recorder.sends == [("chan-1", "worker", "⚙️ _Working on it…_", "root-9")]
-    assert recorder.patches == []
-    assert adapter._working_msg[("chan-1", "worker")].message_ref == "post-2"
-
-
-def test_reposition_rehomes_into_the_thread_of_the_latest_message() -> None:
-    adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=True)
+    recorder = _Recorder()
     recorder.install(adapter)
     _seed_indicator(adapter, thread_root_id="root-9")
 
     _run(adapter.reposition_runtime_state("chan-1", "worker", "root-42"))
 
-    assert recorder.sends == [("chan-1", "worker", "⚙️ _Working on it…_", "root-42")]
-    assert adapter._working_msg[("chan-1", "worker")].thread_root_id == "root-42"
-
-
-def test_reposition_abandoned_when_hard_delete_is_unavailable() -> None:
-    # Without a hard delete, moving would leave a "✓ done" marker behind on
-    # every message. The indicator stays where it is instead.
-    adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=False)
-    recorder.install(adapter)
-    _seed_indicator(adapter)
-
-    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
-
+    assert recorder.deletes == []
     assert recorder.sends == []
-    assert recorder.patches == []
-    assert adapter._working_msg[("chan-1", "worker")].message_ref == "post-1"
-
-
-def test_unavailable_hard_delete_is_warned_once_per_channel() -> None:
-    adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=False)
-    recorder.install(adapter)
-    _seed_indicator(adapter)
-
-    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
-    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
-
-    assert adapter._no_hard_delete_warned == {"chan-1"}
-
-
-def test_reposition_is_a_noop_without_a_live_indicator() -> None:
-    adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=True)
-    recorder.install(adapter)
-
-    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
-
-    assert recorder.hard_deletes == []
-    assert recorder.sends == []
-
-
-def test_failed_repost_after_delete_drops_the_stale_ref() -> None:
-    # The old post is already gone here, so there is nothing to fall back to —
-    # the tracked ref must not keep pointing at a deleted post.
-    adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=True)
-    recorder.install(adapter)
-    _seed_indicator(adapter)
-
-    async def failing_send(*_args: Any, **_kwargs: Any) -> None:
-        return None
-
-    adapter.send_message = failing_send  # type: ignore[method-assign]
-    _run(adapter.reposition_runtime_state("chan-1", "worker", None))
-
-    assert ("chan-1", "worker") not in adapter._working_msg
-
-
-def test_a_turn_ending_during_a_move_leaves_nothing_behind() -> None:
-    # The move and the end-of-turn clear share the agent's runtime lock, so
-    # they cannot interleave: whichever runs second sees the other's result.
-    # Either way the channel ends up with no indicator and none is tracked.
-    adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=True)
-    recorder.install(adapter)
-    _seed_indicator(adapter)
-
-    async def scenario() -> None:
-        await asyncio.gather(
-            adapter.reposition_runtime_state("chan-1", "worker", None),
-            adapter.apply_runtime_state(
-                "chan-1", "worker", "idle", notify_user=None, thread_root_id=None
-            ),
-        )
-
-    _run(scenario())
-
-    posted = {"post-1", *(ref for ref in recorder.sent_ids)}
-    assert posted <= set(recorder.hard_deletes)
-    assert ("chan-1", "worker") not in adapter._working_msg
-
-
-def test_a_refresh_during_a_move_does_not_strand_the_replacement() -> None:
-    # The reported leftover: the periodic activity refresh and the move both
-    # read-modify-write the tracked indicator. Serialised, the refresh edits
-    # whichever message is actually posted rather than restoring a dead ref.
-    adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=True)
-    recorder.install(adapter)
-    _seed_indicator(adapter)
-
-    async def scenario() -> None:
-        await asyncio.gather(
-            adapter.reposition_runtime_state("chan-1", "worker", None),
-            adapter.apply_runtime_state(
-                "chan-1",
-                "worker",
-                "working",
-                notify_user=None,
-                thread_root_id=None,
-                detail="Ran tool post_message",
-            ),
-        )
-
-    _run(scenario())
-
     live = adapter._working_msg[("chan-1", "worker")]
-    posted = {"post-1", *recorder.sent_ids}
-    still_up = posted - set(recorder.hard_deletes)
-    assert still_up == {live.message_ref}
+    assert live.message_ref == "post-1"
+    assert live.thread_root_id == "root-9"
 
 
-def test_idle_still_falls_back_to_a_terminal_marker() -> None:
-    # Turn end is unchanged: without a hard delete the post is edited rather
-    # than soft deleted, so no "(message deleted)" tombstone is left.
+def test_a_finished_turn_retires_the_indicator_in_place() -> None:
     adapter = _adapter()
-    recorder = _Recorder(hard_delete_works=False)
+    recorder = _Recorder()
     recorder.install(adapter)
-    _seed_indicator(adapter)
+    _seed_indicator(adapter, age_seconds=134)
 
     _run(
         adapter.apply_runtime_state(
@@ -228,5 +121,113 @@ def test_idle_still_falls_back_to_a_terminal_marker() -> None:
         )
     )
 
-    assert recorder.patches == [("post-1", "✓ done")]
+    assert recorder.deletes == []
+    assert recorder.patches == [("post-1", "✓ Done · 2m14s")]
     assert ("chan-1", "worker") not in adapter._working_msg
+
+
+def test_the_done_marker_keeps_the_link_into_switch_console() -> None:
+    # The line is staying in the channel either way, so it may as well remain
+    # useful — the session that produced it is one click away.
+    adapter = _adapter()
+    recorder = _Recorder()
+    recorder.install(adapter)
+    _seed_indicator(adapter, age_seconds=8)
+
+    _run(
+        adapter.apply_runtime_state(
+            "chan-1",
+            "worker",
+            "idle",
+            notify_user=None,
+            thread_root_id=None,
+            deeplink_url="https://switch.example/session/1",
+        )
+    )
+
+    assert recorder.patches == [
+        (
+            "post-1",
+            "✓ Done · 8s ([Open in Switch Console](https://switch.example/session/1))",
+        )
+    ]
+
+
+def test_an_operator_ping_is_resolved_rather_than_removed() -> None:
+    adapter = _adapter()
+    recorder = _Recorder()
+    recorder.install(adapter)
+    adapter._input_pings[("chan-1", "worker")] = ["ping-1", "ping-2"]
+
+    _run(
+        adapter.apply_runtime_state(
+            "chan-1", "worker", "idle", notify_user=None, thread_root_id=None
+        )
+    )
+
+    assert recorder.deletes == []
+    assert recorder.patches == [
+        ("ping-1", "✓ Input received"),
+        ("ping-2", "✓ Input received"),
+    ]
+    assert ("chan-1", "worker") not in adapter._input_pings
+
+
+def test_a_turn_posts_one_status_line_and_deletes_nothing() -> None:
+    # The end-to-end shape: one post at the start, edited in place as the work
+    # changes, edited once more when it finishes. Never more than one line, and
+    # never a delete.
+    adapter = _adapter()
+    recorder = _Recorder()
+    recorder.install(adapter)
+
+    async def turn() -> None:
+        for detail in ("Ran tool Bash", "Ran tool Edit", None):
+            await adapter.apply_runtime_state(
+                "chan-1",
+                "worker",
+                "working",
+                notify_user=None,
+                thread_root_id=None,
+                detail=detail,
+            )
+        await adapter.apply_runtime_state(
+            "chan-1", "worker", "idle", notify_user=None, thread_root_id=None
+        )
+
+    _run(turn())
+
+    assert recorder.deletes == []
+    assert len(recorder.sends) == 1
+    assert [content for _, content in recorder.patches] == [
+        "⚙️ Ran tool Edit",
+        "⚙️ _Working on it…_",
+        "✓ Done · 0s",
+    ]
+
+
+def test_idle_without_an_indicator_does_nothing() -> None:
+    adapter = _adapter()
+    recorder = _Recorder()
+    recorder.install(adapter)
+
+    _run(
+        adapter.apply_runtime_state(
+            "chan-1", "worker", "idle", notify_user=None, thread_root_id=None
+        )
+    )
+
+    assert recorder.patches == []
+    assert recorder.deletes == []
+
+
+def test_elapsed_is_written_the_way_it_is_read() -> None:
+    assert _format_elapsed(0.4) == "0s"
+    assert _format_elapsed(8.9) == "8s"
+    assert _format_elapsed(59) == "59s"
+    assert _format_elapsed(60) == "1m00s"
+    assert _format_elapsed(134) == "2m14s"
+    assert _format_elapsed(3600) == "1h00m"
+    assert _format_elapsed(3780) == "1h03m"
+    # A clock that ran backwards is not a negative duration.
+    assert _format_elapsed(-5) == "0s"

--- a/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
+++ b/core/tests/switch_core/bridges/collaboration/test_mattermost_runtime_state.py
@@ -126,9 +126,10 @@ def test_a_finished_turn_retires_the_indicator_in_place() -> None:
     assert ("chan-1", "worker") not in adapter._working_msg
 
 
-def test_the_done_marker_keeps_the_link_into_switch_console() -> None:
-    # The line is staying in the channel either way, so it may as well remain
-    # useful — the session that produced it is one click away.
+def test_the_done_marker_carries_no_session_link() -> None:
+    # The marker is permanent, so it stays minimal. A link into the session is
+    # worth having while the agent is working, not on the record of a finished
+    # turn — and it is one more thing to read on a line nobody asked to keep.
     adapter = _adapter()
     recorder = _Recorder()
     recorder.install(adapter)
@@ -145,12 +146,7 @@ def test_the_done_marker_keeps_the_link_into_switch_console() -> None:
         )
     )
 
-    assert recorder.patches == [
-        (
-            "post-1",
-            "✓ Done · 8s ([Open in Switch Console](https://switch.example/session/1))",
-        )
-    ]
+    assert recorder.patches == [("post-1", "✓ Done · 8s")]
 
 
 def test_an_operator_ping_is_resolved_rather_than_removed() -> None:

--- a/core/tests/switch_core/bridges/collaboration/test_runtime_indicator_race.py
+++ b/core/tests/switch_core/bridges/collaboration/test_runtime_indicator_race.py
@@ -17,6 +17,7 @@ platform is exactly what the adapter thinks is posted.
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 from switch_core.bridges.collaboration.adapter import LiveRuntimeIndicator
@@ -78,6 +79,7 @@ def _adapter() -> tuple[SlackAdapter, _Platform]:
         message_ref="msg-1",
         body="⚙️ _Working on it…_",
         thread_root_id=None,
+        started_at=time.monotonic(),
     )
     return adapter, _Platform(adapter, "msg-1")
 

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -59,10 +59,6 @@ services:
       MM_SERVICESETTINGS_ENABLELOCALMODE: "true"
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
       MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
-      # Lets the bridge hard-delete (permanent=true) an agent's transient
-      # "working on it…" status post instead of soft-deleting it, which would
-      # leave a "(message deleted)" tombstone. Requires Mattermost >= v10.2.
-      MM_SERVICESETTINGS_ENABLEAPIPOSTDELETION: "true"
       MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
       # Both of these exist for Switch Console's embedded room view (CHOO-1674):
       # the onboarding checklist opens a modal over a dimmed page inside the

--- a/deploy/local/standalone-docker-compose.yml
+++ b/deploy/local/standalone-docker-compose.yml
@@ -131,10 +131,6 @@ services:
       MM_DISPLAYSETTINGS_CUSTOMURLSCHEMES: switchdash
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
       MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
-      # Lets the bridge hard-delete (permanent=true) an agent's transient
-      # "working on it…" status post instead of soft-deleting it, which would
-      # leave a "(message deleted)" tombstone. Requires Mattermost >= v10.2.
-      MM_SERVICESETTINGS_ENABLEAPIPOSTDELETION: "true"
       MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
       # Neither plugin is usable in a bundled Switch deployment: Copilot has no
       # configured provider and throws a 404 looking up its bot on every page

--- a/deploy/remote/helm/switch/templates/mattermost/deployment.yaml
+++ b/deploy/remote/helm/switch/templates/mattermost/deployment.yaml
@@ -51,11 +51,6 @@ spec:
               value: "true"
             - name: MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS
               value: "true"
-            # Lets the bridge hard-delete (permanent=true) an agent's transient
-            # "working on it…" status post instead of soft-deleting it, which
-            # would leave a "(message deleted)" tombstone. Requires MM >= v10.2.
-            - name: MM_SERVICESETTINGS_ENABLEAPIPOSTDELETION
-              value: "true"
             - name: MM_TEAMSETTINGS_ENABLEOPENSERVER
               value: "true"
             # For Switch Console's embedded room view (CHOO-1674): suppress the


### PR DESCRIPTION
## The report

An agent working in a Mattermost channel leaves a trail of `(message deleted)`
placeholders where its status line used to be, which only clear when the page is
reloaded.

## What is actually happening

Not a soft delete. The adapter already went out of its way to *hard*-delete the
status post (`?permanent=true`), and that works: checked against a live server,
the posts are physically absent from its database and there is not one
soft-deleted post in it.

The placeholder is Mattermost's web client. Any message deleted while it is
rendered is swapped for `(message deleted)` so the channel does not shift under
the reader, and it stays until reload. The client cannot tell a permanent delete
from a soft one, and there is no server or per-user setting that turns the
behaviour off — I went through the served configuration looking for one.

So the previous approach was defending against the wrong half of the problem.
The only way not to provoke the placeholder is not to delete.

## The change

Nothing the runtime indicator posts is ever deleted now:

- **End of turn** edits the status line into `✓ Done · 2m14s` instead of
  removing it, keeping the *Open in Switch Console* link when the ending event
  supplies one.
- **Operator pings** resolve to `✓ Input received` the same way.
- **The indicator no longer follows the conversation.** Each move was a
  delete-and-repost, so a busy channel generated placeholders fastest. It stays
  where the turn began.

The cost is one quiet line left behind per turn. That reads better than a
deletion marker, and it now says how long the work took.

`MM_SERVICESETTINGS_ENABLEAPIPOSTDELETION` only ever existed to permit the hard
delete, so it comes out of both compose files and the Helm deployment; the
bundled compose copy is re-synced by its own script (no version pins moved).

## Testing

- `test_mattermost_runtime_state.py` rewritten around the new rule — every test
  asserts no delete was issued, including a full-turn case that checks one post
  goes up, is edited in place as the work changes, and is edited once more at
  the end.
- Full collaboration suite: 358 passed (2 errors are the Docker-backed lifecycle
  tests, which cannot reach a daemon here and fail the same way on `main`).
- `mypy` clean, `ruff format`/`check` clean.

Reported by @louis.amaudruz; diagnosis and options discussed with him before
building. He chose this approach over rewriting the status line into the agent's
final message, which would have carried Mattermost's "Edited" tag and the wrong
timestamp on every reply.