### PR TITLE
release: switch-console 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -645,6 +645,15 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.27.1] - 2026-08-17
+
+#### Changed
+
+- Local-server mode now bundles and pulls **switch-core `0.17.1`** (was
+  `0.17.0`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release, so a managed stack picks up the Slack avatar-background
+  fix (#239).
+
 ### [0.27.0] - 2026-08-16
 
 #### Added

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.27.0
+    version: 0.27.1
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.17.0
+      switch-core: 0.17.1
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.17.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.17.1';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.17.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.17.1';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.17.1',
-  'switch-console': '0.27.0',
+  'switch-console': '0.27.1',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
   gateway: '0.17.1',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.17.1',
-  'switch-console': '0.27.0',
+  'switch-console': '0.27.1',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
   gateway: '0.17.1',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,7 +21,7 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.17.1",
-    "switch-console": "0.27.0",
+    "switch-console": "0.27.1",
     "agent-runtime": "0.3.1",
     "sidecar": "1.9.3",
     "gateway": "0.17.1",


### PR DESCRIPTION
Patch release of Switch Console — bundle-pin bump only.

## Contents
- **switch-console `0.27.0 → 0.27.1`** (patch) — local-server mode now bundles and pulls **switch-core `0.17.1`** (was `0.17.0`): `pins.switch-core` + both `COMPATIBLE_SWITCH_VERSION` raised to the current core release, so a managed stack picks up the Slack avatar-background fix (#239).

No console code changed since `0.27.0`. Core/sidecar/agent-runtime/plugins untouched. No contract changes.

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes (pin and `COMPATIBLE_SWITCH_VERSION` both at `0.17.1`).

## Tagging plan
`switch-console-v0.27.1` off the merge commit — macOS build gated on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)