### PR TITLE
docs(changelog): note Windows signing in switch-console 0.27.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -680,6 +680,8 @@ version of their own to them without also giving them a release of their own.
 
 #### Changed
 
+- **Windows builds are now signed** with Azure Trusted Signing, so the installer
+  and app no longer trip SmartScreen's unknown-publisher warning (CHOO-1468).
 - Local-server mode now bundles and pulls **switch-core `0.17.2`** (was
   `0.17.1`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
   current core release.


### PR DESCRIPTION
Records the Windows-signing change (#253, CHOO-1468) in the switch-console `0.27.2` changelog — the PR shipped it without an entry. The `0.27.2` GitHub Release never published (its mac jobs failed the arch-check bug, now fixed by #252), so this re-cuts `0.27.2` on top of #252 + #253 rather than burning a version.

No version change; `just artifacts-check` passes.

After merge: delete the failed draft Release + old `switch-console-v0.27.2` tag, re-tag on this merge commit, and the release rebuilds clean (mac arch check fixed, Windows signed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)