### PR TITLE
fix(console): stop the mac arch check failing on vendored prebuilds (CHOO-2195)

### DIFF
--- a/.github/workflows/switch-console-release.yml
+++ b/.github/workflows/switch-console-release.yml
@@ -189,8 +189,8 @@ jobs:
         working-directory: console/apps/switch-console-desktop
         run: |
           case "${{ matrix.arch }}" in
-            arm64) expected=arm64 ;;
-            x64) expected=x86_64 ;;
+            arm64) expected=arm64; foreign=darwin-x64 ;;
+            x64) expected=x86_64; foreign=darwin-arm64 ;;
             *) echo "::error::unhandled arch '${{ matrix.arch }}'"; exit 1 ;;
           esac
           apps=()
@@ -207,15 +207,31 @@ jobs:
           fi
           app="${apps[0]}"
           binaries=("$app/Contents/MacOS/$(basename "$app" .app)")
+          modules=0
+          skipped=0
           while IFS= read -r module; do
+            # Dependencies vendor a prebuilt binary per target — node-pty ships
+            # Windows ones, which are not Mach-O at all, next to both macOS
+            # arches. A path naming a target other than ours says nothing about
+            # what this build produced. The binaries that do — the electron-rebuild
+            # output under `build/Release` — name no target, so they are always
+            # checked.
+            case "$module" in
+              *win32*|*linux*|*"$foreign"*)
+                skipped=$((skipped + 1))
+                continue
+                ;;
+            esac
             binaries+=("$module")
+            modules=$((modules + 1))
           done < <(find "$app" -type f -name '*.node')
-          if [ "${#binaries[@]}" -lt 2 ]; then
+          if [ "$modules" -eq 0 ]; then
             # asarUnpack is what leaves the native modules on disk to inspect. If
             # they stop appearing, this check has quietly stopped checking.
-            echo "::error::found no unpacked .node under $app — cannot verify native module arch"
+            echo "::error::found no unpacked .node to check under $app — cannot verify native module arch"
             exit 1
           fi
+          echo "checking ${#binaries[@]} binaries ($skipped vendored non-$expected prebuild(s) skipped)"
           failed=""
           for binary in "${binaries[@]}"; do
             archs="$(lipo -archs "$binary" 2>/dev/null || echo "unreadable")"


### PR DESCRIPTION
The arm64 job of `switch-console-v0.27.2` failed on the architecture check added in #249, blocking the release. **The build was fine — the check was wrong.**

[Failed job](https://github.com/sandbox-quantum/switch/actions/runs/32140508388/job/95721842598)

## What happened

`node-pty` vendors a prebuilt binary for every target inside the published package. On an Apple silicon build the check walked all of them:

```
ok    arm64  .../node-pty/build/Release/pty.node
ok    arm64  .../better-sqlite3/build/Release/better_sqlite3.node
ok    arm64  .../@parcel/watcher-darwin-arm64/watcher.node
::error:: .../node-pty/prebuilds/win32-arm64/pty.node is 'unreadable', expected arm64
::error:: .../node-pty/prebuilds/darwin-x64/pty.node is 'x86_64', expected arm64
```

The Windows ones are not Mach-O at all, so `lipo` cannot read them; `prebuilds/darwin-x64/pty.node` is legitimately x86_64 sitting next to the arm64 one. Every binary the app actually loads was correct arm64.

The Intel job would have failed the same way.

## The fix

A path that names a target is describing what it was *vendored* for, not what this build *produced*, so `*win32*`, `*linux*` and the other macOS arch are skipped.

The check keeps its point. A cross-built package goes wrong in the electron-rebuild output — `node-pty/build/Release/pty.node`, `better-sqlite3/build/Release/better_sqlite3.node` — and those paths name no target, so they are always checked. Simulated against the exact file list from the failed run:

| Target | Checked | Skipped |
| --- | --- | --- |
| arm64 | 5 native modules + app binary | 4 |
| x64 | the same `build/Release` outputs | 6 |

The step now prints how many it skipped, and still fails if it is left with nothing to check — so it cannot go quiet.

## Nothing shipped wrong

The Release stayed a draft, which is the designed behaviour: `merge-mac-manifest` skips when a mac job fails, `publish-release` skips after it. 0.27.2 needs a re-run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)