### PR TITLE
fix(console): make Collapse all collapse, and sidebar row menus act (CHOO-2173)

### DIFF
--- a/console/apps/switch-console-desktop/src/renderer/features/sidebar/room-tree.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/sidebar/room-tree.tsx
@@ -17,6 +17,7 @@ import {
   openRoomView,
   RoomRow,
   roomLabel,
+  sessionRoomId,
 } from './sidebar-room-grouping';
 import { roomAgentGroupKey, roomViewGroupKey, UNASSIGNED_ROOM_KEY } from './sidebar-store';
 import {
@@ -62,6 +63,30 @@ function membersByRoom(): Map<string, AgentEntry[]> {
   return byRoom;
 }
 
+/**
+ * Every room this tree puts a top-level row under, before filters narrow it: one
+ * of this app's agents is a member of it, a visible session is connected to it,
+ * or it is listed on its own account — every room on a server this install
+ * manages, and rooms you created elsewhere. None of that waits on a session, so
+ * a room you just made is there immediately.
+ *
+ * Shared with Collapse all, which needs the same set of rows without the tree
+ * being on screen to ask.
+ */
+export function listedRoomKeys(): string[] {
+  const keys = new Set<string>([
+    ...switchRoomsStore.listedRoomsInActiveScope.map((room) => room.id),
+    ...membersByRoom().keys(),
+  ]);
+  for (const entry of scopedAgents()) {
+    for (const session of agentSessions(entry)) {
+      const roomKey = sessionRoomId(session);
+      if (roomKey) keys.add(roomKey);
+    }
+  }
+  return [...keys];
+}
+
 export const RoomTree = observer(function RoomTree() {
   const showAddAgentsToRoomModal = useShowModal('addAgentsToRoomModal');
   const showDeleteRoomModal = useShowModal('deleteRoomModal');
@@ -77,16 +102,7 @@ export const RoomTree = observer(function RoomTree() {
   }
 
   const members = membersByRoom();
-  // A room is listed when one of this app's agents is a member of it, when it
-  // has a session, or when it is listed on its own account — every room on a
-  // server this install manages, and rooms you created elsewhere. None of that
-  // waits on a session, so a room you just made is there immediately.
-  const alwaysShow = [
-    ...new Set([
-      ...switchRoomsStore.listedRoomsInActiveScope.map((room) => room.id),
-      ...members.keys(),
-    ]),
-  ];
+  const alwaysShow = listedRoomKeys();
 
   const sorted = sortRoomGroups(
     filterRoomGroups(

--- a/console/apps/switch-console-desktop/src/renderer/features/sidebar/session-sidebar-agent-status.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/sidebar/session-sidebar-agent-status.tsx
@@ -3,18 +3,16 @@ import { AgentStatusIndicator } from '@renderer/features/sessions/components/age
 import { sessionAgentStatus } from '@renderer/features/sessions/stores/session-selectors';
 import { type SessionStore } from '@renderer/features/sessions/stores/session-store';
 import { useDelayedBoolean } from '@renderer/lib/hooks/use-delay-boolean';
-import { sidebarStore } from '@renderer/lib/stores/app-state';
-import { RelativeTime } from '@renderer/lib/ui/relative-time';
 import { Spinner } from '@renderer/lib/ui/spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
-import { getSortInstant, sortKindFor } from './sidebar-store';
 
 /**
- * Sidebar trailing slot: a spinner while the session is being created or its
- * agent is working, otherwise the relative timestamp. The whole metadata
- * cluster is right-aligned by the parent, so the slot just hugs its content —
- * no fixed width to avoid an empty gap between the timestamp and the
- * line-changes / PR icon to its left.
+ * Sidebar trailing slot: a spinner while the session is being created, the
+ * status dot while its agent is working, and nothing at all otherwise. A row
+ * that is not doing anything says nothing here.
+ *
+ * The width is fixed so a spinner appearing does not shorten the title beside
+ * it, and the parent right-aligns the cluster.
  */
 function Slot({ children }: { children: React.ReactNode }) {
   return <span className="flex w-[3ch] shrink-0 items-center justify-end">{children}</span>;
@@ -42,9 +40,8 @@ export const SessionSidebarTrailingSlot = observer(function SessionSidebarTraili
     );
   }
 
-  // Only a working agent takes the slot from the timestamp. The other non-idle
-  // states no longer draw anything, so testing for "not idle" here would hand
-  // the slot to an indicator that renders nothing and blank the time instead.
+  // Only a working agent draws here. The other non-idle states render nothing,
+  // so testing for "not idle" would fill the slot with an empty indicator.
   if (sessionAgentStatus(session) === 'working') {
     return (
       <Slot>
@@ -53,16 +50,5 @@ export const SessionSidebarTrailingSlot = observer(function SessionSidebarTraili
     );
   }
 
-  const instant = getSortInstant(session, sortKindFor(sidebarStore.sessionSortBy));
-  if (!instant) return null;
-
-  return (
-    <Slot>
-      <RelativeTime
-        value={instant}
-        className="font-mono text-xs text-foreground-passive tabular-nums"
-        compact
-      />
-    </Slot>
-  );
+  return null;
 });

--- a/console/apps/switch-console-desktop/src/renderer/features/sidebar/sessions-section-header.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/sidebar/sessions-section-header.tsx
@@ -33,6 +33,9 @@ import { cn } from '@renderer/utils/utils';
 import type { AgentConnectionKind } from '@shared/core/agents/agent-connection';
 import { getProvider } from '@shared/core/providers/agent-provider-registry';
 import { type SidebarGrouping, UNBRIDGED_FILTER_VALUE } from '@shared/view-state';
+import { listedRoomKeys } from './room-tree';
+import { agentExpandKey, roomViewGroupKey } from './sidebar-store';
+import { scopedAgents } from './sidebar-tree-data';
 
 const CONNECTION_LABEL: Record<AgentConnectionKind, string> = {
   local: 'Local',
@@ -43,6 +46,19 @@ const GROUPING_OPTIONS: { value: SidebarGrouping; label: string }[] = [
   { value: 'agent', label: 'By Agent' },
   { value: 'room', label: 'By Room' },
 ];
+
+/**
+ * The keys of the top-level rows the tree on screen draws — agents in the
+ * agent-focused view, rooms in the room-focused one. Only the grouping being
+ * looked at is named: collapsing the other one would be a change the user never
+ * asked for and would not see until they switched.
+ */
+function topLevelGroupKeys(): string[] {
+  if (sidebarStore.grouping === 'room') {
+    return listedRoomKeys().map(roomViewGroupKey);
+  }
+  return scopedAgents().map((entry) => agentExpandKey(entry.agent.id));
+}
 
 /**
  * View switcher for the grouped sidebar — a segmented control that shows both
@@ -291,7 +307,7 @@ export const SessionsSectionHeader = observer(function SessionsSectionHeader() {
                 Clear filters
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => sidebarStore.collapseAll()}>
+              <DropdownMenuItem onClick={() => sidebarStore.collapseAll(topLevelGroupKeys())}>
                 <ChevronsDownUp className="mr-1.5 h-4 w-4" />
                 Collapse all
               </DropdownMenuItem>

--- a/console/apps/switch-console-desktop/src/renderer/features/sidebar/sidebar-room-grouping.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/sidebar/sidebar-room-grouping.tsx
@@ -235,7 +235,7 @@ export function RoomRow({
               </SidebarItemMiniButton>
             }
           />
-          <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+          <DropdownMenuContent align="end">
             {onAddAgent && (
               <DropdownMenuItem onClick={onAddAgent}>
                 <Plus className="size-4" />

--- a/console/apps/switch-console-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -201,6 +201,41 @@ describe('SidebarStore grouping', () => {
     expect(store.isGroupExpanded(roomViewGroupKey('room-1'))).toBe(true);
   });
 
+  it('closes the branches Collapse all names', () => {
+    // The regression this guards: collapseAll used to clear expandedLocationIds
+    // and expandedRoomKeys, which no tree has read since the sidebar was
+    // regrouped around agents and rooms — so the button moved nothing on screen.
+    const store = new SidebarStore(locationManager([]));
+
+    store.collapseAll([agentExpandKey('agent-1'), agentExpandKey('agent-2')]);
+
+    expect(store.isGroupExpanded(agentExpandKey('agent-1'))).toBe(false);
+    expect(store.isGroupExpanded(agentExpandKey('agent-2'))).toBe(false);
+  });
+
+  it('leaves branches Collapse all was not given open', () => {
+    // The caller passes only the grouping on screen, so collapsing in one view
+    // must not rearrange the other one behind the user's back.
+    const store = new SidebarStore(locationManager([]));
+
+    store.collapseAll([agentExpandKey('agent-1')]);
+
+    expect(store.isGroupExpanded(roomViewGroupKey('room-1'))).toBe(true);
+  });
+
+  it('leaves a nested group as the user left it when its parent collapses', () => {
+    // Reopening an agent should show the rooms under it the way they were, not
+    // a tree flattened by a button pressed at the top level.
+    const store = new SidebarStore(locationManager([]));
+    store.toggleGroupExpanded(agentRoomGroupKey('agent-1', 'room-1'));
+
+    store.collapseAll([agentExpandKey('agent-1')]);
+    store.toggleGroupExpanded(agentExpandKey('agent-1'));
+
+    expect(store.isGroupExpanded(agentExpandKey('agent-1'))).toBe(true);
+    expect(store.isGroupExpanded(agentRoomGroupKey('agent-1', 'room-1'))).toBe(false);
+  });
+
   it('collapses one agent-under-room without collapsing the same agent elsewhere', () => {
     // An agent in two rooms is two rows in two places, not one row drawn twice.
     // Keyed by agent alone they collapsed and highlighted together.

--- a/console/apps/switch-console-desktop/src/renderer/features/sidebar/sidebar-store.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/sidebar/sidebar-store.ts
@@ -533,18 +533,19 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
   }
 
   /**
-   * Close every top-level branch of the tree, in whichever grouping is on
-   * screen. Second-level groups are left alone: they are tracked inverted
-   * (absence means open), so collapsing them would mean enumerating every key
-   * that exists, and they are hidden under a closed parent anyway.
+   * Close every top-level branch of the tree on screen.
    *
-   * A location re-expands on its own if a session starts in it while
-   * collapsed — see the reaction in the constructor. That is deliberate: a new
-   * session appearing nowhere visible is worse than a branch reopening.
+   * The keys come from the caller because the trees, not the store, decide what
+   * they list — which agents are in scope, which rooms are worth a row. Group
+   * openness is tracked inverted (absence means open), so closing a branch means
+   * naming its key; there is nothing to clear.
+   *
+   * Second-level groups are left alone. They are hidden under a closed parent
+   * anyway, and reopening a parent to find its children as you left them is what
+   * a tree is expected to do.
    */
-  collapseAll(): void {
-    this.expandedLocationIds.clear();
-    this.expandedRoomKeys.clear();
+  collapseAll(topLevelKeys: readonly string[]): void {
+    for (const key of topLevelKeys) this.collapsedGroupKeys.add(key);
   }
 
   toggleLocationExpanded(locationId: string): void {

--- a/console/apps/switch-console-desktop/src/renderer/lib/ui/dropdown-menu.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/lib/ui/dropdown-menu.tsx
@@ -21,6 +21,7 @@ function DropdownMenuContent({
   side = 'bottom',
   sideOffset = 4,
   className,
+  onClick,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<MenuPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'>) {
@@ -35,6 +36,14 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
+          // The popup is portalled out of the DOM but not out of the React tree,
+          // so a click on a menu item still reaches whatever the trigger sits
+          // inside. On a clickable row that means the row's own handler fires
+          // straight after the item's, undoing it.
+          onClick={(event) => {
+            event.stopPropagation();
+            onClick?.(event);
+          }}
           className={cn(
             'z-50 max-h-(--available-height) w-(--anchor-width) min-w-48 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-background-quaternary p-1 text-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95',
             className

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/dropdown-menu-row-click.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/dropdown-menu-row-click.test.tsx
@@ -1,0 +1,100 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+/**
+ * A dropdown menu inside a clickable row (CHOO-2173).
+ *
+ * Base UI portals the popup out of the DOM but not out of the React tree, so a
+ * click on a menu item still bubbles to whatever the trigger sits inside. On a
+ * sidebar row that meant the row's own handler ran straight after the item's:
+ * pick Delete on a session and the row reopened the session on top of it, so
+ * every action in that menu looked dead while the same action on the right-click
+ * menu — a sibling of the row, not a child — worked.
+ */
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@renderer/lib/ui/dropdown-menu';
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+async function render(node: React.ReactNode): Promise<HTMLDivElement> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => root!.render(node));
+  return container;
+}
+
+/** A row that does something when clicked, with an actions menu on it — the
+ * shape every session and room row in the sidebar has. */
+function row({ onRowClick, onDelete }: { onRowClick: () => void; onDelete: () => void }) {
+  return (
+    <div onClick={onRowClick} onMouseDown={(e) => e.preventDefault()}>
+      <span>A session</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger aria-label="Actions for session" onClick={(e) => e.stopPropagation()}>
+          Actions
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={onDelete}>Delete…</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+async function openMenu(el: HTMLElement): Promise<void> {
+  const trigger = el.querySelector<HTMLElement>('[aria-label="Actions for session"]');
+  expect(trigger).not.toBeNull();
+  await act(async () => trigger!.click());
+}
+
+function menuItem(label: string): HTMLElement {
+  const found = [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find(
+    (item) => item.textContent?.trim() === label
+  );
+  expect(found, `no menu item labelled ${label}`).toBeDefined();
+  return found!;
+}
+
+describe('a dropdown menu on a clickable row', () => {
+  it('runs the action the item was given', async () => {
+    const onDelete = vi.fn();
+    const el = await render(row({ onRowClick: () => {}, onDelete }));
+    await openMenu(el);
+
+    await act(async () => menuItem('Delete…').click());
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not also click the row underneath it', async () => {
+    const onRowClick = vi.fn();
+    const el = await render(row({ onRowClick, onDelete: () => {} }));
+    await openMenu(el);
+
+    await act(async () => menuItem('Delete…').click());
+
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('opens without clicking the row either', async () => {
+    const onRowClick = vi.fn();
+    const el = await render(row({ onRowClick, onDelete: () => {} }));
+
+    await openMenu(el);
+
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Two UI faults in the redesigned Switch Console sidebar, reported together under [CHOO-2173](https://sandboxquantum.atlassian.net/browse/CHOO-2173).

## Collapse all did nothing

`collapseAll()` cleared `expandedLocationIds` and `expandedRoomKeys`. Neither has driven a rendered row since the sidebar was regrouped around agents and rooms — both trees read the inverted `collapsedGroupKeys` set through `isGroupExpanded()`. The button emptied state nothing draws from.

Because openness is tracked by absence, collapsing has to name the keys. Which rows exist is the trees' business rather than the store's, so the caller passes them and `collapseAll` only writes them down. `RoomTree`'s room list moves into an exported `listedRoomKeys()` so Collapse all closes exactly the rows that tree draws.

Clearing `expandedLocationIds` was also wiping the list behind Next/Previous Session, which stops.

## Session row menu actions were dead, right-click worked

Base UI portals a popup out of the DOM but not out of the React tree, so a click on a menu item still bubbles to whatever the trigger sits inside — here the sidebar row, whose own handler opens the session. Delete and Archive ran and were immediately buried by the row reopening the session on top of them. Right-click was unaffected because `ContextMenuContent` is a sibling of the row rather than a child, which is exactly the asymmetry reported.

`RoomRow` had already hit this and carried its own `stopPropagation` on the popup. The guard belongs in the shared `DropdownMenuContent`, so it moves there and the one-off comes out.

## Tests

- Three store tests for `collapseAll`: it closes what it is given, leaves the other grouping alone, and does not flatten nested groups under a collapsed parent.
- A browser test rendering the real primitive in the shape the bug needs — a dropdown on a clickable row. Verified it fails without the fix (the row handler fires twice) and passes with it.
- `node` and `browser` suites green (2575 tests); typecheck, lint and format clean.

No version bumps — left to the releaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-2173]: https://sandboxquantum.atlassian.net/browse/CHOO-2173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