### PR TITLE
fix(console): keep the bundled-chat sign-in dialog on screen, and stop pointing at a deleted server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -659,6 +659,18 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+#### Fixed
+
+- **Sign-in details** for a managed server's bundled chat now stays open. The
+  dialog was rendered inside the messaging app's dropdown menu, so the same
+  click that opened it closed the menu — and the menu took the dialog with it,
+  before anyone could read a credential off it.
+- Deleting a Switch server no longer leaves the app pointed at it. The deleted
+  server's id survived in the saved page state, so the app could return to a
+  page for a server that no longer exists and keep asking its gateway for a
+  sign-in configuration nothing could answer. The page now falls back to home
+  and the dead id is discarded.
+
 ### [0.27.2] - 2026-08-18
 
 #### Added

--- a/console/apps/switch-console-desktop/src/renderer/app/modal-registry.ts
+++ b/console/apps/switch-console-desktop/src/renderer/app/modal-registry.ts
@@ -11,6 +11,7 @@ import { AddAgentToRoomsModal } from '@renderer/features/switch-rooms/AddAgentTo
 import { DeleteRoomModal } from '@renderer/features/switch-rooms/DeleteRoomModal';
 import { AddServerModal } from '@renderer/features/switch-servers/AddServerModal';
 import { AssignServerModal } from '@renderer/features/switch-servers/assign-server-modal';
+import { BundledChatSignInModal } from '@renderer/features/switch-servers/BundledChatSignIn';
 import { ClaimIdentityModal } from '@renderer/features/switch-servers/ClaimIdentityModal';
 import { ConnectMessagingAppModal } from '@renderer/features/switch-servers/ConnectMessagingAppModal';
 import { CreateRoomModal } from '@renderer/features/switch-servers/CreateRoomModal';
@@ -76,6 +77,7 @@ export const modalRegistry = {
     size: 'md',
     dismissOnOutsideClick: false,
   }),
