### PR TITLE
fix(console): restore the publisherName Azure signing requires (CHOO-1468)

### DIFF
--- a/.github/workflows/switch-console-release.yml
+++ b/.github/workflows/switch-console-release.yml
@@ -569,6 +569,11 @@ jobs:
           ')"
           if [ "$signed" != "0" ]; then
             echo "Authenticode signature present ($signed bytes)."
+            # The subject's CN is the string `publisherName` has to match before
+            # verifyUpdateCodeSignature can be turned on, and the certificate is
+            # the only authoritative source for it.
+            powershell -NoProfile -Command \
+              '$s = Get-AuthenticodeSignature "release\switch-console-x64.exe"; Write-Host "status: $($s.Status)"; Write-Host "subject: $($s.SignerCertificate.Subject)"'
           elif [ -n "$AZURE_CLIENT_ID" ]; then
             echo "::error::Azure credentials were present but the installer is unsigned."
             exit 1

--- a/console/apps/switch-console-desktop/electron-builder.config.ts
+++ b/console/apps/switch-console-desktop/electron-builder.config.ts
@@ -160,26 +160,36 @@ const config: Configuration = {
   rpm: {
     packageName: APP_NAME_LOWER,
   },
-  // `publisherName` is deliberately unset. electron-updater verifies a downloaded
-  // installer's Authenticode signature against the publisher named in
-  // app-update.yml, and the name has to match the certificate subject exactly —
-  // a wrong value rejects every update rather than failing at build time. Until
-  // the certificate's common name is known verbatim, leaving it unset writes no
-  // publisher into app-update.yml, which makes the updater skip that check.
-  // Signing itself is unaffected; setting the real string later strengthens it.
   win: {
     icon: 'src/assets/images/switch-console/app-icon-beta.png',
     target: [
       { target: 'nsis', arch: ['x64'] },
       { target: 'msi', arch: ['x64'] },
     ],
-    azureSignOptions: hasAzureSigning
+    // Off until the certificate's subject common name is known verbatim. This
+    // flag is what decides whether `publisherName` below is copied into
+    // app-update.yml, and electron-updater rejects any update whose signature
+    // does not match the name it finds there. A wrong name therefore breaks
+    // updating for everyone already installed, and does so silently and later —
+    // whereas leaving the field out of the manifest merely skips the check.
+    // Turn this on in the same change that sets the real name.
+    verifyUpdateCodeSignature: false,
+    ...(hasAzureSigning
       ? {
-          endpoint: 'https://eus.codesigning.azure.net/',
-          codeSigningAccountName: 'cg-asa-basic-eastus',
-          certificateProfileName: 'cg-public',
+          azureSignOptions: {
+            endpoint: 'https://eus.codesigning.azure.net/',
+            codeSigningAccountName: 'cg-asa-basic-eastus',
+            certificateProfileName: 'cg-public',
+            // Required by electron-builder's schema, so it cannot be omitted, but
+            // it is stripped before the signing call and never reaches the
+            // certificate — the signature's real publisher comes from the
+            // certificate itself. Its only effect is on app-update.yml, which
+            // verifyUpdateCodeSignature: false above suppresses. Treat it as
+            // unverified until a signed build confirms the actual subject.
+            publisherName: 'SandboxAQ',
+          },
         }
-      : undefined,
+      : {}),
   },
   msi: {
     oneClick: false,


### PR DESCRIPTION
Fixes the Windows job failure that is currently blocking the **v0.27.2 release** (runs [32140508388](https://github.com/sandbox-quantum/switch/actions/runs/32140508388), [32142754031](https://github.com/sandbox-quantum/switch/actions/runs/32142754031)).

```
⨯ Invalid configuration object. electron-builder 26.15.2 has been initialized
  using a configuration object that does not match the API schema.
 - configuration.win.azureSignOptions should be one of these: null
```

## What I got wrong

`publisherName` is a **required** property of `WindowsAzureSigningConfiguration`. #253 deliberately omitted it, so the config was invalid and packaging aborted before it began.

The omission had a real motive — `publisherName` is copied into `app-update.yml`, and electron-updater rejects any update whose signature doesn't match the name it finds there, so a guessed name breaks updating silently and later. But the schema doesn't permit leaving it out, and I didn't check that it did.

## Why the branch test couldn't catch it

The dispatch test in #253 was green, and could not have been otherwise: without credentials `hasAzureSigning` is false and the key is absent entirely. **The invalid shape only exists when credentials are present, which by design only happens on main and tags.** The one path the test couldn't reach was the only path that was broken.

## The fix

Supply the name and neutralise it rather than omit it. electron-builder strips `publisherName` before the signing call — it never reaches the certificate, and the signature's real publisher comes from the certificate itself. Its only consumer is `app-update.yml`, which `verifyUpdateCodeSignature: false` keeps it out of. Verification gets enabled in the same change that sets the confirmed name.

Also prints the certificate subject from the signed installer, so the real common name comes from the certificate instead of from asking around for it.

## Verification

Both config branches validated against electron-builder's actual `scheme.json`:

```
unsigned: VALID
signed:   VALID
previous (no publisherName): INVALID -> must have required property 'publisherName'
```

That last line reproduces the CI error exactly, which is the check I should have run before #253.

## Suggested sequence after merge

1. `workflow_dispatch` from **main** — enters the `release` environment, so it genuinely exercises signing, without touching the release. Needs environment approval.
2. Read the `subject:` line it prints; that is the common name for a follow-up that sets `publisherName` and turns verification on.
3. Then re-run the failed job on the v0.27.2 tag to unblock the release.

Doing step 3 first risks a third failed release run: the config is now schema-valid, but whether the TrustedSigning module accepts an OIDC login rather than a client secret is still unproven.

If you would rather unblock the release immediately, say so and I will push a change that disables Windows signing, releases 0.27.2 unsigned as before, and re-enables it once step 1 has passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)