### PR TITLE
release: batch — core 0.17.0, console 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.17.0] - 2026-08-16
+
+#### Added
+
+- Agents can carry a custom icon. Switch stores a per-agent `icon_url` — a link,
+  never image bytes — accepted at registration and set, changed or cleared
+  through a dedicated `set_agent_icon` operation and `PUT /agents/{id}/icon`; it
+  is reported on the agent summary and detail. The Mattermost bridge fetches the
+  icon and re-uploads it as the bot avatar. Because Switch itself dereferences
+  the URL, it is validated to an absolute `https` address with no embedded
+  credentials and refused when it names a local, private, loopback or
+  link-local host (CHOO-2171).
+
 #### Fixed
 
 - An agent joining a room greets it again. The greeting fires when an agent
@@ -58,6 +71,10 @@ version of their own to them without also giving them a release of their own.
   `RoomService`, `ProtocolService` and `AgentClient`, so every test errored
   during setup — unnoticed, because the suite is excluded from the default run
   and from CI. It is the suite that would have caught the greeting regression.
+- The bundled-stack **setup image** links the seeded Mattermost admin to its
+  owner, so a freshly seeded managed deployment comes up already knowing which
+  chat account the owner is — owner-only addressing then works without the owner
+  linking an account by hand first (CHOO-2172).
 
 ### [0.16.0] - 2026-08-15
 
@@ -617,6 +634,32 @@ version of their own to them without also giving them a release of their own.
 ## switch-console
 
 ### [Unreleased]
+
+### [0.27.0] - 2026-08-16
+
+#### Added
+
+- Give an agent a custom icon. The add-agent dialog and an agent's settings
+  carry an icon picker — set, change, or clear it; cleared means an icon
+  generated from the agent's name. Icons render in the sidebar, the agent pages
+  and dialogs, and existing agents are backfilled on first run (CHOO-2171).
+
+#### Changed
+
+- Local-server mode now bundles and pulls **switch-core `0.17.0`** (was
+  `0.16.0`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release.
+
+#### Fixed
+
+- **Collapse all** collapses again. It cleared state the redesigned sidebar no
+  longer reads, so nothing moved; it now names the rows to collapse. Clearing
+  that state had also been dropping Next/Previous Session's list of visible
+  sessions, which stops (CHOO-2173).
+- A sidebar session row's **actions menu acts** — Delete and Archive ran but the
+  row's own click handler reopened the session on top of them, so they looked
+  inert (right-click was unaffected because it is a sibling of the row). The
+  guard now lives in the shared popup (CHOO-2173).
 
 ### [0.26.0] - 2026-08-16
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.16.0
+    version: 0.17.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.26.0
+    version: 0.27.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.16.0
+      switch-core: 0.17.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.16.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.17.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.16.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.17.0';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.16.0',
-  'switch-console': '0.26.0',
+  'switch-core': '0.17.0',
+  'switch-console': '0.27.0',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
-  gateway: '0.16.0',
-  setup: '0.16.0',
-  'helm-chart': '0.16.0',
-  compose: '0.16.0',
+  gateway: '0.17.0',
+  setup: '0.17.0',
+  'helm-chart': '0.17.0',
+  compose: '0.17.0',
   'switch-connector': '0.9.4',
   'switch-connector-codex': '0.3.5',
   'switch-connector-opencode': '0.1.2',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.16.0',
-  'switch-console': '0.26.0',
+  'switch-core': '0.17.0',
+  'switch-console': '0.27.0',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
-  gateway: '0.16.0',
-  setup: '0.16.0',
-  'helm-chart': '0.16.0',
-  compose: '0.16.0',
+  gateway: '0.17.0',
+  setup: '0.17.0',
+  'helm-chart': '0.17.0',
+  compose: '0.17.0',
   'switch-connector': '0.9.4',
   'switch-connector-codex': '0.3.5',
   'switch-connector-opencode': '0.1.2',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.16.0"
+version = "0.17.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.16.0",
-    "switch-console": "0.26.0",
+    "switch-core": "0.17.0",
+    "switch-console": "0.27.0",
     "agent-runtime": "0.3.1",
     "sidecar": "1.9.3",
-    "gateway": "0.16.0",
-    "setup": "0.16.0",
-    "helm-chart": "0.16.0",
-    "compose": "0.16.0",
+    "gateway": "0.17.0",
+    "setup": "0.17.0",
+    "helm-chart": "0.17.0",
+    "compose": "0.17.0",
     "switch-connector": "0.9.4",
     "switch-connector-codex": "0.3.5",
     "switch-connector-opencode": "0.1.2",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Combined release batch of everything with unreleased changes since #233.

## Contents
- **switch-core `0.16.0 → 0.17.0`** (minor) — custom per-agent icons: `icon_url` on the agent model, a `set_agent_icon` op + `PUT /agents/{id}/icon`, accepted at registration, Mattermost re-uploads it as the bot avatar, https-only validation (CHOO-2171, #237); greet-a-room-on-join fix (CHOO-2170, #235); the bundled **setup image** links the seeded Mattermost admin to the owner (CHOO-2172, #234).
- **switch-console `0.26.0 → 0.27.0`** (minor) — agent icon picker + display + backfill (#237); Collapse-all and sidebar row-menu actions fixed (CHOO-2173, #236). **Bundle pin → switch-core `0.17.0`** (`pins.switch-core` + both `COMPATIBLE_SWITCH_VERSION`) — the managed-server pin.
- **sidecar** (`1.9.3`), **agent-runtime** (`0.3.1`) and all three connector plugins unchanged. No runtime pin moves.

## Authored changelog entries (please eyeball)
The PRs didn't add changelog entries, so these are authored here: **#237** (core + console icons), **#234** (core setup-image seeding), **#236** (console sidebar fix). switch-core `[Unreleased]` had only #235; console `[Unreleased]` was empty.

## Contracts
**gateway-api / agent-protocol left at `1/1`.** #237 adds `PUT …/icon` + `icon_url` on `GET /agents` (gateway-api) and `set_agent_icon` + `icon_url` at registration (agent-protocol) — all additive/backward-compatible, core+console ship together (confirmed with the requester).

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes. `uv.lock` re-locked.

## Tagging plan (off the merge commit)
1. `switch-v0.17.0` — ungated, so images exist before the console bundle pins them.
2. `switch-console-v0.27.0` — macOS build gated on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)