### PR TITLE
release: batch — core 0.15.0, console 0.24.0, sidecar 1.9.3, plugins 0.9.3/0.3.4/0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
-### [0.14.0] - 2026-08-14
+### [0.15.0] - 2026-08-14
 
 #### Added
 - Telegram collaboration bridge, at parity with Slack, Mattermost and Discord
@@ -95,11 +95,6 @@ version of their own to them without also giving them a release of their own.
   dashboard and Switch Console stop offering the option and say which reason
   applies, `list_bridges` carries `can_create_channels` so an agent can choose a
   bridge that works, and a refused create is a `400` naming what to do instead.
-- `opencode` is a registerable known agent type, alongside `claude-code` and
-  `codex`. It carries its own option set — auto-session, working directory and
-  notify-user — rather than borrowing another type's, and the start-session
-  command it shows in a room passes the prompt as a flag, since OpenCode reads
-  its first positional argument as a directory to open.
 
 #### Fixed
 - Creating a room on a bridge that cannot make channels returned "Internal
@@ -171,6 +166,19 @@ version of their own to them without also giving them a release of their own.
   alive and was deaf. Adapters now report the change (`CollaborationAdapter`
   gains `set_channel_migration_handler`) and the room is re-pointed, or the
   refusal is logged with the id to re-point it at by hand.
+
+### [0.14.0] - 2026-08-14
+
+#### Added
+
+- `opencode` is a registerable known agent type, alongside `claude-code` and
+  `codex`. It carries its own option set — auto-session, working directory and
+  notify-user — rather than borrowing another type's, and the start-session
+  command it shows in a room passes the prompt as a flag, since OpenCode reads
+  its first positional argument as a directory to open.
+
+#### Fixed
+
 - The OpenCode server-side connector no longer hangs when the OpenCode server
   raises a tool permission request. The connector's event loop ignored
   `permission.updated`, so no reply was ever sent, the session never went idle,
@@ -502,6 +510,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.24.0] - 2026-08-14
+
 #### Added
 
 - **An OpenCode agent can be configured like a Codex one.** Its model,
@@ -540,8 +550,15 @@ version of their own to them without also giving them a release of their own.
   utility-model setting is worth setting too if the point is to keep everything
   on one machine: it is what OpenCode uses for background work like naming a
   conversation, which otherwise goes wherever your own config sends it.
+- Telegram brand icon, platform label and setup-guide link, so Telegram-bridged
+  rooms show the "open channel" button and the attach form links the right guide
+  (CHOO-1686). Telegram bot tokens are also redacted from the diagnostic logs.
 
 #### Fixed
+- Opening a room from a deeplink expands the sidebar groups hiding it
+  (CHOO-1686). The reveal ran once, before the room a session belongs to had
+  loaded, and never again — so the view routed correctly to a row that stayed
+  collapsed. Affects any bridge, not only Telegram.
 - Two Switch Console installs sharing an agent host no longer trade the sidecar
   back and forth when they are on the *same* release but carry different builds
   — the everyday case for dev builds, and the half of the shared-host problem
@@ -602,9 +619,6 @@ version of their own to them without also giving them a release of their own.
 ### [0.23.0] - 2026-08-14
 
 #### Added
-- Telegram brand icon, platform label and setup-guide link, so Telegram-bridged
-  rooms show the "open channel" button and the attach form links the right guide
-  (CHOO-1686). Telegram bot tokens are also redacted from the diagnostic logs.
 - **OpenCode is now a supported Switch agent type**, locally and on remote
   hosts. An OpenCode session can be onboarded as a Switch agent, join rooms,
   take injected prompts, and be reset, compacted or interrupted from a room.
@@ -670,10 +684,6 @@ version of their own to them without also giving them a release of their own.
   can no longer be hidden. The shortcuts themselves are unchanged.
 
 #### Fixed
-- Opening a room from a deeplink expands the sidebar groups hiding it
-  (CHOO-1686). The reveal ran once, before the room a session belongs to had
-  loaded, and never again — so the view routed correctly to a row that stayed
-  collapsed. Affects any bridge, not only Telegram.
 - Add Agent no longer stalls with an unset agent type once more than one Switch
   connector is installed. The form auto-selected a type only when exactly one
   was available, so a second connector left it blank — and since the directory
@@ -1474,6 +1484,8 @@ by Switch Console rather than published on its own.
 
 ### [Unreleased]
 
+### [1.9.3]
+
 #### Added
 - The ready file carries a `deployer` field: the identity of the Switch Console
   install that started this sidecar, echoed from the environment it was
@@ -1481,6 +1493,10 @@ by Switch Console rather than published on its own.
   running — the content hash says only which. Purely additive, so no contract
   revision moves: an older client ignores the field, and a client reading a
   sidecar that omits it must treat that as unknown rather than as its own.
