### PR TITLE
fix(console): stop CLI updates reading as a fault, and unstick onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,23 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+#### Fixed
+- Installing a Switch connector now finishes the onboarding step it belongs to.
+  The list of agent types you can onboard is cached separately from the agent's
+  own status, and the install refreshed everything but that — so the step stayed
+  unticked, and because the checklist locks each step behind the one above it,
+  the rest of onboarding stayed greyed out with nothing explaining why.
+
+#### Changed
+- An update to an agent's own CLI is no longer reported as though something were
+  wrong. It never gated anything, but an amber badge ahead of "Installed" read
+  like a fault on an agent that worked, and it was the nearest explanation for
+  onboarding appearing stuck. A newer CLI is now mentioned only on the agent's
+  own page, in plain text with the command that installs it.
+- The Switch connector's own updates keep their badge and gain a name —
+  "Connector update" rather than "Update available". That one is worth acting
+  on, and the two used to share a badge that could not say which was behind.
+
 ### [0.23.0] - 2026-08-14
 
 #### Added

--- a/console/apps/switch-console-desktop/src/renderer/features/remote-hosts/host-trouble-indicator.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/remote-hosts/host-trouble-indicator.tsx
@@ -33,8 +33,13 @@ import { hostSetupStore } from './host-setup-store';
 const ICON = 'h-3.5 w-3.5 shrink-0 text-foreground-warning';
 
 /**
- * This agent type's steps that are installed but behind — its CLI, its Switch
- * connector, or both.
+ * This agent type's Switch connector, when it is installed but behind.
+ *
+ * The agent's own CLI is deliberately excluded. A newer release of it changes
+ * nothing about whether the agent works here, and an icon in the sidebar is a
+ * claim that something wants attention — which put a mark against hosts that
+ * were entirely fine. The connector is ours and worth chasing; the CLI is
+ * reported on the host's own page, where someone has gone to look.
  *
  * Only steps carrying a known newer version qualify. `updateAvailable` is never
  * set off a version we could not read, and it is additionally gated on the
@@ -44,7 +49,11 @@ const ICON = 'h-3.5 w-3.5 shrink-0 text-foreground-warning';
 function staleStepsFor(plan: HostSetupPlan | null, agentId: string): HostSetupStep[] {
   if (!plan) return [];
   return agentTypeSteps(plan, agentId).filter(
-    (step) => step.state === 'satisfied' && step.updateAvailable && step.latestVersion
+    (step) =>
+      step.kind === 'agent-plugin' &&
+      step.state === 'satisfied' &&
+      step.updateAvailable &&
+      step.latestVersion
   );
 }
 
@@ -100,10 +109,10 @@ export const HostTroubleIndicator = observer(function HostTroubleIndicator({
             other two icons mean "broken", a refresh glyph reads as "retrying".
             Same warning tone as those, so it belongs to the same family.
           */}
-          <CircleFadingArrowUp className={ICON} aria-label="Update available" />
+          <CircleFadingArrowUp className={ICON} aria-label="Connector update available" />
         </TooltipTrigger>
         <TooltipContent>
