### PR TITLE
fix(clients): greet the room again when an agent joins it (CHOO-2170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+#### Fixed
+
+- An agent joining a room greets it again. The greeting fires when an agent
+  notices its own arrival, and since 0.9.0 it never did: auto-accepting the
+  invite began recording the room as joined a moment before the join arrived
+  over sync, so the arrival was read as one already handled. Every room an
+  agent is invited to went ungreeted, on every connection, regardless of the
+  per-connection greeting toggle. Whether the arrival has been announced is now
+  tracked separately from membership, which the bridge needs recorded as early
+  as possible. Departing a room resets it, so being added back greets again.
+- `just test-integration` runs again. Its wiring had drifted behind
+  `RoomService`, `ProtocolService` and `AgentClient`, so every test errored
+  during setup — unnoticed, because the suite is excluded from the default run
+  and from CI. It is the suite that would have caught the greeting regression.
+
 ### [0.16.0] - 2026-08-15
 
 #### Added

--- a/core/switch_core/clients/client_base.py
+++ b/core/switch_core/clients/client_base.py
@@ -104,6 +104,12 @@ class ClientBase[ConfigT: ClientConfig]:
         self.nio_client: AsyncClient | None = None
         self.room_join_times: dict[str, int] = {}
         self._room_joined_events: dict[str, asyncio.Event] = {}
+        # Rooms this client has already announced its arrival in. Distinct from
+        # `room_join_times`, which is membership bookkeeping recorded as early as
+        # possible (an explicit join, a membership lookup) so `wait_joined` and
+        # the `_should_ignore` cutoff are accurate. Membership being known is not
+        # evidence the arrival was announced.
+        self._self_join_dispatched: set[str] = set()
         self._ready = asyncio.Event()
         self._startup_ts: int = 0
         self._last_sync_persist: float = 0.0
@@ -290,19 +296,32 @@ class ClientBase[ConfigT: ClientConfig]:
     async def _handle_member_event(
         self, room: MatrixRoom, event: RoomMemberEvent
     ) -> None:
-        if event.state_key == self.matrix_user_id and event.membership == "join":
-            already_joined = room.room_id in self.room_join_times
-            self._mark_joined(room.room_id, event.server_timestamp)
-            if not already_joined and event.server_timestamp >= self._startup_ts:
-                try:
-                    await self.on_self_join(room, event)
-                except Exception:
-                    logger.exception(
-                        "Error in on_self_join for %s in %s",
-                        self.matrix_user_id,
-                        room.room_id,
-                    )
-            return
+        if event.state_key == self.matrix_user_id:
+            if event.membership == "join":
+                self._mark_joined(room.room_id, event.server_timestamp)
+                # A membership-preserving update (display name, avatar) re-fires
+                # m.room.member with membership == "join"; only a transition into
+                # membership is an arrival. Joins predating this process are not
+                # ours to announce, and the room is recorded so a redelivery of
+                # the same join does not announce it twice.
+                if (
+                    event.prev_membership != "join"
+                    and event.server_timestamp >= self._startup_ts
+                    and room.room_id not in self._self_join_dispatched
+                ):
+                    self._self_join_dispatched.add(room.room_id)
+                    try:
+                        await self.on_self_join(room, event)
+                    except Exception:
+                        logger.exception(
+                            "Error in on_self_join for %s in %s",
+                            self.matrix_user_id,
+                            room.room_id,
+                        )
+                return
+            if event.membership in ("leave", "ban"):
+                # Departing ends the visit: being added back is a fresh arrival.
+                self._self_join_dispatched.discard(room.room_id)
         if self._should_ignore(room, event):
             return
         try:

--- a/core/tests/integration/conftest.py
+++ b/core/tests/integration/conftest.py
@@ -40,6 +40,7 @@ from testcontainers.postgres import PostgresContainer
 
 # Importing models registers every table on Base.metadata for create_all.
 import switch_core.db.models  # noqa: F401
+from switch_core.bridges.agent.protocol.connections import ConnectionRegistry
 from switch_core.bridges.agent.protocol.event_buffer import EventBuffer
 from switch_core.bridges.agent.protocol.service import ProtocolService
 from switch_core.bridges.agent.protocol.types import (
@@ -431,6 +432,7 @@ async def harness(session_env: SessionEnv) -> AsyncIterator[Harness]:
     # Per-test in-memory wiring: a fresh EventBuffer / client registry so queued
     # events and client registrations never leak across tests.
     event_buffer = EventBuffer()
+    connections = ConnectionRegistry()
     request_tracker = RequestTracker()
     resource_request_tracker = ResourceRequestTracker()
     collab_lifecycle = _NoBridges()
@@ -459,8 +461,10 @@ async def harness(session_env: SessionEnv) -> AsyncIterator[Harness]:
         reference_store=session_env.reference_store,
         agent_session_store=session_env.agent_session_store,
         room_role_store=session_env.room_role_store,
+        external_user_store=session_env.external_user_store,
         request_tracker=request_tracker,
         resource_request_tracker=resource_request_tracker,
+        connections=connections,
         frontend_base_url=config.frontend_base_url,
     )
     client_factory.register("user", ClientBase)
@@ -480,6 +484,7 @@ async def harness(session_env: SessionEnv) -> AsyncIterator[Harness]:
         agent_store=session_env.agent_store,
         client_lifecycle=client_lifecycle,
         collab_lifecycle=collab_lifecycle,  # type: ignore[arg-type]
+        collab_bridge_store=session_env.bridge_store,
         resource_service=resource_service,
         session_factory=session_factory,
     )
