### PR TITLE
release: switch-console 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -603,8 +603,15 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.26.0] - 2026-08-16
+
 #### Changed
 
+- **A visual design pass across the shell.** The window is now one graded
+  material surface with the sidebar sitting on it and the main panel floating
+  above as an inset card with a hairline and a soft shadow, using the design
+  spec's surface/material tokens and corner radii. Home is deliberately left for
+  a later pass (CHOO-2164).
 - **A server is now a workspace, and you switch between them.** The list of
   servers that sat in the sidebar has been replaced by a switcher at the top,
   showing the one you are in and opening onto the rest — each with where it

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.25.0
+    version: 0.26.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.16.0',
-  'switch-console': '0.25.0',
+  'switch-console': '0.26.0',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
   gateway: '0.16.0',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.16.0',
-  'switch-console': '0.25.0',
+  'switch-console': '0.26.0',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
   gateway: '0.16.0',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,7 +21,7 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.16.0",
-    "switch-console": "0.25.0",
+    "switch-console": "0.26.0",
     "agent-runtime": "0.3.1",
     "sidecar": "1.9.3",
     "gateway": "0.16.0",


### PR DESCRIPTION
Console-only release — nothing else changed since #230.

## Contents
- **switch-console `0.25.0 → 0.26.0`** (minor):
  - **A server is now a workspace behind a switcher** — per-server Home / Your Agents / Your Rooms pages, restructured sidebar (Sessions section, per-row action menus, chevron-only expand), Messaging apps as a table, plus first-server/active-server fixes (CHOO-2158, #231).
  - **Visual design pass** — floating inset main panel on a graded material surface, design-spec surface/material tokens and corner radii; Home left for a later pass (CHOO-2164, #232). *This PR's changelog entry was missing on main; authored here.*

## Not releasing
switch-core (`0.16.0`), sidecar (`1.9.3`), agent-runtime (`0.3.1`) and all three connector plugins are unchanged. **No bundle-pin move** — core is unchanged, so `pins.switch-core` / `COMPATIBLE_SWITCH_VERSION` stay at `0.16.0`. No contract changes (console-only UI).

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes.

## Tagging plan
`switch-console-v0.26.0` off the merge commit — macOS build gated on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)