### PR TITLE
release: batch — core 0.14.0, console 0.23.0, sidecar 1.9.2, plugins 0.9.2/0.3.3, opencode 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.14.0] - 2026-08-14
+
 #### Added
 
 - `opencode` is a registerable known agent type, alongside `claude-code` and
@@ -384,6 +386,8 @@ version of their own to them without also giving them a release of their own.
 ## switch-console
 
 ### [Unreleased]
+
+### [0.23.0] - 2026-08-14
 
 #### Added
 
@@ -1250,6 +1254,16 @@ The remote runtime Switch Console deploys to an agent host. Versioned in
 `console/apps/switch-console-desktop/src/sidecar/sidecar-version.ts` and deployed
 by Switch Console rather than published on its own.
 
+### [1.9.2]
+
+#### Changed
+- The remote session spawner now installs a provider's hooks whether they are
+  delivered as config files or as a dropped plugin (OpenCode), mirroring the
+  desktop side. A plugin-delivered provider previously launched on the VM with
+  nothing installed and never reported that it stopped (#203). Behavior change
+  only — the client↔sidecar wire (ready line, endpoints, on-disk layout) is
+  unchanged, so the major stays at `1`.
+
 ### [1.9.1]
 
 #### Changed
@@ -1300,10 +1314,13 @@ compatibility signal. History for those is in the git log.
 `.claude-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.9.2] - 2026-08-14
 #### Changed
 - The room-workflow skill lists `opencode` alongside `codex` and `claude-code`
   wherever it enumerates known agent types — the `list_agents` filter and the
-  per-type options of `update_agent_detail`.
+  per-type options of `update_agent_detail` (#203). The plugin version bumps so
+  installs re-download.
 
 
 ### [0.9.1] - 2026-08-12
@@ -1375,10 +1392,13 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.3.3] - 2026-08-14
+
 #### Changed
 - The room-workflow skill lists `opencode` alongside `codex` and `claude-code`
   wherever it enumerates known agent types — the `list_agents` filter and the
-  per-type options of `update_agent_detail`.
+  per-type options of `update_agent_detail` (#203). The plugin version bumps so
+  installs re-download.
 
 ### [0.3.2] - 2026-08-12
 
@@ -1456,7 +1476,7 @@ the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
 
-### [0.1.0]
+### [0.1.0] - 2026-08-14
 
 First release. Ships the Switch room-workflow skill, registers the Switch MCP
 server in OpenCode's global config as a local server — so the runtime takes its

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.13.2
+    version: 0.14.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.22.1
+    version: 0.23.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.13.2
+      switch-core: 0.14.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -90,7 +90,7 @@ artifacts:
       The remote runtime Switch Console deploys to an agent host. Deployed rather
       than published, so nothing else declares its version — this file is its
       only source and the constant is generated from it.
-    version: 1.9.1
+    version: 1.9.2
 
   # ── Published under the switch-core release ────────────────────────────────
   # No version of their own: `helm package` and the image build stamp them with
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.1
+    version: 0.9.2
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.2
+    version: 0.3.3
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.13.2';
+export const COMPATIBLE_SWITCH_VERSION = '0.14.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.13.2';
+export const COMPATIBLE_SWITCH_VERSION = '0.14.0';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,16 +20,16 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.13.2',
-  'switch-console': '0.22.1',
+  'switch-core': '0.14.0',
+  'switch-console': '0.23.0',
   'agent-runtime': '0.3.1',
-  sidecar: '1.9.1',
-  gateway: '0.13.2',
-  setup: '0.13.2',
-  'helm-chart': '0.13.2',
-  compose: '0.13.2',
-  'switch-connector': '0.9.1',
-  'switch-connector-codex': '0.3.2',
+  sidecar: '1.9.2',
+  gateway: '0.14.0',
+  setup: '0.14.0',
+  'helm-chart': '0.14.0',
+  compose: '0.14.0',
+  'switch-connector': '0.9.2',
+  'switch-connector-codex': '0.3.3',
   'switch-connector-opencode': '0.1.0',
 } as const satisfies Record<string, string>;
 

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,16 +20,16 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.13.2',
-  'switch-console': '0.22.1',
+  'switch-core': '0.14.0',
+  'switch-console': '0.23.0',
   'agent-runtime': '0.3.1',
-  sidecar: '1.9.1',
-  gateway: '0.13.2',
-  setup: '0.13.2',
-  'helm-chart': '0.13.2',
-  compose: '0.13.2',
-  'switch-connector': '0.9.1',
-  'switch-connector-codex': '0.3.2',
+  sidecar: '1.9.2',
+  gateway: '0.14.0',
+  setup: '0.14.0',
+  'helm-chart': '0.14.0',
+  compose: '0.14.0',
+  'switch-connector': '0.9.2',
+  'switch-connector-codex': '0.3.3',
   'switch-connector-opencode': '0.1.0',
 } as const satisfies Record<string, string>;
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.13.2"
+version = "0.14.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,16 +20,16 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.13.2",
-    "switch-console": "0.22.1",
+    "switch-core": "0.14.0",
+    "switch-console": "0.23.0",
     "agent-runtime": "0.3.1",
-    "sidecar": "1.9.1",
-    "gateway": "0.13.2",
-    "setup": "0.13.2",
-    "helm-chart": "0.13.2",
-    "compose": "0.13.2",
-    "switch-connector": "0.9.1",
-    "switch-connector-codex": "0.3.2",
+    "sidecar": "1.9.2",
+    "gateway": "0.14.0",
+    "setup": "0.14.0",
+    "helm-chart": "0.14.0",
+    "compose": "0.14.0",
+    "switch-connector": "0.9.2",
+    "switch-connector-codex": "0.3.3",
     "switch-connector-opencode": "0.1.0",
 }
 

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2433,7 +2433,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Combined release batch of everything with unreleased changes since #211.

## Contents
- **switch-core `0.13.2 → 0.14.0`** (minor) — `opencode` registerable known agent type (#203); OpenCode server-side connector no longer hangs on a permission request (#203); Mattermost status line no longer leaves "(message deleted)" markers (#214).
- **switch-console `0.22.1 → 0.23.0`** (minor) — OpenCode agent support locally + remote (#203), edit a Codex agent's config after creation (CHOO-1985 #213), first-run onboarding checklist (CHOO-2022 #212), Remote Hosts back as a Settings tab, settings cleanup, fixes. **Bundle pin → switch-core `0.14.0`** (`pins.switch-core` + both `COMPATIBLE_SWITCH_VERSION`).
- **sidecar `1.9.1 → 1.9.2`** — remote spawner installs plugin-delivered hooks (OpenCode), not just config-file hooks (#203); wire unchanged, major stays `1`. Ships inside console.
- **switch-connector (Claude) `0.9.1 → 0.9.2`** & **switch-connector-codex `0.3.2 → 0.3.3`** — room-workflow skill lists `opencode` as a known agent type (#203); version bumps so installs re-download.
- **switch-connector-opencode `0.1.0`** — dated first release (written by Console, ships inside it).
- **agent-runtime** unchanged at `0.3.1` — only its generated module regenerated (version-map). No runtime pin moves anywhere.

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes. `uv.lock` re-locked.

## Contracts
No `speaks`/`accepts` moved — no wire changes (Mattermost indicator is bridge-internal, OpenCode connector talks to an external server, runtime unchanged ⇒ `agent-protocol` stays 1/1).

## Tagging plan (off the merge commit)
1. `switch-v0.14.0` — ungated, so images exist before the console bundle pins them.
2. `switch-console-v0.23.0` — macOS build gated on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)