### PR TITLE
release: batch — runtime 0.3.2, core 0.17.3, console 0.27.3, sidecar 1.9.4, plugins 0.9.6/0.3.7/0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.17.3] - 2026-08-19
+
+#### Fixed
+- The Mattermost bridge now bridges the channels a new bot is already a member
+  of. A bot's websocket opens only after Mattermost has added it to the team's
+  default channels, so it never witnessed its own joins — the first agent on an
+  instance bridged nothing, and creating a second adopted Town Square and
+  Off-Topic late and attributed to the wrong action. Current membership is now
+  reconciled on connect rather than relying on live join broadcasts alone
+  (CHOO-2203).
+
 ### [0.17.2] - 2026-08-18
 
 #### Fixed
@@ -659,8 +670,37 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.27.3] - 2026-08-19
+
+#### Added
+
+- Set an agent's **instructions** — what it is for, addressed to the agent
+  itself — as a first-class field edited from its page, applied to whichever
+  mechanism its provider uses (a Claude repo-agent, a Codex or OpenCode launch
+  profile) rather than being a per-provider setting only (CHOO-2228).
+- **Build switch-core from your checkout** for the managed local stack. A dev
+  build launched from a Switch checkout can run switch/gateway/setup from the
+  working tree (`up -d --build`) instead of this build's pinned GHCR images, via
+  a toggle on the local server's page. Dev builds only, and only when an ancestor
+  of the app's directory carries the Dockerfiles and `core/pyproject.toml` (#258).
+
+#### Changed
+
+- Local-server mode now bundles and pulls **switch-core `0.17.3`** (was
+  `0.17.2`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release.
+
 #### Fixed
 
+- CLI first-run prompts that leave a spawned session alive but never answering
+  are now cleared or detected before the session starts — Claude Code auto-trust
+  (silently broken since a config-key rename), its first-run setup wizard, and
+  the bypass-permissions warning (CHOO-2213).
+- @mentions in the embedded Mattermost view are readable in the light theme
+  again — the link/mention colour pointed at the text-selection-highlight
+  background and rendered at ~1.4:1 on the white channel (CHOO-2203).
+- A newly onboarded agent's default Mattermost rooms show in the sidebar without
+  waiting for a background reconcile to happen to fire (CHOO-2203).
 - **Sign-in details** for a managed server's bundled chat now stays open. The
   dialog was rendered inside the messaging app's dropdown menu, so the same
   click that opened it closed the menu — and the menu took the dialog with it,
@@ -1881,6 +1921,8 @@ The Switch protocol client and MCP runtime
 
 ### [Unreleased]
 
+### [0.3.2] - 2026-08-19
+
 #### Fixed
 - An environment naming an agent but carrying no token now resolves against the
   local agent store instead of refusing to start. Any partial `SWITCH_*`
@@ -1988,6 +2030,14 @@ by Switch Console rather than published on its own.
 
 ### [Unreleased]
 
+### [1.9.4]
+
+#### Fixed
+- The remote session spawner clears the CLI first-run prompts that would
+  otherwise leave a spawned session alive but never answering, matching the
+  desktop-side fix (CHOO-2213). Behavior change only — the client↔sidecar wire
+  (ready line, endpoints, on-disk layout) is unchanged, so the major stays `1`.
+
 ### [1.9.3]
 
 #### Added
@@ -2062,6 +2112,13 @@ compatibility signal. History for those is in the git log.
 `.claude-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.9.6] - 2026-08-19
+
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.2` (was `0.3.1`) — picks up the
+  runtime's store-based credential resolution (CHOO-1862); the plugin version
+  bumps so installs re-download.
 
 #### Fixed
 - **The `configure` skill no longer breaks the standalone path it exists to set
@@ -2250,6 +2307,16 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.3.7] - 2026-08-19
+
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.2` (was `0.3.1`) — picks up the
+  runtime's store-based credential resolution (CHOO-1862); the plugin version
+  bumps so installs re-download.
+- The room-workflow skill lists the full set of reasons `switch_unavailable` can
+  be the only tool, and points at the `configure` skill as the remedy for the
+  ones it can fix (CHOO-1862).
+
 ### [0.3.6] - 2026-08-18
 
 #### Changed
@@ -2387,6 +2454,14 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.4] - 2026-08-19
+
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.2` (was `0.3.1`) — picks up the
+  runtime's store-based credential resolution (CHOO-1862). The pin lives in
+  `distribution.ts` and `opencode.json`; the version bumps so a re-written
+  install is stamped fresh.
 
 ### [0.1.3] - 2026-08-18
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.17.2
+    version: 0.17.3
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.27.2
+    version: 0.27.3
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,11 +78,11 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.17.2
+      switch-core: 0.17.3
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
-    version: 0.3.1
+    version: 0.3.2
     declared_in: console/packages/switch-agent-runtime/package.json
 
   sidecar:
@@ -90,7 +90,7 @@ artifacts:
       The remote runtime Switch Console deploys to an agent host. Deployed rather
       than published, so nothing else declares its version — this file is its
       only source and the constant is generated from it.
-    version: 1.9.3
+    version: 1.9.4
 
   # ── Published under the switch-core release ────────────────────────────────
   # No version of their own: `helm package` and the image build stamp them with
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.5
+    version: 0.9.6
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.6
+    version: 0.3.7
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.3
+    version: 0.1.4
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/.mcp.json
+++ b/connectors/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.1"]
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.2"]
     }
   }
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/codex-plugin/.mcp.json
+++ b/connectors/codex-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.1"],
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.2"],
       "env_vars": [
         "SWITCH_API_ENDPOINT",
         "SWITCH_API_TOKEN",

--- a/connectors/opencode-plugin/opencode.json
+++ b/connectors/opencode-plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "switch": {
       "type": "local",
-      "command": ["npx", "-y", "@sandboxaq/switch-agent-runtime@0.3.1"],
+      "command": ["npx", "-y", "@sandboxaq/switch-agent-runtime@0.3.2"],
       "enabled": true,
       "timeout": 60000
     }

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.17.2';
+export const COMPATIBLE_SWITCH_VERSION = '0.17.3';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.17.2';
+export const COMPATIBLE_SWITCH_VERSION = '0.17.3';

--- a/console/packages/plugins/src/distribution.ts
+++ b/console/packages/plugins/src/distribution.ts
@@ -27,4 +27,4 @@ export const SWITCH_MARKETPLACE_SOURCE = 'sandbox-quantum/switch';
  * has got to, which during a release is a version npm does not have yet. A
  * pin has to lag it deliberately, and the lag is the point.
  */
-export const SWITCH_AGENT_RUNTIME_PIN = '@sandboxaq/switch-agent-runtime@0.3.1';
+export const SWITCH_AGENT_RUNTIME_PIN = '@sandboxaq/switch-agent-runtime@0.3.2';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.17.2',
-  'switch-console': '0.27.2',
-  'agent-runtime': '0.3.1',
-  sidecar: '1.9.3',
-  gateway: '0.17.2',
-  setup: '0.17.2',
-  'helm-chart': '0.17.2',
-  compose: '0.17.2',
-  'switch-connector': '0.9.5',
-  'switch-connector-codex': '0.3.6',
-  'switch-connector-opencode': '0.1.3',
+  'switch-core': '0.17.3',
+  'switch-console': '0.27.3',
+  'agent-runtime': '0.3.2',
+  sidecar: '1.9.4',
+  gateway: '0.17.3',
+  setup: '0.17.3',
+  'helm-chart': '0.17.3',
+  compose: '0.17.3',
+  'switch-connector': '0.9.6',
+  'switch-connector-codex': '0.3.7',
+  'switch-connector-opencode': '0.1.4',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/package.json
+++ b/console/packages/switch-agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sandboxaq/switch-agent-runtime",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Switch agent protocol client, and the local MCP runtime built on it",
   "license": "Apache-2.0",
   "author": {

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.17.2',
-  'switch-console': '0.27.2',
-  'agent-runtime': '0.3.1',
-  sidecar: '1.9.3',
-  gateway: '0.17.2',
-  setup: '0.17.2',
-  'helm-chart': '0.17.2',
-  compose: '0.17.2',
-  'switch-connector': '0.9.5',
-  'switch-connector-codex': '0.3.6',
-  'switch-connector-opencode': '0.1.3',
+  'switch-core': '0.17.3',
+  'switch-console': '0.27.3',
+  'agent-runtime': '0.3.2',
+  sidecar: '1.9.4',
+  gateway: '0.17.3',
+  setup: '0.17.3',
+  'helm-chart': '0.17.3',
+  compose: '0.17.3',
+  'switch-connector': '0.9.6',
+  'switch-connector-codex': '0.3.7',
+  'switch-connector-opencode': '0.1.4',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.17.2"
+version = "0.17.3"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,17 +20,17 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.17.2",
-    "switch-console": "0.27.2",
-    "agent-runtime": "0.3.1",
-    "sidecar": "1.9.3",
-    "gateway": "0.17.2",
-    "setup": "0.17.2",
-    "helm-chart": "0.17.2",
-    "compose": "0.17.2",
-    "switch-connector": "0.9.5",
-    "switch-connector-codex": "0.3.6",
-    "switch-connector-opencode": "0.1.3",
+    "switch-core": "0.17.3",
+    "switch-console": "0.27.3",
+    "agent-runtime": "0.3.2",
+    "sidecar": "1.9.4",
+    "gateway": "0.17.3",
+    "setup": "0.17.3",
+    "helm-chart": "0.17.3",
+    "compose": "0.17.3",
+    "switch-connector": "0.9.6",
+    "switch-connector-codex": "0.3.7",
+    "switch-connector-opencode": "0.1.4",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.17.2"
+version = "0.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Patch release of everything with unreleased changes since #250 — includes the #205 runtime cascade.

## Contents
- **agent-runtime `0.3.1 → 0.3.2`** — resolve `SWITCH_*` from the local store so standalone connector sessions connect (CHOO-1862, #205). Published by `switch-agent-runtime-v0.3.2` (gated npmjs).
- **switch-core `0.17.2 → 0.17.3`** — Mattermost bridges the channels a new bot is already a member of (CHOO-2203, #260).
- **switch-console `0.27.2 → 0.27.3`** — agent instructions as a first-class attribute (CHOO-2228, #261), build switch-core from a checkout for the managed stack (#258), clear first-run prompts that stall a session (CHOO-2213, #257), Mattermost light-theme mentions + default-room sidebar reconcile (CHOO-2203, #260), bundled-chat dialog + deleted-server fixes (#259). **Bundle pin → core `0.17.3`**.
- **sidecar `1.9.3 → 1.9.4`** — remote spawner clears the same stalling first-run prompts (CHOO-2213, #257).
- **plugins re-pinned to runtime `0.3.2`:** Claude `0.9.5 → 0.9.6` (#205), Codex `0.3.6 → 0.3.7` (#205), opencode `0.1.3 → 0.1.4` (pin only, `distribution.ts` + `opencode.json`).

## Authored changelog entries (please eyeball)
#260 (core), #257/#258/#260/#261 (console), #257 (sidecar), #205 (codex), and the runtime-pin notes. (agent-runtime + claude #205 were staged.)

## Contracts
No changes — the agent-instructions endpoints already shipped in `0.17.2`; runtime credential resolution is client-side; #260 is bridge-internal.

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes. All four runtime pins now at `@0.3.2`. `uv.lock` re-locked.

## Tagging plan (off the merge commit)
1. **`switch-agent-runtime-v0.3.2` first** — gated npmjs publish (approve promptly; the plugin pins name `@0.3.2`).
2. `switch-v0.17.3` — ungated.
3. `switch-console-v0.27.3` — macOS gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)