### PR TITLE
release: batch — core 0.16.0, console 0.25.0, plugins 0.9.4/0.3.5/0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.16.0] - 2026-08-15
+
 #### Added
 
 - A Switch user can claim their messaging-app account as their own, linking a
@@ -601,6 +603,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.25.0] - 2026-08-15
+
 #### Added
 
 - **You can tell Switch which messaging-app account is yours.** A new dialog
@@ -698,8 +702,6 @@ version of their own to them without also giving them a release of their own.
   titled for the platform it is linking on — "Link your Discord user account" —
   and its search names the workspace, not the platform, since two workspaces on
   the same platform can be connected and only the name tells them apart.
-
-### [0.23.0] - 2026-08-14
 
 #### Removed
 
@@ -1770,6 +1772,8 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
+### [0.9.4] - 2026-08-15
+
 #### Changed
 
 - The room-workflow skill describes owner-only addressing — the new default for
@@ -1869,6 +1873,8 @@ manifest history.
 `connectors/codex-plugin/`. Version lives in `.codex-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.3.5] - 2026-08-15
 
 #### Changed
 
@@ -1977,6 +1983,8 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.2] - 2026-08-15
 
 #### Changed
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.15.0
+    version: 0.16.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.24.0
+    version: 0.25.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.15.0
+      switch-core: 0.16.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.3
+    version: 0.9.4
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.4
+    version: 0.3.5
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.1
+    version: 0.1.2
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.15.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.16.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.15.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.16.0';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.15.0',
-  'switch-console': '0.24.0',
+  'switch-core': '0.16.0',
+  'switch-console': '0.25.0',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
-  gateway: '0.15.0',
-  setup: '0.15.0',
-  'helm-chart': '0.15.0',
-  compose: '0.15.0',
-  'switch-connector': '0.9.3',
-  'switch-connector-codex': '0.3.4',
-  'switch-connector-opencode': '0.1.1',
+  gateway: '0.16.0',
+  setup: '0.16.0',
+  'helm-chart': '0.16.0',
+  compose: '0.16.0',
+  'switch-connector': '0.9.4',
+  'switch-connector-codex': '0.3.5',
+  'switch-connector-opencode': '0.1.2',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.15.0',
-  'switch-console': '0.24.0',
+  'switch-core': '0.16.0',
+  'switch-console': '0.25.0',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
-  gateway: '0.15.0',
-  setup: '0.15.0',
-  'helm-chart': '0.15.0',
-  compose: '0.15.0',
-  'switch-connector': '0.9.3',
-  'switch-connector-codex': '0.3.4',
-  'switch-connector-opencode': '0.1.1',
+  gateway: '0.16.0',
+  setup: '0.16.0',
+  'helm-chart': '0.16.0',
+  compose: '0.16.0',
+  'switch-connector': '0.9.4',
+  'switch-connector-codex': '0.3.5',
+  'switch-connector-opencode': '0.1.2',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.15.0"
+version = "0.16.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,17 +20,17 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.15.0",
-    "switch-console": "0.24.0",
+    "switch-core": "0.16.0",
+    "switch-console": "0.25.0",
     "agent-runtime": "0.3.1",
     "sidecar": "1.9.3",
-    "gateway": "0.15.0",
-    "setup": "0.15.0",
-    "helm-chart": "0.15.0",
-    "compose": "0.15.0",
-    "switch-connector": "0.9.3",
-    "switch-connector-codex": "0.3.4",
-    "switch-connector-opencode": "0.1.1",
+    "gateway": "0.16.0",
+    "setup": "0.16.0",
+    "helm-chart": "0.16.0",
+    "compose": "0.16.0",
+    "switch-connector": "0.9.4",
+    "switch-connector-codex": "0.3.5",
+    "switch-connector-opencode": "0.1.2",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Combined release batch of everything with unreleased changes since #224.

## Contents
- **switch-core `0.15.0 → 0.16.0`** (minor) — owner-only agent addressing: rules can name the owner / the owner's agents; new agents default owner-only; claim your messaging-app account (`external_user_claims`); `addressing_policy` on `GET /agents`; in-room commands honour the policy; `notify_user` replaced by owner-nudge (CHOO-2137, #226).
- **switch-console `0.24.0 → 0.25.0`** (minor) — account-linking dialog, four-answer addressing chooser, per-app Messaging-apps card + disconnect (#226); remote session opens at its pane size (#223); Give-Feedback feature + hardcoded webhook removed (#182). **Bundle pin → switch-core `0.16.0`**.
- **plugins** — Claude `0.9.3 → 0.9.4`, Codex `0.3.4 → 0.3.5`, opencode `0.1.1 → 0.1.2`: all three skills describe owner-only addressing (#226). Version bumps so installs re-download.
- **sidecar** unchanged (`1.9.3`); **agent-runtime** unchanged (`0.3.1`). No runtime pin moves.

## Changelog integrity fix (please eyeball)
#182/#223 merged after the last batch and their entries created a **spurious duplicate `### [0.23.0]`** heading between `[Unreleased]` and the real `[0.24.0]` — their code is not in the `switch-console-v0.24.0` tag. Both entries are relocated into `[0.25.0]` and the duplicate heading dropped; the real `[0.24.0]`/`[0.23.0]` are restored to their tagged content (verified byte-for-byte).

## Contracts
**gateway-api left at `1/1`.** #226 adds `addressing_policy` to `GET /agents` and `directory_search_supported` to bridge info — additive/backward-compatible, and core+console ship together (confirmed with the requester).

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes. `uv.lock` re-locked.

## Tagging plan (off the merge commit)
1. `switch-v0.16.0` — ungated, so images exist before the console bundle pins them.
2. `switch-console-v0.25.0` — macOS build gated on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)