### PR TITLE
release: switch-core 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.17.1] - 2026-08-16
+
+#### Fixed
+
+- Agent avatars no longer show a bright square on Slack's dark message list. A
+  generated avatar is a transparent DiceBear PNG and Slack composites it onto
+  white; newly generated icon URLs now name Slack's resting dark surface as the
+  background instead. Only newly generated URLs change — an icon already stored
+  keeps its URL (#239).
+
 ### [0.17.0] - 2026-08-16
 
 #### Added

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.17.0
+    version: 0.17.1
     declared_in: core/pyproject.toml
     published_as: switch-core
 

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.17.0',
+  'switch-core': '0.17.1',
   'switch-console': '0.27.0',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
-  gateway: '0.17.0',
-  setup: '0.17.0',
-  'helm-chart': '0.17.0',
-  compose: '0.17.0',
+  gateway: '0.17.1',
+  setup: '0.17.1',
+  'helm-chart': '0.17.1',
+  compose: '0.17.1',
   'switch-connector': '0.9.4',
   'switch-connector-codex': '0.3.5',
   'switch-connector-opencode': '0.1.2',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.17.0',
+  'switch-core': '0.17.1',
   'switch-console': '0.27.0',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
-  gateway: '0.17.0',
-  setup: '0.17.0',
-  'helm-chart': '0.17.0',
-  compose: '0.17.0',
+  gateway: '0.17.1',
+  setup: '0.17.1',
+  'helm-chart': '0.17.1',
+  compose: '0.17.1',
   'switch-connector': '0.9.4',
   'switch-connector-codex': '0.3.5',
   'switch-connector-opencode': '0.1.2',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.17.0"
+version = "0.17.1"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.17.0",
+    "switch-core": "0.17.1",
     "switch-console": "0.27.0",
     "agent-runtime": "0.3.1",
     "sidecar": "1.9.3",
-    "gateway": "0.17.0",
-    "setup": "0.17.0",
-    "helm-chart": "0.17.0",
-    "compose": "0.17.0",
+    "gateway": "0.17.1",
+    "setup": "0.17.1",
+    "helm-chart": "0.17.1",
+    "compose": "0.17.1",
     "switch-connector": "0.9.4",
     "switch-connector-codex": "0.3.5",
     "switch-connector-opencode": "0.1.2",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Patch release of switch-core — one fix since `0.17.0`.

## Contents
- **switch-core `0.17.0 → 0.17.1`** (patch) — agent avatars no longer show a bright square on Slack's dark message list; newly generated icon URLs name Slack's resting dark surface as the background (only newly generated URLs change) (#239). *Changelog entry authored here — the PR added none.*

## Not releasing
console (`0.27.0`), sidecar (`1.9.3`), agent-runtime (`0.3.1`) and all plugins are unchanged. The console bundle pin / `COMPATIBLE_SWITCH_VERSION` deliberately stay at core `0.17.0` — no console release in this cut, so managed-server users pick up `0.17.1` at the next console bump. No contract changes (bridge-internal rendering).

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes.

## Tagging plan
`switch-v0.17.1` off the merge commit (ungated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)