### PR TITLE
fix(console): re-sync the OpenCode connector's embedded skill

### DIFF
--- a/console/packages/plugins/src/agents/impl/opencode/skill-file.ts
+++ b/console/packages/plugins/src/agents/impl/opencode/skill-file.ts
@@ -233,6 +233,11 @@ local operator is explicitly steering you outside the room conversation.
 - Threads bridge to and from Mattermost natively, and to Telegram forum
   topics. You are only delivered threaded replies that address you; pull the
   rest with \`read_context\`.
+- **Mattermost only — post at the root unless you were asked in a thread.**
+  Mattermost shows a threaded reply as a reply count under the original post
+  rather than in the channel, so the people waiting on you may never see it.
+  \`connect_to_room\` names the platform a room is bridged to. Everywhere else,
+  thread as described above.
 
 ## Sending and receiving attachments
 


### PR DESCRIPTION
## Why

`main` is red, and has been since #221 — every PR is blocked, including unrelated ones.

#221 added the Mattermost root-reply guidance to the room-workflow skill in all three connector directories. But Switch Console **writes** the OpenCode connector itself rather than installing it from a marketplace, so it carries its own embedded copy of that skill in `console/packages/plugins/src/agents/impl/opencode/skill-file.ts` — and that copy didn't get the update.

`connector-assets.test.ts` exists precisely to catch this drift, and it did its job. This just applies the missing five lines.

## Why it matters beyond the red build

The test's own comment says it best: the connector directory is what a reader reviews, while sessions run whatever the app embedded. Left alone, OpenCode sessions would keep loading the pre-#221 skill while the version under review said otherwise.

## Claude Code and Codex need no equivalent change

Their connectors are installed from the marketplace directory (`switchSetup.kind: 'cli'`), so `connectors/*/skills/switch/SKILL.md` is the only copy. OpenCode is the sole agent type with a second, embedded copy that can drift.

## Verification

- The five lines are the *only* difference between the two files — confirmed by round-tripping the embedded template literal back to plain text and diffing it against the connector's `SKILL.md`.
- Full workspace suite green: **2506** desktop + **155** plugins + **179** core + **45** runtime + **7** shared. `typecheck` clean across all five projects.

No version bumps — that belongs to the releaser.