### PR TITLE
fix(security): post-flip follow-ups — H1 claim, M4 actor gating, M7 internal scrub (CHOO-1251)

### DIFF
--- a/.github/renovate-security/jira_client.py
+++ b/.github/renovate-security/jira_client.py
@@ -1,18 +1,12 @@
 """Tiny Jira REST client (stdlib only) for linking/creating vulnerability tickets.
 
-Uses REST API v3 with basic auth (email + API token) against the SandboxAQ Jira
-Cloud instance (sandboxquantum.atlassian.net): search via /rest/api/3/search/jql
-(with a legacy fallback), create with an ADF description, assign, comment, remote
-link and transition to Done. Stdlib-only so the CI step needs no extra pip install.
+Uses REST API v3 with basic auth (email + API token) against the Jira Cloud
+instance named by JIRA_BASE_URL: search via /rest/api/3/search/jql (with a legacy
+fallback), create with an ADF description, assign, comment, remote link and
+transition to Done. Stdlib-only so the CI step needs no extra pip install.
 
 Every network call degrades gracefully: on any error it logs and returns an empty
 result / None, so a Jira outage never fails the autofix run.
-
-Vendored from ``root/scripts/socket-autofix/jira_client.py`` so this tool is
-self-contained and independently mergeable (with one addition, ``field_value()``, for
-verify-after-set routing). Once both tools land, the shared stdlib helpers (this
-module, ``advisory.py``, ``codeowners.py``) should be extracted to a single
-``root/scripts/lib/`` and imported by both.
 """
 
 from __future__ import annotations
@@ -25,7 +19,6 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-DEFAULT_BASE = "https://sandboxquantum.atlassian.net"
 # Vulnerabilities are tracked in the VULNMGMT project. Both search and create
 # default here; the driver overrides them from JIRA_VULN_PROJECT when set.
 SEARCH_PROJECTS = ("VULNMGMT",)
@@ -53,12 +46,11 @@ class JiraClient:
     def from_env(cls) -> JiraClient | None:
         email = os.environ.get("SBT_MACHINE_USER_EMAIL")
         token = os.environ.get("SBT_MACHINE_USER_JIRA_TOKEN")
-        # `or DEFAULT_BASE` (not a get default): the workflow sets
-        # JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}, which is the EMPTY STRING when
-        # the repo var is undefined. get(k, default) returns "" there (key present),
-        # leaving base="" and every request URL schemeless. Treat empty as unset.
-        base = os.environ.get("JIRA_BASE_URL") or DEFAULT_BASE
-        if not (email and token):
+        # The workflow sets JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}, which is the
+        # EMPTY STRING when the variable is undefined. Treat empty as unset and
+        # skip — there is no hardcoded fallback host, since this tree is public.
+        base = os.environ.get("JIRA_BASE_URL") or ""
+        if not (base and email and token):
             return None
         return cls(base, email, token)
 

--- a/.github/workflows/container_security.yml
+++ b/.github/workflows/container_security.yml
@@ -81,9 +81,9 @@ jobs:
           JIRA_VULN_EPIC: ${{ vars.JIRA_VULN_EPIC }}
           JIRA_AISIM_ACCOUNT_ID: ${{ vars.JIRA_AISIM_ACCOUNT_ID }}
           JIRA_AISIM_USER: ${{ vars.JIRA_AISIM_USER }}
-          JIRA_AISIM_LABEL: "cg-aqtiveguard"
+          JIRA_AISIM_LABEL: ${{ vars.JIRA_AISIM_LABEL }}
           JIRA_AISIM_FIELD_ID: ${{ vars.JIRA_AISIM_FIELD_ID }}
-          JIRA_AISIM_FIELD_VALUE: "CG - AqtiveGuard"  # baked BU (org has no repo vars)
+          JIRA_AISIM_FIELD_VALUE: ${{ vars.JIRA_AISIM_FIELD_VALUE }}
         run: |
           if [ -z "${SBT_MACHINE_USER_JIRA_TOKEN:-}" ]; then
             echo "::warning::Jira creds not set; skipping ticketing."
@@ -94,9 +94,13 @@ jobs:
             --repo "${REPO}" --run-url "${RUN_URL}"
 
   gate:
-    # Non-blocking scan of the base image(s) a renovate/* PR bumps to.
+    # Non-blocking scan of the base image(s) a renovate/* PR bumps to. Gated on
+    # the automation's identity (the app that opens these PRs), not just the
+    # branch name — a branch prefix is not an identity, anyone opening a PR can
+    # name their branch renovate/anything (M4).
     if: >-
       github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login == 'autofix-pr-bot[bot]' &&
       startsWith(github.event.pull_request.head.ref, 'renovate/')
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 name: Renovate
 # Self-hosted Renovate for the ecosystems Socket does NOT cover (containers, GitHub
 # Actions, CircleCI orbs). Policy lives in renovate.json5 at the repo root; see
-# root/scripts/renovate-security/README.md for the rationale (security-focused,
+# .github/renovate-security/README.md for the rationale (security-focused,
 # minimally invasive, minimumReleaseAge guard, one PR per project+ecosystem).
 #
 # Terraform PROVIDER security is a separate job (tf_provider_security.yml). VULNMGMT

--- a/.github/workflows/renovate_jira.yml
+++ b/.github/workflows/renovate_jira.yml
@@ -17,9 +17,12 @@ permissions:
 
 jobs:
   create-ticket:
-    # Freshly-opened renovate/* PRs (not merges).
+    # Freshly-opened renovate/* PRs (not merges). Gated on the automation's
+    # identity (the app that opens these PRs), not just the branch name — a
+    # branch prefix is not an identity check (M4).
     if: >-
       github.event.action != 'closed' &&
+      github.event.pull_request.user.login == 'autofix-pr-bot[bot]' &&
       startsWith(github.event.pull_request.head.ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
@@ -50,9 +53,9 @@ jobs:
           JIRA_VULN_EPIC: ${{ vars.JIRA_VULN_EPIC }}
           JIRA_AISIM_ACCOUNT_ID: ${{ vars.JIRA_AISIM_ACCOUNT_ID }}
           JIRA_AISIM_USER: ${{ vars.JIRA_AISIM_USER }}
-          JIRA_AISIM_LABEL: "cg-aqtiveguard"
+          JIRA_AISIM_LABEL: ${{ vars.JIRA_AISIM_LABEL }}
           JIRA_AISIM_FIELD_ID: ${{ vars.JIRA_AISIM_FIELD_ID }}
-          JIRA_AISIM_FIELD_VALUE: "CG - AqtiveGuard"  # baked BU (org has no repo vars)
+          JIRA_AISIM_FIELD_VALUE: ${{ vars.JIRA_AISIM_FIELD_VALUE }}
         run: |
           set -euo pipefail
           if [ -z "${SBT_MACHINE_USER_JIRA_TOKEN:-}" ]; then
@@ -72,10 +75,12 @@ jobs:
           fi
 
   close-ticket:
-    # Merged renovate/* PRs -> close the ticket the automation created.
+    # Merged renovate/* PRs -> close the ticket the automation created. Same
+    # identity gate as create-ticket (M4).
     if: >-
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login == 'autofix-pr-bot[bot]' &&
       startsWith(github.event.pull_request.head.ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:

--- a/console/apps/switch-console-desktop/src/renderer/features/onboarding/welcome-learn-more.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/onboarding/welcome-learn-more.tsx
@@ -55,7 +55,7 @@ export function WelcomeFooter() {
   return (
     <div className="flex items-center justify-center gap-2 pt-6 text-xs text-foreground-muted">
       <span>
-        Switch is an open source project of <span className="text-foreground">Flint AI</span> by
+        Switch is a project of <span className="text-foreground">Flint AI</span> by
         SandboxAQ
       </span>
       <span aria-hidden>|</span>

--- a/console/apps/switch-console-desktop/src/renderer/features/onboarding/welcome-learn-more.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/onboarding/welcome-learn-more.tsx
@@ -55,8 +55,7 @@ export function WelcomeFooter() {
   return (
     <div className="flex items-center justify-center gap-2 pt-6 text-xs text-foreground-muted">
       <span>
-        Switch is a project of <span className="text-foreground">Flint AI</span> by
-        SandboxAQ
+        Switch is a project of <span className="text-foreground">Flint AI</span> by SandboxAQ
       </span>
       <span aria-hidden>|</span>
       <button


### PR DESCRIPTION
## Post-flip security follow-ups (CHOO-1251)

Clears the remaining code-side InfoSec review items after the public flip. Two items (M3 ruleset, M7 Actions variables) are applied via the GitHub API and noted below rather than in this diff.

### In this PR
- **H1 — false "open source" claim.** The Switch Console welcome screen said *"Switch is an open source project…"*; the license is Apache-2.0 + Commons Clause (not OSI). Reworded to *"Switch is a project of Flint AI by SandboxAQ."* (`welcome-learn-more.tsx`)
- **M4 — branch name as trust boundary.** `container_security.yml` (gate) and `renovate_jira.yml` (create/close) now also require `github.event.pull_request.user.login == 'autofix-pr-bot[bot]'` — the app that actually opens these PRs — on top of the `renovate/` prefix. A prefix is spoofable (anyone can name a branch `renovate/x`); an identity is not. (Bot login verified against the real PRs.)
- **M7 — internal tooling in the public tree.** `.github/renovate-security/jira_client.py` no longer hardcodes the internal Jira host (now requires `JIRA_BASE_URL`, skips gracefully if unset) and drops the internal-monorepo provenance docstring; `container_security.yml` + `renovate_jira.yml` read the AISIM label / BU value from **Actions variables** instead of baking the literals; `renovate.yml`'s README pointer uses the in-repo path.

### Applied via API (not in the diff)
- **M3 — tag protection.** New repo ruleset `protect-release-tags` (id 20990492), target=tag, **active**, covering `refs/tags/switch-v*`, `refs/tags/switch-console-v*`, `refs/tags/switch-agent-runtime-v*`, rules deletion/non_fast_forward/creation/update, **bypass = Repository admin** so a maintainer can still cut a release. ⚠️ Please confirm "Repository admin" shows in the bypass list before the next release (it can be softened to "evaluate"/dry-run in the UI if you want to test first).
- **M7 vars.** Created repo Actions variables `JIRA_AISIM_LABEL=cg-aqtiveguard` and `JIRA_AISIM_FIELD_VALUE=CG - AqtiveGuard` so the workflows resolve the same routing without the values living in the public source.

### Verification
- All three workflows parse (YAML); `jira_client.py` compiles; repo-wide grep confirms no `sandboxquantum.atlassian` host, `Vendored from root/scripts`, or baked BU literals remain in tracked files.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)