+- Writes an agent's launch profile on the VM and completes the home-directory
+  placeholder in its environment, so a provider that names a config file by
+  absolute path (OpenCode's `OPENCODE_CONFIG`) launches correctly on a remote
+  host. Additive — the client↔sidecar wire is unchanged, so the major stays `1`.
 
 ### [1.9.2]
 
@@ -1543,19 +1559,7 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
-#### Changed
-- The room workflow adds a Mattermost-only rule: post at the root there unless
-  you were asked in a thread. Mattermost shows a threaded reply as a reply count
-  under the original post rather than in the channel, so a first-time reader can
-  take it for no answer. Threading is unchanged everywhere else.
-
-### [0.9.2] - 2026-08-14
-#### Changed
-- The room-workflow skill lists `opencode` alongside `codex` and `claude-code`
-  wherever it enumerates known agent types — the `list_agents` filter and the
-  per-type options of `update_agent_detail` (#203). The plugin version bumps so
-  installs re-download.
-
+### [0.9.3] - 2026-08-14
 
 #### Changed
 - The room-workflow skill covers Telegram: attachments cross the bridge as real
@@ -1567,6 +1571,17 @@ compatibility signal. History for those is in the git log.
   rest with `read_context`" promise does not hold. The slash-command and
   attachment platform lists now also name Discord, which had been left out of
   both.
+- The room workflow adds a Mattermost-only rule: post at the root there unless
+  you were asked in a thread. Mattermost shows a threaded reply as a reply count
+  under the original post rather than in the channel, so a first-time reader can
+  take it for no answer. Threading is unchanged everywhere else.
+
+### [0.9.2] - 2026-08-14
+#### Changed
+- The room-workflow skill lists `opencode` alongside `codex` and `claude-code`
+  wherever it enumerates known agent types — the `list_agents` filter and the
+  per-type options of `update_agent_detail` (#203). The plugin version bumps so
+  installs re-download.
 
 ### [0.9.1] - 2026-08-12
 
@@ -1637,13 +1652,7 @@ manifest history.
 
 ### [Unreleased]
 
-#### Changed
-- The room workflow adds a Mattermost-only rule: post at the root there unless
-  you were asked in a thread. Mattermost shows a threaded reply as a reply count
-  under the original post rather than in the channel, so a first-time reader can
-  take it for no answer. Threading is unchanged everywhere else.
-
-### [0.3.3] - 2026-08-14
+### [0.3.4] - 2026-08-14
 
 #### Changed
 - The room-workflow skill covers Telegram: attachments cross the bridge as real
@@ -1655,6 +1664,14 @@ manifest history.
   rest with `read_context`" promise does not hold. The slash-command and
   attachment platform lists now also name Discord, which had been left out of
   both.
+- The room workflow adds a Mattermost-only rule: post at the root there unless
+  you were asked in a thread. Mattermost shows a threaded reply as a reply count
+  under the original post rather than in the channel, so a first-time reader can
+  take it for no answer. Threading is unchanged everywhere else.
+
+### [0.3.3] - 2026-08-14
+
+#### Changed
 - The room-workflow skill lists `opencode` alongside `codex` and `claude-code`
   wherever it enumerates known agent types — the `list_agents` filter and the
   per-type options of `update_agent_detail` (#203). The plugin version bumps so
@@ -1736,7 +1753,16 @@ the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
 
+### [0.1.1] - 2026-08-14
+
 #### Changed
+- The room-workflow skill covers Telegram: attachments cross the bridge as real
+  uploads, chats cannot be created by a bot at all (so `create_room` fails there
+  for every channel type), forum topics thread natively, and formatting has no
+  tables and a 4096-character cap (CHOO-1686). It also warns that a Telegram
+  room may be mention-only, where unaddressed talk never reaches Switch at all
+  and `read_context` cannot recover it. The slash-command and attachment
+  platform lists now also name Discord.
 - The room workflow adds a Mattermost-only rule: post at the root there unless
   you were asked in a thread. Mattermost shows a threaded reply as a reply count
   under the original post rather than in the channel, so a first-time reader can

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.14.0
+    version: 0.15.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.23.0
+    version: 0.24.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.14.0
+      switch-core: 0.15.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -90,7 +90,7 @@ artifacts:
       The remote runtime Switch Console deploys to an agent host. Deployed rather
       than published, so nothing else declares its version — this file is its
       only source and the constant is generated from it.
-    version: 1.9.2
+    version: 1.9.3
 
   # ── Published under the switch-core release ────────────────────────────────
   # No version of their own: `helm package` and the image build stamp them with
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.2
+    version: 0.9.3
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.3
+    version: 0.3.4
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.0
+    version: 0.1.1
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.14.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.15.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.14.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.15.0';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.14.0',
-  'switch-console': '0.23.0',
+  'switch-core': '0.15.0',
+  'switch-console': '0.24.0',
   'agent-runtime': '0.3.1',
-  sidecar: '1.9.2',
-  gateway: '0.14.0',
-  setup: '0.14.0',
-  'helm-chart': '0.14.0',
-  compose: '0.14.0',
-  'switch-connector': '0.9.2',
-  'switch-connector-codex': '0.3.3',
-  'switch-connector-opencode': '0.1.0',
+  sidecar: '1.9.3',
+  gateway: '0.15.0',
+  setup: '0.15.0',
+  'helm-chart': '0.15.0',
+  compose: '0.15.0',
+  'switch-connector': '0.9.3',
+  'switch-connector-codex': '0.3.4',
+  'switch-connector-opencode': '0.1.1',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.14.0',
-  'switch-console': '0.23.0',
+  'switch-core': '0.15.0',
+  'switch-console': '0.24.0',
   'agent-runtime': '0.3.1',
-  sidecar: '1.9.2',
-  gateway: '0.14.0',
-  setup: '0.14.0',
-  'helm-chart': '0.14.0',
-  compose: '0.14.0',
-  'switch-connector': '0.9.2',
-  'switch-connector-codex': '0.3.3',
-  'switch-connector-opencode': '0.1.0',
+  sidecar: '1.9.3',
+  gateway: '0.15.0',
+  setup: '0.15.0',
+  'helm-chart': '0.15.0',
+  compose: '0.15.0',
+  'switch-connector': '0.9.3',
+  'switch-connector-codex': '0.3.4',
+  'switch-connector-opencode': '0.1.1',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.14.0"
+version = "0.15.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,17 +20,17 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.14.0",
-    "switch-console": "0.23.0",
+    "switch-core": "0.15.0",
+    "switch-console": "0.24.0",
     "agent-runtime": "0.3.1",
-    "sidecar": "1.9.2",
-    "gateway": "0.14.0",
-    "setup": "0.14.0",
-    "helm-chart": "0.14.0",
-    "compose": "0.14.0",
-    "switch-connector": "0.9.2",
-    "switch-connector-codex": "0.3.3",
-    "switch-connector-opencode": "0.1.0",
+    "sidecar": "1.9.3",
+    "gateway": "0.15.0",
+    "setup": "0.15.0",
+    "helm-chart": "0.15.0",
+    "compose": "0.15.0",
+    "switch-connector": "0.9.3",
+    "switch-connector-codex": "0.3.4",
+    "switch-connector-opencode": "0.1.1",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Combined release batch of everything with unreleased changes since #219.

## Contents
- **switch-core `0.14.0 → 0.15.0`** (minor) — Telegram collaboration bridge, per-connection `can_create_channels` declaration, one-click bridge install links (#187).
- **switch-console `0.23.0 → 0.24.0`** (minor) — Telegram icon/label/scheme + deeplink reveal fix (#187); first-run fixes: search headings, install-log streaming, room creation, onboarding step (#220); shared-host sidecar deployer-identity client side (#216). **Bundle pin → switch-core `0.15.0`** (`pins.switch-core` + both `COMPATIBLE_SWITCH_VERSION`).
- **sidecar `1.9.2 → 1.9.3`** — ready file carries an additive `deployer` identity so two same-version installs on one host don't trade the sidecar (#216); wire unchanged, major stays `1`. Ships inside console.
- **plugins** — Claude `0.9.2 → 0.9.3`, Codex `0.3.3 → 0.3.4`, opencode `0.1.0 → 0.1.1`: skills now cover Telegram (#187) and add the Mattermost post-at-root rule (#221). Version bumps so installs re-download.
- **agent-runtime** unchanged at `0.3.1` — only its generated module regenerated. No runtime pin moves.

## ⚠️ Changelog integrity fix (please eyeball)
#187 (Telegram) merged right after the last batch and its diff was computed pre-release, so its changelog entries landed **inside the already-published `[0.14.0]` / `[0.23.0]` / `[0.9.2]` / `[0.3.3]` headings** — but the Telegram code isn't in those tags. This PR **relocates every #187 entry** into the new version headings above and **restores the released headings to their tagged content** (verified byte-for-byte against `596ed51a`). The opencode Telegram skill change, which had no changelog entry at all, is now recorded under `[0.1.1]`.

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes. `uv.lock` re-locked.

## Contracts
No `speaks`/`accepts` moved — the Telegram `can_create_channels` field and the sidecar `deployer` field are both explicitly additive.

## Tagging plan (off the merge commit)
1. `switch-v0.15.0` — ungated, so images exist before the console bundle pins them.
2. `switch-console-v0.24.0` — macOS build gated on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)