### PR TITLE
fix(console): open a remote session at its pane size (CHOO-2066)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -518,6 +518,18 @@ version of their own to them without also giving them a release of their own.
   upstream. **Help → Report Issue** remains the way to send us something; it
   opens an issue on this repository (CHOO-2040).
 
+#### Fixed
+
+- **A session on a remote agent now opens at the size of the pane it opens
+  into**, instead of a fraction of it that only corrected itself when the window
+  was resized or the session was switched away from and back (CHOO-2066). A
+  remote session opens its terminal over SSH, and the renderer mounts and
+  measures its pane partway through that: the measurement arrived after the
+  spawn size had been read and before there was a PTY to resize, so it was
+  discarded and the session kept the 80x24 it was spawned with. Measured
+  dimensions are now kept whether or not a PTY is live yet, and applied to the
+  PTY when it registers.
+
 ### [0.24.0] - 2026-08-14
 
 #### Added

--- a/console/apps/switch-console-desktop/src/main/core/agent-runtime/impl/ssh-agent-runtime.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/agent-runtime/impl/ssh-agent-runtime.test.ts
@@ -828,6 +828,29 @@ describe('SshAgentRuntime', () => {
     expect(provider.isAttached()).toBe(true);
   });
 
+  // Covers a re-open, where a size is already on record: the attach spawns at it
+  // rather than the 80x24 default. It does NOT cover a first open — nothing has
+  // measured the pane by then, and the fix for that is in the registry, which
+  // applies a late-arriving size when the pty registers (CHOO-2066).
+  it('attaches at a size already on record rather than the default', async () => {
+    mockSpawn([]);
+    const provider = sshProvider({ tmux: true });
+    const item = session();
+    const ptySessionId = makeAgentPtySessionId('location-1', item.id);
+
+    ptySessionRegistry.resize(ptySessionId, 203, 51);
+
+    await provider.ensureAttachable(item);
+    await provider.attach();
+
+    expect(openSsh2Pty).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ cols: 203, rows: 51 })
+    );
+
+    ptySessionRegistry.unregister(ptySessionId);
+  });
+
   it('does not report the agent as exited when a session is evicted', async () => {
     // The sidebar derives status from hook events; a deliberate detach must not
     // look like the agent stopping, or every eviction would flip it to idle.

--- a/console/apps/switch-console-desktop/src/main/core/pty/pty-session-registry.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/pty/pty-session-registry.test.ts
@@ -138,6 +138,42 @@ describe('PtySessionRegistry', () => {
     expect(registry.getLastSize('session-1')).toEqual({ cols: 120, rows: 50 });
   });
 
+  it('remembers a resize that arrives before the PTY exists', () => {
+    const registry = new PtySessionRegistry();
+
+    const resized = registry.resize('session-1', 203, 51);
+
+    expect(resized).toBe(false);
+    expect(registry.getLastSize('session-1')).toEqual({ cols: 203, rows: 51 });
+  });
+
+  // The ordering an actual remote attach produces, taken from the logs: the
+  // spawn size is read (nothing recorded yet), the renderer mounts mid-attach
+  // and reports twice while there is still no pty, and only then does the pty
+  // register. Every resize misses, and the session sat at its 80x24 spawn size
+  // until the pane moved (CHOO-2066).
+  it('applies a size reported before the PTY registered once it does', () => {
+    const registry = new PtySessionRegistry();
+    const pty = fakePty();
+
+    expect(registry.getLastSize('session-1')).toBeUndefined();
+    registry.resize('session-1', 105, 34);
+    registry.resize('session-1', 105, 34);
+
+    registry.register('session-1', pty);
+
+    expect(pty.resize).toHaveBeenCalledWith(105, 34);
+  });
+
+  it('leaves a PTY at its spawn size when nothing was reported', () => {
+    const registry = new PtySessionRegistry();
+    const pty = fakePty();
+
+    registry.register('session-1', pty);
+
+    expect(pty.resize).not.toHaveBeenCalled();
+  });
+
   it('clears last observed size when preserving output after exit', () => {
     const registry = new PtySessionRegistry();
     const pty = fakePty();

--- a/console/apps/switch-console-desktop/src/main/core/pty/pty-session-registry.ts
+++ b/console/apps/switch-console-desktop/src/main/core/pty/pty-session-registry.ts
@@ -40,6 +40,16 @@ export class PtySessionRegistry {
 
     this.ptyMap.set(sessionId, pty);
 
+    // Apply a size that arrived while this pty was still being created.
+    //
+    // A remote session opens its terminal over SSH, and the renderer mounts and
+    // measures its pane partway through: the measurement lands after the spawn
+    // size was read and before there is a pty to resize. Without this the pty
+    // keeps the size it was spawned with — 80x24 in a pane twice that — until
+    // something moves the pane, which is why switching away and back fixed it.
+    const desiredSize = this.lastSizes.get(sessionId);
+    if (desiredSize) pty.resize(desiredSize.cols, desiredSize.rows);
+
     let buffer = '';
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -157,10 +167,23 @@ export class PtySessionRegistry {
     return this.metadata.get(sessionId);
   }
 
+  /**
+   * Record the dimensions the renderer measured and apply them to the pty.
+   *
+   * The size is remembered whether or not a pty is live, because for a remote
+   * session it routinely is not: its terminal is opened asynchronously by the
+   * attachment pool, long after the renderer measured its pane and reported.
+   * The renderer reports once and then only on an actual pane change, so a size
+   * dropped here is not sent again — the attach falls back to 80x24 and stays
+   * there. Keeping it means the attach spawns at the size the pane already has.
+   *
+   * The return value still reports only whether a live pty was resized, so a
+   * remembered size cannot be mistaken for one that reached a process.
+   */
   resize(sessionId: string, cols: number, rows: number): boolean {
+    this.lastSizes.set(sessionId, { cols, rows });
     const pty = this.ptyMap.get(sessionId);
     if (!pty) return false;
-    this.lastSizes.set(sessionId, { cols, rows });
     pty.resize(cols, rows);
     return true;
   }


### PR DESCRIPTION
[CHOO-2066](https://sandboxquantum.atlassian.net/browse/CHOO-2066)

Opening a session on a **remote** agent started with the terminal at 80x24 no matter how large the pane was. It corrected itself only when the user resized the window, or switched away from the session and back. Local sessions were unaffected.

## Cause

The renderer measures its pane and sends the dimensions down via `rpc.pty.resize`. `PtySessionRegistry.resize` dropped any resize for a session with no live PTY.

Instrumenting a real remote attach gave the ordering that produces the bug:

```
attachInternal  remembered: null    using: 80x24
pty.resize      105x34              livePty: false
pty.resize      105x34              livePty: false
...
pty.resize      105x34              livePty: true   <- only after switching away and back
```

A remote session opens its terminal over SSH, and the renderer mounts and measures its pane partway through that. The measurement lands **after** `SshAgentRuntime.attachInternal` read the spawn size and **before** the PTY is registered — so it missed at both ends, and the session kept the 80x24 it was spawned with until something moved the pane.

Local sessions escape this by ordering: their node-pty spawn registers before the renderer mounts, so their resizes always find a live PTY. Worth noting `initialSize` is `undefined` at every real call site, so **both** runtimes default to 80x24 — local just never has to rely on it.

## Fix

Close the window from both ends, in the one place both orderings pass through:

- **Keep a measured size whether or not a PTY is live**, so an attach that already has one spawns at it (the re-open case).
- **Apply a kept size to the PTY on register**, so one that arrives mid-attach is picked up as soon as there is something to resize (the first-open case, which is the reported bug).

The `resize` return value still reports only whether a live PTY was resized, so a remembered size cannot be mistaken for one that reached a process.

## Verification

- `pty-session-registry.test.ts` — drives the ordering taken from the logs above: two resizes arrive with no PTY, then the PTY registers, and it must come up at the reported size. Fails without the fix.
- A companion test asserts a PTY is left at its spawn size when nothing was ever reported, so the new resize-on-register is not unconditional.
- `ssh-agent-runtime.test.ts` — attach uses a size already on record rather than the default, asserted against the **actual cols/rows handed to the SSH channel**. Without the fix that call reports exactly `cols: 80, rows: 24`.

Full desktop suite passes (2453 tests), plus typecheck, lint and format.

## Ruled out

- **Not CSS/layout.** The clipped tmux status line was correct evidence that the PTY genuinely believed it was ~80 columns.
- **Not tmux's own default.** Both the console and the on-VM sidecar create detached tmux sessions with no `-x/-y`, so panes really do start at 80x24 — but the console re-applies `window-size latest` on **every** attach, not just at creation, so tmux sizes the window to the attaching client.

## Adjacent cases

Re-attach after eviction and opening in a background tab then switching to it both go through the same two paths and are covered. A session re-attached by reconnect replay that has never been viewed still has no measured size and starts at the default; it self-corrects on first view.

No version bumps — versioning belongs to the releaser. `[Unreleased]` changelog entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-2066]: https://sandboxquantum.atlassian.net/browse/CHOO-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