### PR TITLE
feat(console): sign Windows builds with Azure Artifact Signing (CHOO-1468)

### DIFF
--- a/.github/workflows/switch-console-release.yml
+++ b/.github/workflows/switch-console-release.yml
@@ -6,9 +6,10 @@ name: Switch Console release
 #
 # macOS (arm64 and x64) is signed + notarized. Linux (x64 and arm64) builds
 # AppImage, deb and rpm, unsigned. Every macOS and Linux arch builds on a runner of
-# that arch. Windows (x64) builds nsis and msi, also unsigned — there is no
-# Authenticode identity for this app, so SmartScreen warns on first run
-# (CHOO-1468).
+# that arch. Windows (x64) builds nsis and msi, signed with Azure Artifact Signing
+# on main and tags, where the `release` environment supplies the OIDC credentials;
+# a dispatch from any other branch builds the same artifacts unsigned, and those
+# warn via SmartScreen on first run (CHOO-1468).
 #
 # The two macOS jobs do NOT upload a channel manifest. electron-builder gives Linux
 # a per-arch channel file but macOS none, so both write `latest-mac.yml` and one
@@ -456,11 +457,28 @@ jobs:
     name: Build & release (Windows x64)
     runs-on: windows-latest
     # Waits only for the Release to exist, not for the other platform builds.
-    # Windows is unsigned, so this job takes no secrets — which is also why it is
-    # not gated to `main` the way the macOS job is: it is safe to dispatch from a
-    # branch.
     needs: create-release
     if: ${{ !cancelled() && needs.create-release.result != 'failure' }}
