### PR TITLE
release: batch — core 0.17.2, console 0.27.2, plugins 0.9.5/0.3.6/0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,20 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.17.2] - 2026-08-18
+
+#### Fixed
+
+- The collaboration-bridge runtime status is delivered where the reply is. When
+  an agent was addressed at channel level its reply opened a thread on the
+  triggering message while the status line stayed at the channel root, so the
+  two landed in different places. Adapters can now opt into anchoring the status
+  on the triggering message; Mattermost takes it — where a thread is a side
+  panel, a status left at the root is the one nobody opens. The typing indicator
+  is reported against the trigger's actual location (channel vs thread) rather
+  than the status's, so it shows where the person who addressed the agent is
+  watching (CHOO-2173).
+
 ### [0.17.1] - 2026-08-16
 
 #### Fixed
@@ -645,6 +659,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.27.2] - 2026-08-18
+
 #### Added
 
 - Switch Console now asks, the first time you open it, whether you are happy to
@@ -657,9 +673,36 @@ version of their own to them without also giving them a release of their own.
   that has not reached the prompt sends nothing regardless of how the toggle
   reads. Because the toggle defaults to on, `console/AGENTS.md` now pins what a
   payload may ever contain: anonymous counters, and no identifier of any kind.
+- A signed, notarized **Intel (x86_64) macOS build**. macOS now builds per-arch
+  on native runners, so an Intel Mac has an installer again after the app went
+  Apple-silicon-only; the auto-update channel manifest is written per arch so
+  the two builds no longer overwrite each other's update feed (CHOO-2195).
+
+#### Changed
+
+- Local-server mode now bundles and pulls **switch-core `0.17.2`** (was
+  `0.17.1`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release.
+- The add-agent addressing control is renamed **"Who can talk to your agent"**,
+  and its Settings section now unfolds itself when the owner-only default would
+  reach nobody, so the warning that the agent will answer no one on that
+  messaging app is visible instead of hidden in the fold (CHOO-2173).
 
 #### Fixed
 
+- An auto-started session now receives the message it was started for. Its room
+  connection opens before the terminal is spawned, so the replayed trigger had
+  nowhere to go and — unlike the other wait paths — never retried: the agent
+  booted, greeted, and never answered. It now retries until the connection
+  closes, and a pty accepts injected input only once the runtime has delivered
+  the session's opening prompt, so the trigger can't be appended to that prompt
+  and sent as one (CHOO-2173).
+- The agent tree no longer highlights every copy of an open room, and the
+  titlebar breadcrumb shows the agent's own icon rather than its provider logo
+  (CHOO-2173).
+- User-facing error messages across the app were audited and rewritten to say
+  what happened and what to do, rather than surfacing raw internal errors
+  (CHOO-2060).
 - Two Switch Console installs sharing a host no longer destroy each other's
   agents. Per-agent credentials live at `.switch/agents/<name>.json`, keyed by
   name alone, and each install's uniqueness check only sees its own database —
@@ -1972,6 +2015,17 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
+### [0.9.5] - 2026-08-18
+
+#### Changed
+
+- The room-workflow skill no longer teaches the task protocol as an interaction
+  mode: the lifecycle section is replaced by a short note that the protocol
+  exists, is registered on the server, and must not be called yet, and the
+  guidance to delegate rather than message is removed. The scoped-addressing
+  material moves to its own section. Documentation only — the MCP/HTTP tool
+  surface is unchanged (CHOO-1418).
+
 ### [0.9.4] - 2026-08-15
 
 #### Changed
@@ -2073,6 +2127,17 @@ manifest history.
 `connectors/codex-plugin/`. Version lives in `.codex-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.3.6] - 2026-08-18
+
+#### Changed
+
+- The room-workflow skill no longer teaches the task protocol as an interaction
+  mode: the lifecycle section is replaced by a short note that the protocol
+  exists, is registered on the server, and must not be called yet, and the
+  guidance to delegate rather than message is removed. The scoped-addressing
+  material moves to its own section. Documentation only — the MCP/HTTP tool
+  surface is unchanged (CHOO-1418).
 
 #### Fixed
 
@@ -2192,6 +2257,17 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.3] - 2026-08-18
+
+#### Changed
+
+- The room-workflow skill no longer teaches the task protocol as an interaction
+  mode: the lifecycle section is replaced by a short note that the protocol
+  exists, is registered on the server, and must not be called yet, and the
+  guidance to delegate rather than message is removed. The scoped-addressing
+  material moves to its own section. Documentation only — the MCP/HTTP tool
+  surface is unchanged (CHOO-1418).
 
 ### [0.1.2] - 2026-08-15
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.17.1
+    version: 0.17.2
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.27.1
+    version: 0.27.2
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.17.1
+      switch-core: 0.17.2
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.4
+    version: 0.9.5
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.5
+    version: 0.3.6
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.2
+    version: 0.1.3
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.17.1';
+export const COMPATIBLE_SWITCH_VERSION = '0.17.2';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.17.1';
+export const COMPATIBLE_SWITCH_VERSION = '0.17.2';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.17.1',
-  'switch-console': '0.27.1',
+  'switch-core': '0.17.2',
+  'switch-console': '0.27.2',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
-  gateway: '0.17.1',
-  setup: '0.17.1',
-  'helm-chart': '0.17.1',
-  compose: '0.17.1',
-  'switch-connector': '0.9.4',
-  'switch-connector-codex': '0.3.5',
-  'switch-connector-opencode': '0.1.2',
+  gateway: '0.17.2',
+  setup: '0.17.2',
+  'helm-chart': '0.17.2',
+  compose: '0.17.2',
+  'switch-connector': '0.9.5',
+  'switch-connector-codex': '0.3.6',
+  'switch-connector-opencode': '0.1.3',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.17.1',
-  'switch-console': '0.27.1',
+  'switch-core': '0.17.2',
+  'switch-console': '0.27.2',
   'agent-runtime': '0.3.1',
   sidecar: '1.9.3',
-  gateway: '0.17.1',
-  setup: '0.17.1',
-  'helm-chart': '0.17.1',
-  compose: '0.17.1',
-  'switch-connector': '0.9.4',
-  'switch-connector-codex': '0.3.5',
-  'switch-connector-opencode': '0.1.2',
+  gateway: '0.17.2',
+  setup: '0.17.2',
+  'helm-chart': '0.17.2',
+  compose: '0.17.2',
+  'switch-connector': '0.9.5',
+  'switch-connector-codex': '0.3.6',
+  'switch-connector-opencode': '0.1.3',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.17.1"
+version = "0.17.2"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,17 +20,17 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.17.1",
-    "switch-console": "0.27.1",
+    "switch-core": "0.17.2",
+    "switch-console": "0.27.2",
     "agent-runtime": "0.3.1",
     "sidecar": "1.9.3",
-    "gateway": "0.17.1",
-    "setup": "0.17.1",
-    "helm-chart": "0.17.1",
-    "compose": "0.17.1",
-    "switch-connector": "0.9.4",
-    "switch-connector-codex": "0.3.5",
-    "switch-connector-opencode": "0.1.2",
+    "gateway": "0.17.2",
+    "setup": "0.17.2",
+    "helm-chart": "0.17.2",
+    "compose": "0.17.2",
+    "switch-connector": "0.9.5",
+    "switch-connector-codex": "0.3.6",
+    "switch-connector-opencode": "0.1.3",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.17.1"
+version = "0.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Patch release of everything with unreleased changes since #242.

## Contents
- **switch-core `0.17.1 → 0.17.2`** — collaboration-bridge runtime status threads on the trigger message's anchor (opt-in per adapter; Mattermost takes it), and the typing indicator follows the trigger's actual location (CHOO-2173, #243).
- **switch-console `0.27.1 → 0.27.2`** — signed **Intel (x86_64) macOS build** with a per-arch update manifest (CHOO-2195, #249); #243 polish (agent-tree highlight, titlebar agent icon, "Who can talk to your agent" unfold, auto-started session now receives its trigger); refuse a credentials file another install owns (CHOO-1960, #217). **Bundle pin → switch-core `0.17.2`**.
- **plugins** — Claude `0.9.4 → 0.9.5`, Codex `0.3.5 → 0.3.6`, opencode `0.1.2 → 0.1.3`: all three skills stop teaching the task protocol (exists, registered, must not be called yet) (CHOO-1418, #244); Codex also carries its configure-skill credentials fix (#217).
- **sidecar** (`1.9.3`) and **agent-runtime** (`0.3.1`) unchanged. No runtime pin moves.

## Authored changelog entries (please eyeball)
Missing on main, authored here: #243 (core + console), #249 (console), #244 (all three plugins). (#248 landed as an empty commit — its CHOO-2173 changes are in the tree via #243.)

## Contracts
No changes — Mattermost threading uses the existing runtime-state anchor; #244 is docs-only (MCP/HTTP tool surface unchanged).

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes. `uv.lock` re-locked.

## Tagging plan (off the merge commit)
1. `switch-v0.17.2` — ungated.
2. `switch-console-v0.27.2` — macOS build gated on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)