-          {`Update available on ${sshHost}: ${stale
+          {`Connector update available on ${sshHost}: ${stale
             .map((step) => `${step.name} ${step.latestVersion}`)
             .join(', ')}`}
         </TooltipContent>

--- a/console/apps/switch-console-desktop/src/renderer/features/remote-hosts/setup/step-presentation.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/remote-hosts/setup/step-presentation.ts
@@ -206,10 +206,11 @@ export function agentTypeBadge(row: AgentTypeRow): BadgeSpec {
   if (row.plugin && row.plugin.state !== 'satisfied') {
     return { tone: 'warning', label: 'Switch setup required' };
   }
-  // Either half being out of date is worth saying, and the row states one
-  // question — is this usable, and is it current?
-  if (row.cli.updateAvailable || row.plugin?.updateAvailable) {
-    return { tone: 'warning', label: 'Update available' };
+  // Only the connector. A newer release of the agent's own CLI changes nothing
+  // about whether the agent works here, and reporting it in place of
+  // "Installed" made a working host look like it needed attention.
+  if (row.plugin?.updateAvailable) {
+    return { tone: 'warning', label: 'Connector update' };
   }
   return { tone: 'success', label: 'Installed' };
 }

--- a/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/AgentRow.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/AgentRow.tsx
@@ -1,5 +1,4 @@
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
-import { getAgentUpdateActionState } from '@renderer/lib/components/agent-selector/agent-install';
 import type { AgentPayload } from '@shared/core/providers/agent-payload';
 import { AgentRowStatus } from './AgentRowStatus';
 
@@ -7,16 +6,6 @@ export const AgentRow = ({ agent, onClick }: { agent: AgentPayload; onClick?: ()
   const isInstalled = agent.status === 'available';
   const isClickable = !!onClick;
   const Tag = isClickable ? 'button' : 'div';
-
-  const updates = agent.capabilities.hostDependency.updates;
-  const updateStrategyKind = updates.kind === 'supported' ? updates.update.kind : 'none';
-  const updateState = getAgentUpdateActionState({
-    updateAvailable: agent.updateAvailable,
-    updateStrategyKind,
-    version: agent.version,
-    latestVersion: agent.latestVersion,
-    isUpdating: false,
-  });
 
   return (
     <Tag
@@ -34,7 +23,6 @@ export const AgentRow = ({ agent, onClick }: { agent: AgentPayload; onClick?: ()
               agentId={agent.id}
               supportsSwitch={agent.capabilities.switchSetup.kind !== 'none'}
               cliInstalled={isInstalled}
-              cliUpdateAvailable={!!updateState.render}
             />
           </div>
         </div>

--- a/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/AgentRowStatus.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/AgentRowStatus.tsx
@@ -1,9 +1,9 @@
 import { useSwitchSetup } from '@renderer/lib/stores/use-switch-setup';
 import {
+  ConnectorUpdateBadge,
   InstalledBadge,
   SwitchSetupRequiredBadge,
   UninstalledBadge,
-  UpdateAvailableBadge,
 } from './agent-status-badge';
 
 /**
@@ -14,65 +14,44 @@ import {
  * the connector is set up. The intermediate "Switch setup required" state makes
  * clear that an installed CLI is not yet usable on its own. Agent types with no
  * Switch setup keep the plain installed/not-installed status.
+ *
+ * A newer version of the agent's own CLI is deliberately not reported here. It
+ * changes nothing about whether the agent works in Switch, and shown beside the
+ * name it read as a fault on an agent that was fine — the list answers "can I
+ * use this", and an optional upgrade is not an answer to that. It stays on the
+ * agent's own page, where someone has gone looking. The connector is the
+ * exception: it is ours, and a stale one is worth acting on.
  */
 export function AgentRowStatus({
   agentId,
   supportsSwitch,
   cliInstalled,
-  cliUpdateAvailable,
 }: {
   agentId: string;
   supportsSwitch: boolean;
   cliInstalled: boolean;
-  cliUpdateAvailable: boolean;
 }) {
   if (!supportsSwitch) {
-    return (
-      <>
-        {cliUpdateAvailable && <UpdateAvailableBadge />}
-        {cliInstalled ? <InstalledBadge /> : <UninstalledBadge />}
-      </>
-    );
+    return cliInstalled ? <InstalledBadge /> : <UninstalledBadge />;
   }
-  return (
-    <SwitchAwareStatus
-      agentId={agentId}
-      cliInstalled={cliInstalled}
-      cliUpdateAvailable={cliUpdateAvailable}
-    />
-  );
+  return <SwitchAwareStatus agentId={agentId} cliInstalled={cliInstalled} />;
 }
 
-function SwitchAwareStatus({
-  agentId,
-  cliInstalled,
-  cliUpdateAvailable,
-}: {
-  agentId: string;
-  cliInstalled: boolean;
-  cliUpdateAvailable: boolean;
-}) {
+function SwitchAwareStatus({ agentId, cliInstalled }: { agentId: string; cliInstalled: boolean }) {
   const { status, isLoading } = useSwitchSetup(agentId);
-  const connectorUpdateAvailable = !!status?.installed && !!status.updateAvailable;
 
   // Not on the machine yet — nothing else matters.
   if (!cliInstalled) return <UninstalledBadge />;
 
   // CLI installed; refine by connector state. While the connector status is
   // still loading (or unexpectedly unsupported), fall back to plain Installed.
-  const statusBadge =
-    isLoading || !status?.supported ? (
-      <InstalledBadge />
-    ) : status.installed ? (
-      <InstalledBadge />
-    ) : (
-      <SwitchSetupRequiredBadge />
-    );
+  if (isLoading || !status?.supported) return <InstalledBadge />;
+  if (!status.installed) return <SwitchSetupRequiredBadge />;
 
   return (
     <>
-      {(cliUpdateAvailable || connectorUpdateAvailable) && <UpdateAvailableBadge />}
-      {statusBadge}
+      {status.updateAvailable && <ConnectorUpdateBadge />}
+      <InstalledBadge />
     </>
   );
 }

--- a/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/DependencyInstallationUpdateCard.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/DependencyInstallationUpdateCard.tsx
@@ -127,6 +127,14 @@ export function DependencyInstallationUpdateCard({
   return null;
 }
 
+/**
+ * A newer release of the agent's own CLI.
+ *
+ * Presented plainly, not as a warning. Nothing in Switch needs the newest CLI —
+ * the agent works either way — so amber here put an alarm on a healthy agent
+ * and left people updating a tool they had no reason to touch. This is an
+ * offer: here is a newer version, and the command that installs it.
+ */
 function UpdateCard({
   versionArrow,
   children,
@@ -138,14 +146,10 @@ function UpdateCard({
     <div className="space-y-2 rounded-lg border p-3">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <div className="flex size-6 items-center justify-center rounded-lg bg-background-warning">
-            <RefreshCw
-              className="size-3.5 shrink-0 text-foreground-warning"
-              absoluteStrokeWidth
-              strokeWidth={3}
-            />
+          <div className="flex size-6 items-center justify-center rounded-lg bg-background-1">
+            <RefreshCw className="size-3.5 shrink-0 text-foreground-muted" />
           </div>
-          <span>Update available</span>
+          <span className="text-foreground-muted">Newer version available</span>
         </div>
         {versionArrow}
       </div>

--- a/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/SwitchSetupCard.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/SwitchSetupCard.tsx
@@ -8,7 +8,7 @@ import {
   InstalledBadge,
   InstallingBadge,
   UninstalledBadge,
-  UpdateAvailableBadge,
+  ConnectorUpdateBadge,
   UpdatingBadge,
 } from './agent-status-badge';
 
@@ -45,7 +45,7 @@ export function SwitchSetupCard({ agentId }: { agentId: string }) {
   ) : !status.installed ? (
     <UninstalledBadge />
   ) : status.updateAvailable ? (
-    <UpdateAvailableBadge />
+    <ConnectorUpdateBadge />
   ) : (
     <InstalledBadge />
   );

--- a/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/agent-status-badge.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/settings/agents-page/agent-status-badge.tsx
@@ -13,8 +13,16 @@ export function SwitchSetupRequiredBadge() {
   return <StatusBadge tone="warning">Switch setup required</StatusBadge>;
 }
 
-export function UpdateAvailableBadge() {
-  return <StatusBadge tone="warning">Update available</StatusBadge>;
+/**
+ * The Switch connector is behind the version this build ships.
+ *
+ * Named for the connector rather than "Update available": the agent's own CLI
+ * can also be out of date, and that is between the user and their CLI. This one
+ * is ours, it is what lets the agent speak to Switch at all, and it is worth
+ * acting on — so it says which thing it means.
+ */
+export function ConnectorUpdateBadge() {
+  return <StatusBadge tone="warning">Connector update</StatusBadge>;
 }
 
 export function RecommendedBadge() {

--- a/console/apps/switch-console-desktop/src/renderer/lib/stores/use-switch-setup.ts
+++ b/console/apps/switch-console-desktop/src/renderer/lib/stores/use-switch-setup.ts
@@ -7,6 +7,12 @@ function switchSetupQueryKey(agentId: string) {
   return ['switch-setup', agentId] as const;
 }
 
+/** Deliberately not under `switchSetupQueryKey`: this answers for every agent
+ *  type at once, so it belongs to no single one of them. */
+function agentTypeAvailabilityQueryKey(sshHost: string | undefined) {
+  return ['switch-setup', 'agent-type-availability', sshHost ?? 'local'] as const;
+}
+
 /**
  * Every Switch-capable agent type, each carrying whether it can be onboarded
  * here and — when it cannot — why. Drives the onboarding agent-type picker,
@@ -19,7 +25,7 @@ function switchSetupQueryKey(agentId: string) {
  */
 export function useAgentTypeAvailability(sshHost?: string) {
   return useQuery({
-    queryKey: ['switch-setup', 'agent-type-availability', sshHost ?? 'local'] as const,
+    queryKey: agentTypeAvailabilityQueryKey(sshHost),
     queryFn: () =>
       sshHost
         ? rpc.switchSetup.listAgentTypeAvailabilityRemote(sshHost)
@@ -43,7 +49,21 @@ export function useSwitchSetup(agentId: string) {
     staleTime: 30_000,
   });
 
-  const invalidate = () => void qc.invalidateQueries({ queryKey });
+  /**
+   * Installing or removing a connector changes two answers: this agent type's
+   * own status, and the roster of types that can be onboarded at all.
+   *
+   * The roster is cached under its own key, so the per-agent invalidation did
+   * not reach it. The onboarding checklist reads the roster to decide whether
+   * the agent-providers step is done — and it locks every later step behind the
+   * first unfinished one. Installing a connector therefore left the step
+   * unticked and the rest of onboarding greyed out until something else
+   * happened to refetch.
+   */
+  const invalidate = () => {
+    void qc.invalidateQueries({ queryKey });
+    void qc.invalidateQueries({ queryKey: ['switch-setup', 'agent-type-availability'] });
+  };
 
   const checkForUpdates = useMutation({
     mutationFn: () => rpc.switchSetup.checkForUpdates(agentId),

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/host-trouble-indicator.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/host-trouble-indicator.test.tsx
@@ -129,7 +129,35 @@ describe('the update indicator', () => {
   it('appears when this agent’s connector is behind', async () => {
     stores.plans.set('dev-vm', healthyPlan({ latestVersion: '0.8.0', updateAvailable: true }));
 
-    expect(shows(await render(indicator()), 'Update available')).toBe(true);
+    expect(shows(await render(indicator()), 'Connector update available')).toBe(true);
+  });
+
+  it('ignores the agent CLI being behind, which is not a problem here', async () => {
+    // A newer `claude` does not stop the agent working on this host, and a mark
+    // in the sidebar reads as something needing attention.
+    stores.plans.set(
+      'dev-vm',
+      plan([
+        step({}),
+        step({
+          id: 'claude',
+          kind: 'agent-cli',
+          name: 'Claude Code',
+          version: '2.1.0',
+          latestVersion: '2.2.0',
+          updateAvailable: true,
+        }),
+        step({
+          id: 'claude:plugin',
+          kind: 'agent-plugin',
+          name: 'Switch connector',
+          version: '0.7.7',
+          dependsOn: ['claude'],
+        }),
+      ])
+    );
+
+    expect(icons(await render(indicator()))).toBe(0);
   });
 
   it('stays away when everything is current', async () => {

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/switch-setup-invalidation.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/switch-setup-invalidation.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Installing a connector has to reach the onboarding checklist.
+ *
+ * The checklist decides the agent-providers step from the roster of agent types
+ * that can be onboarded, which is cached under its own key — not under the
+ * agent's. Invalidating only the agent's key left the roster stale, so a
+ * successful install did not tick the step, and the checklist locks every later
+ * step behind the first unfinished one. The whole rest of onboarding went grey
+ * with nothing on screen saying why.
+ */
+
+const install = vi.hoisted(() => vi.fn(() => Promise.resolve({ success: true })));
+const getStatus = vi.hoisted(() =>
+  vi.fn(() =>
+    Promise.resolve({
+      agentId: 'claude',
+      supported: true,
+      installed: false,
+      installedVersion: null,
+      latestVersion: null,
+      updateAvailable: false,
+      refreshError: null,
+    })
+  )
+);
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    switchSetup: {
+      getStatus,
+      install,
+      update: vi.fn(),
+      uninstall: vi.fn(),
+      checkForUpdates: vi.fn(),
+      listAgentTypeAvailability: vi.fn(() => Promise.resolve([])),
+      listAgentTypeAvailabilityRemote: vi.fn(() => Promise.resolve([])),
+    },
+  },
+}));
+vi.mock('@renderer/lib/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+import { useSwitchSetup } from '@renderer/lib/stores/use-switch-setup';
+
+const AVAILABILITY_KEY = ['switch-setup', 'agent-type-availability', 'local'];
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+/** Renders the hook and hands back its `install`, plus the shared client. */
+async function mountSwitchSetup() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // Seeded as fresh so nothing refetches it except an invalidation.
+  queryClient.setQueryData(AVAILABILITY_KEY, []);
+
+  let installConnector: () => void = () => {};
+  function Probe() {
+    installConnector = useSwitchSetup('claude').install;
+    return null;
+  }
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () =>
+    root!.render(
+      <QueryClientProvider client={queryClient}>
+        <Probe />
+      </QueryClientProvider>
+    )
+  );
+
+  return { queryClient, installConnector: () => installConnector() };
+}
+
+describe('installing a Switch connector', () => {
+  it('marks the onboardable agent types stale, so the checklist re-reads them', async () => {
+    const { queryClient, installConnector } = await mountSwitchSetup();
+
+    expect(queryClient.getQueryState(AVAILABILITY_KEY)?.isInvalidated).toBe(false);
+
+    await act(async () => {
+      installConnector();
+      await vi.waitFor(() =>
+        expect(queryClient.getQueryState(AVAILABILITY_KEY)?.isInvalidated).toBe(true)
+      );
+    });
+
+    expect(install).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Reported from a first-run: a connector installed fine, the CLI had a pending update the user did not want, and the next onboarding steps were greyed out. The update looked like the gate.

## The gate was a stale cache, not the update

Nothing anywhere treats a pending CLI update as "not set up" — the onboarding predicate, the agent-type picker and the readiness rules all key off connector-installed.

What actually happens: the roster of onboardable agent types is cached under `['switch-setup', 'agent-type-availability', …]`, and the connector mutations invalidated `['switch-setup', <agentId>]`, which does not match it. The checklist reads the roster to decide the agent-providers step, and locks every later step behind the first unfinished one — so a successful install left steps 3 and 4 disabled until a window focus happened to refetch. Intermittent, and with nothing on screen naming the cause.

Both mutations now invalidate the roster too. `switch-setup-invalidation.test.tsx` covers it and fails without the fix (verified by reverting).

## The CLI update no longer reads as a fault

It was amber, and it sat *ahead* of the green "Installed" pill — so the nearest explanation for a stuck checklist was an agent that appeared to need attention. Per the ask, a newer agent CLI is now:

- **gone** from the settings agents list, the remote-host agent-type summary row, and the sidebar trouble indicator — all three answer "does this want attention", and it does not;
- **kept** on the agent's own page, demoted from an amber "Update available" card to a plain "Newer version available" with the command that installs it.

Per-step rows inside a host's setup detail still show it, with the button that performs it. That is the surface you reach by going to look.

## The connector keeps its badge, and gains a name

`UpdateAvailableBadge` → `ConnectorUpdateBadge`, reading **"Connector update"**. One badge used to cover both updates and could not say which was behind; the connector is ours and worth acting on.

Note "Update available" still means two further things elsewhere — the sidecar, and Switch Console itself. Out of scope here, but they should not keep sharing the label.

### Checks

Typecheck clean, lint clean bar one pre-existing warning, 268 files / 2451 tests passing.

No version numbers touched; changelog entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)