@@ -501,6 +506,7 @@ async def harness(session_env: SessionEnv) -> AsyncIterator[Harness]:
         bridge_store=session_env.bridge_store,
         session_factory=session_factory,
         config=config,
+        connections=connections,
     )
 
     h = Harness(

--- a/core/tests/integration/test_agent_greeting_e2e.py
+++ b/core/tests/integration/test_agent_greeting_e2e.py
@@ -1,0 +1,146 @@
+"""End-to-end test for the agent self-join greeting over a real Matrix homeserver.
+
+Drives the genuine path: RoomService creates a room and invites the agent →
+the agent's AgentClient sync loop sees the invite → auto-joins → on_self_join
+posts the greeting. The assertion reads the room timeline back off the
+homeserver, so nothing is inferred from in-process state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from switch_core.db.models import Agent, CollaborationBridge, Room
+from switch_core.room_service import RoomCreateConfig
+from tests.integration.conftest import Harness, SessionEnv
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
+
+
+async def _wait_joined(
+    client: object, matrix_room_id: str, timeout: float = 30
+) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if matrix_room_id in client.room_join_times:  # type: ignore[attr-defined]
+            return
+        await asyncio.sleep(0.25)
+    raise AssertionError(f"client never joined {matrix_room_id} within {timeout}s")
+
+
+async def _timeline_messages(
+    session_env: SessionEnv, matrix_room_id: str
+) -> list[dict]:
+    """Every m.room.message in the room, read back off the homeserver as admin."""
+    admin = session_env.matrix_admin
+    resp = await admin._http.get(
+        f"/_matrix/client/r0/rooms/{matrix_room_id}/messages",
+        params={"dir": "b", "limit": 100},
+        headers={"Authorization": f"Bearer {admin.access_token}"},
+    )
+    resp.raise_for_status()
+    return [
+        event
+        for event in resp.json().get("chunk", [])
+        if event.get("type") == "m.room.message"
+    ]
+
+
+async def _wait_for_message_from(
+    session_env: SessionEnv,
+    matrix_room_id: str,
+    sender_localpart: str,
+    timeout: float = 20,
+) -> dict | None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        for event in await _timeline_messages(session_env, matrix_room_id):
+            if event.get("sender", "").startswith(f"@{sender_localpart}"):
+                return event
+        await asyncio.sleep(0.5)
+    return None
+
+
+async def test_agent_posts_greeting_on_join(
+    harness: Harness, session_env: SessionEnv
+) -> None:
+    agent = await harness.register_agent("e2e-greeter")
+    await harness.start_clients()
+    client = harness.client_for(agent.agent_id)
+    await client.wait_ready()
+
+    result = await harness.room_service.create_room(
+        RoomCreateConfig(
+            name="e2e-greeting-room",
+            description="integration self-join greeting test",
+            agent_ids=[agent.agent_id],
+        )
+    )
+    matrix_room_id = result.room.matrix_room_id
+    await _wait_joined(client, matrix_room_id)
+
+    greeting = await _wait_for_message_from(
+        session_env, matrix_room_id, client.matrix_user_id.split(":")[0].lstrip("@")
+    )
+
+    assert greeting is not None, (
+        "agent joined the room but never posted a self-join greeting"
+    )
+    assert "e2e-greeter" in greeting["content"]["body"]
+
+
+async def test_no_greeting_when_the_bridge_has_them_disabled(
+    harness: Harness, session_env: SessionEnv
+) -> None:
+    """The per-connection toggle still wins over the arrival."""
+    host = await harness.register_agent("e2e-quiet-host")
+    joiner = await harness.register_agent("e2e-quiet-joiner")
+    await harness.start_clients()
+    joiner_client = harness.client_for(joiner.agent_id)
+
+    result = await harness.room_service.create_room(
+        RoomCreateConfig(
+            name="e2e-quiet-room",
+            description="integration greeting-toggle test",
+            agent_ids=[host.agent_id],
+        )
+    )
+    matrix_room_id = result.room.matrix_room_id
+    await _wait_joined(harness.client_for(host.agent_id), matrix_room_id)
+
+    # Point the room at a connection with greetings turned off. Done after
+    # creation because the harness runs no collaboration bridge — the join path
+    # only ever reads the room's bridge row, which is what is under test.
+    async with harness.session_factory() as session:
+        host_agent = await session.get(Agent, host.agent_id)
+        session.add(
+            CollaborationBridge(
+                id="quiet-bridge",
+                type="mattermost",
+                display_name="Quiet",
+                client_id=host_agent.client_id,
+                status="active",
+                agent_greetings_enabled=False,
+            )
+        )
+        room = await session.get(Room, result.room.id)
+        room.bridge_id = "quiet-bridge"
+        await session.commit()
+
+    await harness.room_service.add_agents_to_room(
+        result.room.id, agent_ids=[joiner.agent_id]
+    )
+    await _wait_joined(joiner_client, matrix_room_id)
+
+    greeting = await _wait_for_message_from(
+        session_env,
+        matrix_room_id,
+        joiner_client.matrix_user_id.split(":")[0].lstrip("@"),
+        timeout=8,
+    )
+
+    assert greeting is None, (
+        f"greeting posted despite the connection having them disabled: {greeting}"
+    )

--- a/core/tests/switch_core/clients/test_self_join_dispatch.py
+++ b/core/tests/switch_core/clients/test_self_join_dispatch.py
@@ -1,0 +1,129 @@
+"""The self-join hook must still fire when the client joined the room itself.
+
+`join_room` records membership as soon as the join returns so `wait_joined` and
+the `_should_ignore` cutoff are accurate (CHOO-1781). Auto-accepting an invite
+goes through it, so by the time the join arrives over sync the room is already
+in `room_join_times` — CHOO-2170: gating the hook on that made the agent
+greeting unreachable on every room an agent is invited to, which is all of them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from switch_core.clients.client_base import ClientBase
+
+MATRIX_ROOM_ID = "!matrix:switch.local"
+SELF = "@switch-agent-1:switch.local"
+
+
+class _Client(ClientBase):
+    def __init__(self) -> None:
+        self.matrix_user_id = SELF
+        self.room_join_times = {}
+        self._room_joined_events = {}
+        self._self_join_dispatched = set()
+        self._startup_ts = 1000
+        self.self_joins: list[str] = []
+        self.member_events: list[str] = []
+
+    async def on_self_join(self, room, event) -> None:
+        self.self_joins.append(room.room_id)
+
+    async def on_member_event(self, room, event) -> None:
+        self.member_events.append(event.state_key)
+
+
+def _room() -> SimpleNamespace:
+    return SimpleNamespace(room_id=MATRIX_ROOM_ID)
+
+
+def _member_event(
+    *,
+    state_key: str = SELF,
+    membership: str = "join",
+    prev_membership: str | None = "invite",
+    server_timestamp: int = 2000,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        state_key=state_key,
+        membership=membership,
+        prev_membership=prev_membership,
+        server_timestamp=server_timestamp,
+        sender=state_key,
+        content={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_self_join_fires_after_the_client_joined_itself() -> None:
+    client = _Client()
+    # Auto-accepting the invite records membership before sync reports the join.
+    client._mark_joined(MATRIX_ROOM_ID, 1500)
+
+    await client._handle_member_event(_room(), _member_event())
+
+    assert client.self_joins == [MATRIX_ROOM_ID]
+
+
+@pytest.mark.asyncio
+async def test_self_join_fires_only_once_for_the_same_join() -> None:
+    client = _Client()
+    event = _member_event()
+
+    await client._handle_member_event(_room(), event)
+    await client._handle_member_event(_room(), event)
+
+    assert client.self_joins == [MATRIX_ROOM_ID]
+
+
+@pytest.mark.asyncio
+async def test_profile_update_is_not_an_arrival() -> None:
+    """A display-name change re-fires m.room.member with membership == join."""
+    client = _Client()
+
+    await client._handle_member_event(
+        _room(), _member_event(prev_membership="join", server_timestamp=3000)
+    )
+
+    assert client.self_joins == []
+
+
+@pytest.mark.asyncio
+async def test_join_predating_this_process_is_not_announced() -> None:
+    client = _Client()
+
+    await client._handle_member_event(_room(), _member_event(server_timestamp=500))
+
+    assert client.self_joins == []
+
+
+@pytest.mark.asyncio
+async def test_rejoining_after_leaving_is_a_fresh_arrival() -> None:
+    client = _Client()
+
+    await client._handle_member_event(_room(), _member_event())
+    await client._handle_member_event(
+        _room(),
+        _member_event(
+            membership="leave", prev_membership="join", server_timestamp=3000
+        ),
+    )
+    await client._handle_member_event(
+        _room(), _member_event(prev_membership="leave", server_timestamp=4000)
+    )
+
+    assert client.self_joins == [MATRIX_ROOM_ID, MATRIX_ROOM_ID]
+
+
+@pytest.mark.asyncio
+async def test_another_member_joining_is_not_a_self_join() -> None:
+    client = _Client()
+    other = "@switch-agent-2:switch.local"
+
+    await client._handle_member_event(_room(), _member_event(state_key=other))
+
+    assert client.self_joins == []
+    assert client.member_events == [other]


### PR DESCRIPTION
## The cause

The greeting was never repaired because it was never broken — **the trigger stopped firing.**

An agent greets a room from `AgentClient.on_self_join`, which `ClientBase._handle_member_event` dispatched only when the room was *absent* from `room_join_times`:

```python
already_joined = room.room_id in self.room_join_times
self._mark_joined(room.room_id, event.server_timestamp)
if not already_joined and event.server_timestamp >= self._startup_ts:
    await self.on_self_join(room, event)
```

`8be349d6` (CHOO-1781, 29 Jul, shipped in 0.9.0) routed the invite auto-accept through `join_room` so `wait_joined` could resolve on an explicit join:

```diff
-        await self.client.join(room.room_id)
+        await self.join_room(room.room_id)
```

`join_room` records the room in `room_join_times` the moment the join returns. Agents are added to rooms by invite, so from that commit on the room was *always* already recorded by the time the agent's own join arrived over sync. `already_joined` was always true, `on_self_join` never ran, and no agent has greeted a room in about two and a half weeks — on every connection, whatever the per-connection greeting toggle said.

Bisected with a live probe: good on `724ccf2c`, bad on `8be349d6` and every commit since.

## The fix

Whether the arrival has been *announced* is now tracked separately from membership, which the bridge needs recorded as early as possible for `wait_joined` and the `_should_ignore` cutoff. Membership being known is not evidence the arrival was announced.

Alongside it, two things the old guard was doing implicitly are now explicit: a membership-preserving `m.room.member` re-fire (display name, avatar) is not an arrival, and a departure resets the room so being added back greets again.

## Why nothing caught it

- `test_join_greeting_suppression.py` calls `AgentClient.on_self_join` directly. It proves the greeting *would* work if something called it — it cannot detect that nothing does. All four tests stayed green throughout.
- The integration suite drives the real join path and would have caught it, but it is excluded from the default run *and* from CI, and had drifted behind `RoomService`, `ProtocolService` and `AgentClient` — every test errored during setup, unnoticed.

So this adds the missing coverage in the **default** suite (`test_self_join_dispatch.py`, six cases on the dispatch itself) and repairs the integration wiring, with a live end-to-end test of both toggle states.

Not done here: putting the integration suite back in CI. Worth a follow-up — it is the only layer that can see this class of bug.

## Verified live

On a real stack — switch-core from this branch, real Tuwunel, real Mattermost bridge, real rooms:

| | greeting in the Mattermost channel |
|---|---|
| before the fix, greetings enabled | none |
| after the fix, greetings enabled | posted |
| after the fix, greetings disabled | none |

`just test` 1514 passed · `just test-integration` 5 passed · `just check` · `just typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)