+    # The Azure signing credentials live in the `release` environment, whose
+    # federated credential is scoped to `environment:release` — so entering it is
+    # what makes the OIDC token acceptable to Azure at all. Only main and tags may
+    # enter it. Everywhere else this resolves to no environment, the login step is
+    # skipped, and the build produces an unsigned installer rather than failing:
+    # that is what keeps a branch dispatch a usable test of everything except the
+    # signature itself.
+    environment: ${{ (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main') && 'release' || '' }}
+    permissions:
+      contents: write
+      # Required for the workflow to mint the OIDC token azure/login exchanges.
+      id-token: write
+    # Surfaced through env because the `secrets` context is not allowed in `if:`,
+    # and because electron-builder's Azure signing path reads these directly.
+    # Outside the `release` environment they are empty, which is what makes the
+    # config leave `azureSignOptions` off and produce an unsigned build.
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     # windows-latest defaults to pwsh; the scripted steps below are bash.
     defaults:
       run:
@@ -504,9 +522,43 @@ jobs:
       - name: Build workspace packages + app
         run: pnpm run build
 
+      - name: Azure login for Artifact Signing
+        # Federated OIDC, so there is no stored client secret to leak. Absent on
+        # runs outside the `release` environment, where AZURE_CLIENT_ID is empty
+        # and the package step below then builds unsigned.
+        if: ${{ env.AZURE_CLIENT_ID != '' }}
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Package (windows x64, no publish)
         working-directory: console/apps/switch-console-desktop
         run: pnpm exec electron-builder --win --publish never --config electron-builder.config.ts
+
+      - name: Report whether the installer was signed
+        # The build logs "signing with signtool.exe" whether or not a certificate
+        # was found, so the log cannot answer this. Read the PE certificate table
+        # instead, and fail a signed run that silently produced nothing.
+        working-directory: console/apps/switch-console-desktop
+        run: |
+          signed="$(node -e '
+            const fs = require("fs");
+            const d = fs.readFileSync("release/switch-console-x64.exe");
+            const pe = d.readUInt32LE(0x3c);
+            const magic = d.readUInt16LE(pe + 24);
+            const dirs = pe + 24 + (magic === 0x20b ? 112 : 96);
+            process.stdout.write(String(d.readUInt32LE(dirs + 4 * 8 + 4)));
+          ')"
+          if [ "$signed" != "0" ]; then
+            echo "Authenticode signature present ($signed bytes)."
+          elif [ -n "$AZURE_CLIENT_ID" ]; then
+            echo "::error::Azure credentials were present but the installer is unsigned."
+            exit 1
+          else
+            echo "::notice::No Azure credentials on this run — installer is unsigned, as expected."
+          fi
 
       - name: Upload to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/console/apps/switch-console-desktop/electron-builder.canary.config.ts
+++ b/console/apps/switch-console-desktop/electron-builder.canary.config.ts
@@ -85,8 +85,10 @@ const config: Configuration = {
   rpm: {
     packageName: APP_NAME_LOWER,
   },
-  // Unsigned, like the base config — see the `win` comment there before adding
-  // any signing key here.
+  // Always unsigned: no workflow builds this channel, so the Azure OIDC login the
+  // stable config's signing depends on never runs here. Adding `azureSignOptions`
+  // without that login breaks the build outright rather than leaving it unsigned —
+  // see the `hasAzureSigning` comment in the base config.
   win: {
     icon: 'src/assets/images/switch-console/app-icon-canary.png',
     target: [

--- a/console/apps/switch-console-desktop/electron-builder.config.ts
+++ b/console/apps/switch-console-desktop/electron-builder.config.ts
@@ -44,6 +44,18 @@ async function adhocSignMac(context: AfterPackContext): Promise<void> {
 // the bundle at least launches on Apple Silicon.
 const hasDeveloperIdCert = Boolean(process.env.CSC_LINK);
 
+// Azure Artifact Signing credentials reach the build as an OIDC login performed
+// by the release workflow, which only happens on main and tags. Elsewhere — a
+// branch dispatch, a fork, a local build — there is nothing to sign with, so the
+// `win.azureSignOptions` key below must be absent rather than merely unusable:
+// electron-builder picks its signing backend from that key's presence alone and
+// never checks for credentials, so leaving it set would send every build down
+// the Azure path, which shells out to PowerShell and fails without them.
+// Omitting it selects the signtool backend, which finds no certificate and skips
+// signing rather than failing. Unsigned Windows builds warn via SmartScreen but
+// install (CHOO-1468).
+const hasAzureSigning = Boolean(process.env.AZURE_CLIENT_ID);
+
 const config: Configuration = {
   // Must run AFTER electron-builder applies @electron/fuses (which rewrites the
   // Electron Framework binary and would invalidate an earlier signature). afterSign
@@ -148,28 +160,26 @@ const config: Configuration = {
   rpm: {
     packageName: APP_NAME_LOWER,
   },
-  // Windows ships UNSIGNED: there is no Authenticode identity for this app
-  // (CHOO-1468), so SmartScreen warns on first run.
-  //
-  // There is deliberately no `azureSignOptions` key. electron-builder chooses its
-  // signing backend from that key's presence alone, never checking for
-  // credentials, so setting it commits the build to Azure Trusted Signing: a
-  // PowerShell call that fails on any non-Windows host and, without credentials,
-  // on Windows too. Its absence selects the signtool backend, which finds no
-  // certificate and skips signing rather than failing.
-  //
-  // Its absence also keeps `publisherName` out of app-update.yml, which is what
-  // makes auto-update work here: electron-updater verifies an installer's
-  // Authenticode signature only when app-update.yml names a publisher, so an
-  // unsigned build that named one would reject every update it downloaded.
-  //
-  // Adding signing therefore means adding both an identity and this key together.
+  // `publisherName` is deliberately unset. electron-updater verifies a downloaded
+  // installer's Authenticode signature against the publisher named in
+  // app-update.yml, and the name has to match the certificate subject exactly —
+  // a wrong value rejects every update rather than failing at build time. Until
+  // the certificate's common name is known verbatim, leaving it unset writes no
+  // publisher into app-update.yml, which makes the updater skip that check.
+  // Signing itself is unaffected; setting the real string later strengthens it.
   win: {
     icon: 'src/assets/images/switch-console/app-icon-beta.png',
     target: [
       { target: 'nsis', arch: ['x64'] },
       { target: 'msi', arch: ['x64'] },
     ],
+    azureSignOptions: hasAzureSigning
+      ? {
+          endpoint: 'https://eus.codesigning.azure.net/',
+          codeSigningAccountName: 'cg-asa-basic-eastus',
+          certificateProfileName: 'cg-public',
+        }
+      : undefined,
   },
   msi: {
     oneClick: false,


### PR DESCRIPTION
Jira: [CHOO-1468](https://sandboxquantum.atlassian.net/browse/CHOO-1468)

Wires up the OIDC application and `release`-environment secrets provisioned by InfoSec, so Windows installers carry a real Authenticode signature instead of hitting the SmartScreen wall.

## Signing happens inside electron-builder, not after it

The obvious approach — run `azure/artifact-signing-action` over the output folder — is wrong here, in two ways:

1. By the time the installer exists, the binaries it contains are already packed inside it. Signing the outer file leaves the nested executables (`OpenConsole.exe`, `winpty-agent.exe`, the app exe, the uninstaller) unsigned.
2. Signing rewrites the file, which invalidates the sha512 and size recorded in `latest.yml` and the blockmaps — silently breaking auto-update for everyone already installed.

electron-builder signs each binary during packaging and then computes the manifests, so both problems disappear.

## Why `azureSignOptions` is conditional

electron-builder picks its signing backend from the presence of that key alone and never checks whether credentials exist. Set unconditionally, every credential-less build (branch dispatch, fork, local) would take the Azure path and fail in PowerShell — the exact breakage that left Windows unbuildable before #204. Gating on `AZURE_CLIENT_ID` keeps those builds on the signtool backend, which finds no certificate and skips signing.

## Why a branch dispatch still works

The federated credential's subject is scoped to `environment:release`, so entering that environment is what makes the OIDC token acceptable to Azure. Only main and tags may enter it. The `environment:` expression resolves to nothing elsewhere, the login step is skipped, and the build produces an unsigned installer — preserving the branch dispatch as a test of everything except the signature.

## `publisherName` deliberately unset

It must match the certificate subject exactly. A wrong value doesn't fail the build — it rejects every update the app downloads. The certificate's common name hasn't been provided yet, and unset means no publisher in `app-update.yml`, which makes electron-updater skip that check. Setting the real string later strengthens it.

## Verification step

The build logs `signing with signtool.exe` whether or not a certificate was found — the message is emitted before the attempt — so the log cannot tell you what happened. Added a step that reads the PE certificate table directly and **fails** a run that had credentials yet produced an unsigned installer.

## Testing

Branch dispatch [32140867018](https://github.com/sandbox-quantum/switch/actions/runs/32140867018) — green, Windows job reports:

```
No Azure credentials on this run — installer is unsigned, as expected.
```

That covers the fallback path and confirms the conditional environment doesn't block branch runs.

**The signed path is unverified.** It cannot run from a branch by design. After merge it needs a `workflow_dispatch` from main with the `release` environment approved. Do that before cutting a tag: if the credential chain needs adjusting, a dispatch fails harmlessly whereas a tag would leave a half-built draft Release.

Known unknown: electron-builder drives signing through Microsoft's TrustedSigning PowerShell module, whose documented credential path expects a client secret. With OIDC there is none, so it must pick up the CLI session `azure/login` establishes. If it doesn't, the fallback is writing the OIDC token to a file and pointing workload identity at it — a small follow-up, but only a real run will say.

## Follow-ups

- Get the certificate common name verbatim, then set `publisherName`.
- Confirm Public Trust identity validation has completed on `cg-public`; a Public Trust profile can exist while validation is pending.
- `INSTALL.md` still documents Windows as unsigned. Left alone deliberately until a signed build is observed — changing it now would promise users something unproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CHOO-1468]: https://sandboxquantum.atlassian.net/browse/CHOO-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