+  bundledChatSignInModal: createModal(BundledChatSignInModal, { size: 'sm' }),
   disconnectMessagingAppModal: createModal(DisconnectMessagingAppModal, {
     size: 'sm',
     dismissOnOutsideClick: false,

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/BundledChatSignIn.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/BundledChatSignIn.tsx
@@ -1,22 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
-import { Check, Copy, ExternalLink, Eye, EyeOff, KeyRound } from 'lucide-react';
+import { Check, Copy, ExternalLink, Eye, EyeOff } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { BridgeIcon } from '@renderer/lib/components/bridge-icon';
 import { failureText } from '@renderer/lib/errors/describe-failure';
 import { rpc } from '@renderer/lib/ipc';
+import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { openExternalUrl } from '@renderer/lib/open-external';
 import { Button } from '@renderer/lib/ui/button';
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
   DialogContentArea,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
-import { DropdownMenuItem } from '@renderer/lib/ui/dropdown-menu';
 import { Spinner } from '@renderer/lib/ui/spinner';
 
 function CopyButton({ value, label }: { value: string; label: string }) {
@@ -81,6 +78,13 @@ function CredentialRow({
   );
 }
 
+type BundledChatSignInModalArgs = {
+  serverId: string;
+  bridgeDisplayName: string;
+};
+
+type Props = BaseModalProps<void> & BundledChatSignInModalArgs;
+
 /**
  * The bundled chat's address and sign-in, for signing in outside Switch Console —
  * a browser or the desktop Mattermost client (CHOO-1787).
@@ -89,31 +93,22 @@ function CredentialRow({
  * so it is never exposed to the LAN, so the copy must not invite the user to
  * try a device that cannot reach it.
  *
+ * It goes through the modal registry rather than owning a `Dialog` of its own,
+ * because the only thing that opens it is an item in the messaging app's
+ * dropdown menu. A dialog rendered there is a child of the menu's popup, which
+ * base-ui unmounts the moment the menu closes — so the same click that opened
+ * it took it away again.
+ *
  * The values are only fetched once the dialog is opened: the password should
  * not cross into the renderer for everyone who merely looks at the server page.
  * When Switch Console cannot read the real values it says which one is missing
  * and why, and shows nothing else — a template password would only send the
  * user round a login loop.
  */
-export function BundledChatSignIn({
-  serverId,
-  bridgeDisplayName,
-  asMenuItem = false,
-}: {
-  serverId: string;
-  bridgeDisplayName: string;
-  /** Render the opener as a dropdown entry rather than a standalone icon
-   * button, for the row menu that now carries this action. */
-  asMenuItem?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-
+export function BundledChatSignInModal({ serverId, bridgeDisplayName, onClose }: Props) {
   const signInQuery = useQuery({
     queryKey: ['bundled-chat-sign-in', serverId],
     queryFn: () => rpc.switchServers.getBundledChatSignIn(serverId),
-    // The password only crosses into the renderer once the dialog is actually
-    // opened, so merely listing the app never fetches it.
-    enabled: open,
   });
 
   const signIn = signInQuery.data;
@@ -121,69 +116,47 @@ export function BundledChatSignIn({
 
   return (
     <>
-      {asMenuItem ? (
-        // `closeOnClick={false}` would leave the menu over the dialog; letting
-        // it close and opening the dialog from the same click is what keeps one
-        // surface on screen at a time.
-        <DropdownMenuItem onClick={() => setOpen(true)}>
-          <KeyRound className="size-4" />
-          Sign-in details…
-        </DropdownMenuItem>
-      ) : (
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          aria-label={`${bridgeDisplayName} sign-in details`}
-          title={`${bridgeDisplayName} sign-in details`}
-          onClick={() => setOpen(true)}
-        >
-          <KeyRound className="size-3" />
+      <DialogHeader>
+        <BridgeIcon bridgeType="mattermost" size={16} />
+        <DialogTitle>{bridgeDisplayName} sign-in details</DialogTitle>
+      </DialogHeader>
+      <DialogContentArea className="space-y-3">
+        <DialogDescription>
+          Use these to sign in to this chat in a browser or the {bridgeDisplayName} desktop app on
+          this computer.
+        </DialogDescription>
+
+        {signInQuery.isLoading ? (
+          <Spinner className="size-3.5" />
+        ) : signInQuery.isError ? (
+          <p className="text-destructive text-xs">
+            {failureText(signInQuery.error, 'Could not read the sign-in details.')}
+          </p>
+        ) : signIn?.kind === 'unavailable' ? (
+          <p className="text-xs text-foreground-muted">{signIn.reason}</p>
+        ) : signIn?.kind === 'available' ? (
+          <>
+            <CredentialRow label="Server" value={signIn.url} />
+            <CredentialRow label="Username" value={signIn.username} />
+            <CredentialRow label="Password" value={signIn.password} secret />
+          </>
+        ) : null}
+      </DialogContentArea>
+      <DialogFooter>
+        {url && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void openExternalUrl(url, `Could not open ${bridgeDisplayName}`)}
+          >
+            <ExternalLink className="size-4" />
+            Open in browser
+          </Button>
+        )}
+        <Button size="sm" onClick={onClose}>
+          Done
         </Button>
-      )}
-
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <BridgeIcon bridgeType="mattermost" size={16} />
-            <DialogTitle>{bridgeDisplayName} sign-in details</DialogTitle>
-          </DialogHeader>
-          <DialogContentArea className="space-y-3">
-            <DialogDescription>
-              Use these to sign in to this chat in a browser or the {bridgeDisplayName} desktop app
-              on this computer.
-            </DialogDescription>
-
-            {signInQuery.isLoading ? (
-              <Spinner className="size-3.5" />
-            ) : signInQuery.isError ? (
-              <p className="text-destructive text-xs">
-                {failureText(signInQuery.error, 'Could not read the sign-in details.')}
-              </p>
-            ) : signIn?.kind === 'unavailable' ? (
-              <p className="text-xs text-foreground-muted">{signIn.reason}</p>
-            ) : signIn?.kind === 'available' ? (
-              <>
-                <CredentialRow label="Server" value={signIn.url} />
-                <CredentialRow label="Username" value={signIn.username} />
-                <CredentialRow label="Password" value={signIn.password} secret />
-              </>
-            ) : null}
-          </DialogContentArea>
-          <DialogFooter>
-            {url && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => void openExternalUrl(url, `Could not open ${bridgeDisplayName}`)}
-              >
-                <ExternalLink className="size-4" />
-                Open in browser
-              </Button>
-            )}
-            <DialogClose render={<Button size="sm" />}>Done</DialogClose>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      </DialogFooter>
     </>
   );
 }

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/MessagingAppsCard.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/MessagingAppsCard.tsx
@@ -3,6 +3,7 @@ import {
   CircleAlert,
   ExternalLink,
   Info,
+  KeyRound,
   Link2,
   MessageSquare,
   MoreVertical,
@@ -34,7 +35,6 @@ import { Spinner } from '@renderer/lib/ui/spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { log } from '@renderer/utils/logger';
 import type { LinkedIdentity, RemoteBridge } from '@shared/core/switch-servers/switch-servers';
-import { BundledChatSignIn } from './BundledChatSignIn';
 import { orderBridges } from './messaging-apps-order';
 import {
   hasUnlinkedMessagingApp,
@@ -355,6 +355,7 @@ export function MessagingAppRow({
   onDisconnect: () => void;
 }) {
   const showClaimIdentity = useShowModal('claimIdentityModal');
+  const showBundledChatSignIn = useShowModal('bundledChatSignInModal');
   const [releasing, setReleasing] = useState(false);
   const [releaseError, setReleaseError] = useState<string | null>(null);
 
@@ -510,11 +511,14 @@ export function MessagingAppRow({
 
           {(showBundledSignIn || bridge.homeUrl) && <DropdownMenuSeparator />}
           {showBundledSignIn && (
-            <BundledChatSignIn
-              serverId={serverId}
-              bridgeDisplayName={bridge.displayName}
-              asMenuItem
-            />
+            <DropdownMenuItem
+              onClick={() =>
+                showBundledChatSignIn({ serverId, bridgeDisplayName: bridge.displayName })
+              }
+            >
+              <KeyRound className="size-4" />
+              Sign-in details…
+            </DropdownMenuItem>
           )}
           {/* Offered only when the link resolves — an older server, or a bridge
               that is down, reports none. */}

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
@@ -28,6 +28,10 @@ vi.mock('@renderer/lib/ipc', () => ({
 vi.mock('@renderer/features/remote-hosts/host-reachability-store', () => ({
   hostReachabilityStore: { isBlocked: (sshHost: string) => blockedHosts.has(sshHost) },
 }));
+const revalidate = vi.hoisted(() => vi.fn());
+vi.mock('@renderer/lib/stores/app-state', () => ({
+  appState: { navigation: { revalidate } },
+}));
 
 const { SwitchServersStore } = await import('./switch-servers-store');
 
@@ -167,6 +171,31 @@ describe('recovering when connectivity returns', () => {
     await store.recoverStale();
 
     expect(getAuthConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('a page left on a server that is gone', () => {
+  it('is revalidated when the server is removed', async () => {
+    const store = newStore([server('srv-a')]);
+    listServers.mockResolvedValue([]);
+    getActiveServerId.mockResolvedValue(null);
+    removeServer.mockResolvedValue(undefined);
+
+    await store.removeServer('srv-a');
+
+    expect(revalidate).toHaveBeenCalled();
+  });
+
+  it('is revalidated once the list is known, not before', async () => {
+    const store = new SwitchServersStore();
+    expect(store.loaded).toBe(false);
+
+    listServers.mockResolvedValue([server('srv-a')]);
+    getActiveServerId.mockResolvedValue('srv-a');
+    await store.init();
+
+    expect(store.loaded).toBe(true);
+    expect(revalidate).toHaveBeenCalled();
   });
 });
 

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -2,6 +2,7 @@ import { makeAutoObservable, runInAction } from 'mobx';
 import { hostReachabilityStore } from '@renderer/features/remote-hosts/host-reachability-store';
 import { describeFailure } from '@renderer/lib/errors/describe-failure';
 import { rpc } from '@renderer/lib/ipc';
+import { appState } from '@renderer/lib/stores/app-state';
 import type {
   ServerConnectionStatus,
   SwitchAuthConfig,
@@ -38,6 +39,11 @@ export class SwitchServersStore {
   readonly unreachable = new Set<string>();
 
   loadingServers = false;
+  /** Whether the list has been read at least once. Until it has, an empty
+   * `servers` means "not asked yet", not "no such server" — the difference
+   * matters to the server view's guard, which runs at startup before anything
+   * has mounted to call {@link init}. */
+  loaded = false;
   /** Server ids with an in-flight status refresh. */
   readonly refreshing = new Set<string>();
   /** The sentence the page leads with. Never raw exception text. */
@@ -98,7 +104,12 @@ export class SwitchServersStore {
       runInAction(() => {
         this.servers = servers;
         this.activeServerId = activeServerId;
+        this.loaded = true;
       });
+      // A page restored onto a server that has since been deleted can only be
+      // judged once the list is known, and startup restores navigation before
+      // anything asks for it.
+      appState.navigation.revalidate();
       await this.ensureActiveServer();
       await this.refreshAllStatuses();
     } catch (cause) {
@@ -330,6 +341,10 @@ export class SwitchServersStore {
         this.authConfigWanted.delete(serverId);
         this.unreachable.delete(serverId);
       });
+      // The removed id also sits in the server view's saved params, where it
+      // outlives the record and would be read back — as a page for a server
+      // that is gone, and as gateway calls for an id nothing can resolve.
+      appState.navigation.revalidate();
       await this.ensureActiveServer();
     } catch (cause) {
       this.setError(cause, 'Could not remove the server.');

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/view.tsx
@@ -135,11 +135,15 @@ const ServerMainPanel = observer(function ServerMainPanel() {
   // effect re-runs and finally fetches what it skipped (CHOO-2042).
   const hostBlocked = store.isHostBlocked(serverId);
 
+  // An id naming no server resolves to nothing on the main side, so both reads
+  // would fail — and mark the server unreachable, which is a different claim
+  // from the truth that it is gone. The page says so below instead.
+  const serverExists = server !== undefined;
   useEffect(() => {
-    if (!detailsVisible || hostBlocked) return;
+    if (!serverExists || !detailsVisible || hostBlocked) return;
     void store.refreshStatus(serverId);
     void store.ensureAuthConfig(serverId);
-  }, [serverId, store, detailsVisible, hostBlocked]);
+  }, [serverId, store, serverExists, detailsVisible, hostBlocked]);
 
   if (!server) {
     return (
@@ -485,6 +489,13 @@ export const serverView = {
         : undefined;
     if (typeof serverId !== 'string') {
       return { ok: false, redirect: 'home' };
+    }
+    // Saved params outlive the server they name: deleting one leaves its id
+    // here, and a page restored onto it reads a gateway nothing can resolve.
+    // Until the list has been read, an absent server means "not asked yet" —
+    // the store revalidates once it knows.
+    if (switchServersStore.loaded && !switchServersStore.servers.some((s) => s.id === serverId)) {
+      return { ok: false, redirect: 'home', discardParams: true };
     }
     return { ok: true };
   },


### PR DESCRIPTION
Clicking **Sign-in details…** on a managed server's Mattermost row opened a dialog that disappeared in the same frame. Two separate faults were behind what that page does; both are fixed here.

## The dialog was a child of the menu that opened it

`BundledChatSignIn` returned the `DropdownMenuItem` **and** the `<Dialog>` as one fragment, and it was rendered inside `DropdownMenuContent` — so the dialog lived under base-ui's `Menu.Portal` → `Positioner` → `Popup`. That subtree is unmounted when the menu closes, and the click that set `open = true` also closed the menu. The dialog mounted, painted, and was torn down with the menu, taking its `open` state and its in-flight credential fetch with it. Deterministic on every click.

It was the only `<Dialog>` inside a `DropdownMenuContent` in the renderer. Every other item on that same menu — link account, disconnect app, rename/delete server — goes through the modal registry, which renders at app root, outside the menu's portal. This one now does too: `BundledChatSignInModal`, registered as `bundledChatSignInModal`, opened with `useShowModal`.

The password still only crosses into the renderer when the dialog is actually opened — the modal is not mounted until then, so the old `enabled: open` guard on the query is redundant rather than lost.

## A deleted server's id outlived the server

Reported as `No Switch server with id …` from `switchServers.getAuthConfig` after deleting a server and creating a new one.

The id is kept in the server view's saved params, which are persisted and are per-view — they outlive any particular navigation. `canActivate` only checked that it was a string, so the app could restore onto a page for a server that no longer exists. Worse, the effect behind that page ran *before* the `if (!server)` early return, so it fired `getConnectionStatus` and `getAuthConfig` at an id the main side cannot resolve, and then flagged the server `unreachable` — a different claim from the truth, which is that it is gone.

- `canActivate` now checks the server exists and returns `discardParams: true`, so the dead id is dropped rather than replayed.
- `switchServersStore` gained `loaded` and calls `appState.navigation.revalidate()` after `init()` and after `removeServer()` — the same pattern `location-manager` already uses for deleted locations.
- The guard defers to `loaded` rather than to an empty list: the store is initialised from a component effect, long after `restoreSnapshot` runs at boot, so an unconditional existence check would bounce you to home on every launch.
- The page effect is gated on the server existing.

## Testing

`format`, `lint`, `typecheck` (only the pre-existing `js-yaml` errors under `scripts/`), and 2634 `node` + `main-db` tests pass. Two store tests added for the revalidation. The dialog fix has no test: it is a renderer-browser concern, and those are CI-only per `console/AGENTS.md` — verified by hand in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)