### PR TITLE
fix(deploy): link the owner's Mattermost account when the stack is seeded (CHOO-2172)

### DIFF
--- a/deploy/shared_resources/setup.py
+++ b/deploy/shared_resources/setup.py
@@ -4,6 +4,8 @@ Runs as a short-lived init container in docker-compose. Waits for Switch and
 Mattermost to be healthy, bootstraps the Mattermost admin/team, then registers
 the Mattermost bridge via the authorized Switch gateway API — logging in as the
 seeded gateway admin first, since bridge administration is an admin action.
+Finally it links the seeded Mattermost account to that admin, so the deployment
+comes up knowing which chat account its owner is.
 """
 
 import os
@@ -38,6 +40,10 @@ MATTERMOST_USER_EMAIL = os.environ.get(
 MAX_RETRIES = 60
 RETRY_DELAY = 5
 
+# Shorter than MAX_RETRIES: by the time this runs both services have answered,
+# so it waits only for the bridge adapter to finish starting.
+LINK_MAX_RETRIES = 24
+
 
 def wait_for_service(url: str, name: str) -> None:
     for attempt in range(1, MAX_RETRIES + 1):
@@ -54,8 +60,13 @@ def wait_for_service(url: str, name: str) -> None:
     sys.exit(1)
 
 
-def setup_mattermost() -> None:
-    """Create admin user and team in Mattermost."""
+def setup_mattermost() -> str | None:
+    """Create admin user and team in Mattermost.
+
+    Returns the Mattermost id of the human account, which is also its
+    ``external_user_id`` on the bridge — what linking it to a Switch user is
+    keyed by. None when the account could not be created or read.
+    """
     client = httpx.Client(base_url=MATTERMOST_URL, timeout=10)
 
     # Create admin user (first user becomes system admin)
@@ -162,19 +173,19 @@ def setup_mattermost() -> None:
         print(f"Added {MATTERMOST_USER} to team {MATTERMOST_TEAM_NAME}")
 
     client.close()
+    return user_id
 
 
-def register_bridge() -> None:
-    """Register Mattermost bridge with Switch via the authorized gateway API.
+def gateway_login() -> httpx.Client:
+    """A gateway client authenticated as the seeded admin.
 
     Bridge administration is admin-gated, so we log in as the seeded gateway
-    admin (cookie-based JWT) and drive the same authorized endpoint the
-    dashboard uses — there is no unauthenticated bridge-admin surface.
+    admin (cookie-based JWT) and drive the same authorized endpoints the
+    dashboard uses — there is no unauthenticated bridge-admin surface. The
+    login sets the switch_auth cookie on the client, which every subsequent
+    gateway call carries.
     """
     client = httpx.Client(base_url=SWITCH_URL, timeout=10)
-
-    # Authenticate as the seeded gateway admin; the login sets the switch_auth
-    # cookie on the client, which every subsequent gateway call carries.
     resp = client.post(
         "/gateway/auth/login",
         json={"email": GATEWAY_ADMIN_EMAIL, "password": GATEWAY_ADMIN_PASSWORD},
@@ -185,7 +196,16 @@ def register_bridge() -> None:
             f"{GATEWAY_ADMIN_EMAIL}: {resp.status_code} {resp.text}"
         )
         sys.exit(1)
+    return client
 
+
+def register_bridge(client: httpx.Client) -> str:
+    """Register Mattermost bridge with Switch via the authorized gateway API.
+
+    Returns the bridge id — the one already registered, or the new one. A
+    registration that fails raises, as it did before: without a bridge there is
+    no deployment to speak of, so it is not something to carry on past.
+    """
     # Check if bridge already registered
     resp = client.get("/gateway/collaborations")
     if resp.is_success:
@@ -202,8 +222,7 @@ def register_bridge() -> None:
                         f"/gateway/collaborations/{bridge_id}/default"
                     ).raise_for_status()
                     print(f"Set Mattermost bridge as default: {bridge_id}")
-                client.close()
-                return
+                return bridge_id
 
     # Register new bridge
     connection_config: dict[str, str] = {
@@ -233,18 +252,112 @@ def register_bridge() -> None:
     resp.raise_for_status()
     data = resp.json()
     print(f"Registered Mattermost bridge: {data['bridge_id']} (default)")
+    return data["bridge_id"]
 
-    client.close()
+
+def await_directory_account(
+    client: httpx.Client, bridge_id: str, external_user_id: str
+) -> bool:
+    """Wait until the bridge's own directory lists the seeded human account.
+
+    Registering a bridge records it; it does not mean its adapter has finished
+    starting, and a claim for an account Switch has never seen is refused until
+    it has (409). This probes the directory the claim itself consults, so a
+    success here means the next call has what it needs rather than merely that
+    some other endpoint answered.
+    """
+    for attempt in range(1, LINK_MAX_RETRIES + 1):
+        resp = client.get(
+            f"/gateway/collaborations/{bridge_id}/directory",
+            params={"query": MATTERMOST_USER},
+        )
+        if resp.is_success:
+            found = resp.json().get("users", [])
+            if any(u.get("external_user_id") == external_user_id for u in found):
+                return True
+            reason = f"{MATTERMOST_USER} not in the directory yet"
+        else:
+            reason = f"{resp.status_code} {resp.text}"
+        print(
+            f"Waiting for the Mattermost bridge to serve its directory "
+            f"({attempt}/{LINK_MAX_RETRIES}): {reason}"
+        )
+        time.sleep(RETRY_DELAY)
+    return False
+
+
+def link_owner_identity(
+    client: httpx.Client, bridge_id: str, external_user_id: str
+) -> None:
+    """Link the seeded Mattermost account to the seeded gateway admin.
+
+    The deployment provisions both halves of one person — a Switch admin and
+    the Mattermost account they will chat from — so leaving them unassociated
+    means owner-only addressing (CHOO-2137) cannot recognise the owner in the
+    deployment's own chat, and the Home page reports an account the user has to
+    link by hand (CHOO-2172).
+
+    Only ever claims when the admin holds no identity on this bridge, so a
+    re-run is a no-op. Someone who deliberately unlinks themselves and runs
+    setup again does get relinked; that is the cost of repairing every existing
+    deployment on its next run, and the manual control to undo it is still
+    there.
+    """
+    resp = client.get("/gateway/auth/me/identities")
+    if resp.is_success:
+        if any(i.get("bridge_id") == bridge_id for i in resp.json()):
+            print(f"Gateway admin already linked to a Mattermost account: {bridge_id}")
+            return
+    else:
+        print(
+            "WARNING: Could not read the gateway admin's linked accounts: "
+            f"{resp.status_code} {resp.text}"
+        )
+        return
+
+    if not await_directory_account(client, bridge_id, external_user_id):
+        print(
+            f"WARNING: The Mattermost bridge never listed {MATTERMOST_USER} in its "
+            f"directory, so {GATEWAY_ADMIN_EMAIL} was NOT linked to it. Owner-only "
+            "agents will not recognise you in Mattermost until you link the account "
+            "yourself from the server's Messaging apps section."
+        )
+        return
+
+    resp = client.post(
+        f"/gateway/collaborations/{bridge_id}/identities",
+        json={"external_user_id": external_user_id, "username": MATTERMOST_USER},
+    )
+    if resp.is_success:
+        print(f"Linked {GATEWAY_ADMIN_EMAIL} to Mattermost account {MATTERMOST_USER}")
+        return
+    print(
+        f"WARNING: Could not link {GATEWAY_ADMIN_EMAIL} to the Mattermost account "
+        f"{MATTERMOST_USER}: {resp.status_code} {resp.text}. Owner-only agents will "
+        "not recognise you in Mattermost until you link the account yourself from "
+        "the server's Messaging apps section."
+    )
 
 
 def main() -> None:
     print("Switch local setup starting...")
 
     wait_for_service(f"{MATTERMOST_URL}/api/v4/system/ping", "Mattermost")
-    setup_mattermost()
+    mattermost_user_id = setup_mattermost()
 
     wait_for_service(f"{SWITCH_URL}/health", "Switch")
-    register_bridge()
+    client = gateway_login()
+    try:
+        bridge_id = register_bridge(client)
+        if mattermost_user_id is None:
+            print(
+                f"WARNING: No Mattermost account for {MATTERMOST_USER}, so "
+                f"{GATEWAY_ADMIN_EMAIL} could not be linked to one"
+            )
+        else:
+            link_owner_identity(client, bridge_id, mattermost_user_id)
+    finally:
+        client.close()
 
     print("Setup complete!")
 


### PR DESCRIPTION
[CHOO-2172](https://sandboxquantum.atlassian.net/browse/CHOO-2172)

## The bug

Creating a managed server left the owner's Mattermost account unlinked. Home showed **Mattermost `Default` — ⚠️ No account linked**, and the user had to press **Link** by hand — on a server they created, as its only user, with a chat app that was provisioned as part of it.

Not cosmetic: owner-only agent addressing (CHOO-2137) is built on this link, so the *default* state of a new managed server was one where an owner-restricted agent could not recognise its own owner in the deployment's own chat.

## Diagnosis

Both halves already existed — the seeder creates the Mattermost user, and CHOO-2137 added the owner↔account link. Nothing called them together.

Confirmed before designing anything, on a live managed server showing the warning: driving the manual **Link** path (directory search → claim → read back) linked it first try. The link path is healthy; provisioning simply never asked for it.

## The fix

`deploy/shared_resources/setup.py` claims the seeded Mattermost account for the seeded gateway admin, straight after registering the bridge. That script is the one place holding both identities, and it serves the local compose, the standalone compose the desktop app deploys, and the Helm setup job alike — so local and remote managed servers are covered by one change rather than two.

**Waiting for the app to be onboarded.** Registering a bridge records it; it does not mean its adapter can answer. Observed on a from-scratch stack:

```
Registered Mattermost bridge: 40d02f97-… (default)
Waiting for the Mattermost bridge to serve its directory (1/24): 502 {"detail":"Mattermost user directory lookup failed: Invalid or expired session, please login again."}
Linked admin@switch.local to Mattermost account user
```

So the claim waits on the directory endpoint the claim itself consults — a success there means the next call has what it needs, rather than merely that some other endpoint answered. Without it the primary case in the ticket (a brand-new server) would fail.

## The three questions the ticket asks

- **Local vs remote.** Both run this same seeder, so one change covers them. The server used to reproduce the bug was a *remote* managed server, so it is confirmed on that path rather than assumed from the local one.
- **Servers that already exist.** The claim is skipped when the admin already holds an identity on the bridge, so a re-run is a no-op and an existing unlinked deployment repairs itself on its next setup run. Anyone who does not restart keeps the manual button — accepted deliberately.
- **If linking cannot happen.** Nothing is faked and nothing is silently skipped: the run prints why, names the manual step, and leaves the rest of setup intact. Provisioning is not failed over it — the stack is healthy and refusing to finish would be worse.

Known trade-off: someone who deliberately unlinks themselves is relinked by the next setup run. That is the cost of repairing existing deployments; the manual control to undo it remains.

## Verification

Live, not by test — a test that constructs the link and then asserts it proves nothing here. There is no existing test suite for this script.

- **Brand-new stack** from scratch (fresh volumes, bridge registered for the first time): comes up linked, `GET /auth/me/identities` returns the Mattermost account, no warning on Home.
- **An existing unlinked managed server**: put back to the broken state, ran the seeder, it linked; two further runs reported "already linked" and changed nothing.

## Not included

No version bumps — the setup image ships with switch-core, so this reaches managed servers when the releaser cuts a release and the console's pin follows. Deliberately left to the releaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-2172]: https://sandboxquantum.atlassian.net/browse/CHOO-2172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