### PR TITLE
fix(console): keep the New agent modal's footer below its body (CHOO-2243)

### DIFF
--- a/console/apps/switch-console-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
@@ -352,7 +352,11 @@ export const AddAgentModal = observer(function AddAgentModal({ onClose }: AddLoc
         </DialogFooter>
       }
     >
-      <DialogContentArea data-autofocus tabIndex={-1} className="max-h-[calc(100dvh-13rem)] gap-4">
+      <DialogContentArea
+        data-autofocus
+        tabIndex={-1}
+        className="max-h-[calc(100dvh-2rem-var(--modal-chrome,8.5rem))] gap-4"
+      >
         <AgentIdentityFields form={form} />
 
         <Field>

--- a/console/apps/switch-console-desktop/src/renderer/lib/ui/animated-height.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/lib/ui/animated-height.tsx
@@ -5,10 +5,13 @@ import { cn } from '@renderer/utils/utils';
 export function AnimatedHeight({
   children,
   className,
+  style,
   onAnimatingChange,
 }: {
   children: React.ReactNode;
   className?: string;
+  // React sets custom properties happily; only the type omits them.
+  style?: React.CSSProperties & Record<`--${string}`, string>;
   onAnimatingChange?: (isAnimating: boolean) => void;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
@@ -59,6 +62,7 @@ export function AnimatedHeight({
     <motion.div
       animate={{ height: height ?? 'auto' }}
       transition={{ duration: 0.25, ease: 'easeInOut' }}
+      style={style}
       className={cn('w-full', isAnimating ? 'overflow-hidden' : 'overflow-visible', className)}
       onAnimationComplete={() => setIsAnimating(false)}
     >

--- a/console/apps/switch-console-desktop/src/renderer/lib/ui/animated-height.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/lib/ui/animated-height.tsx
@@ -34,14 +34,13 @@ export function AnimatedHeight({
   useEffect(() => {
     const el = contentRef.current;
     if (!el) return;
-    // Skip the ResizeObserver's initial callback — the height was already
-    // captured synchronously above, so the first observation is never new.
-    let isFirstCallback = true;
+    // The observer's first delivery is not redundant with the measurement
+    // above: content that grows in between — a section that opens itself once
+    // a query settles — is reported there and nowhere else. Discarding it
+    // leaves the wrapper pinned too short, and its content then paints outside
+    // the box, under whatever follows. `lastHeightRef` is what keeps an
+    // unchanged first observation from animating.
     const ro = new ResizeObserver(() => {
-      if (isFirstCallback) {
-        isFirstCallback = false;
-        return;
-      }
       const next = el.offsetHeight;
       if (lastHeightRef.current === next) return;
       lastHeightRef.current = next;

--- a/console/apps/switch-console-desktop/src/renderer/lib/ui/modal-layout.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/lib/ui/modal-layout.tsx
@@ -1,6 +1,19 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import { AnimatedHeight } from './animated-height';
 
+/**
+ * The height the body may not exceed is the popup's own cap less whatever the
+ * header and footer take, and only the header and footer know that. A constant
+ * standing in for them is wrong in both directions: too generous and the body
+ * pushes the footer past the popup's cap, which is how the New agent modal came
+ * to paint its warning callout underneath the footer (CHOO-2243); too mean and
+ * the modal is shorter than the window allows for no reason.
+ *
+ * So measure them and publish the total, rather than guess. Consumers cap their
+ * scroll area with `max-h-[calc(100dvh-2rem-var(--modal-chrome))]` — `2rem`
+ * being the popup's own margin, see `modal-renderer.tsx`. Until the first
+ * measurement lands the variable is unset, so a consumer's fallback applies.
+ */
 export function ModalLayout({
   header,
   footer,
@@ -10,11 +23,42 @@ export function ModalLayout({
   footer: ReactNode;
   children: ReactNode;
 }) {
+  const headerRef = useRef<HTMLDivElement>(null);
+  const footerRef = useRef<HTMLDivElement>(null);
+  const [chrome, setChrome] = useState<number | null>(null);
+
+  // Before paint: the body's cap depends on this, so a frame spent at the
+  // fallback would be a frame at the wrong height.
+  useLayoutEffect(() => {
+    const elements = [headerRef.current, footerRef.current].filter(
+      (el): el is HTMLDivElement => el !== null
+    );
+    if (elements.length === 0) return;
+
+    // `offsetHeight`, not a bounding rect: the popup zooms as it opens, and a
+    // rect measured mid-animation is scaled down with it — enough to under-
+    // reserve and clip the footer against the popup's own cap.
+    const measure = () => setChrome(elements.reduce((total, el) => total + el.offsetHeight, 0));
+
+    measure();
+    // The footer grows a row when it wraps, and again while it waits on a
+    // remote host, so this is not a one-off measurement.
+    const observer = new ResizeObserver(measure);
+    for (const el of elements) observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <>
-      {header}
-      <AnimatedHeight>{children}</AnimatedHeight>
-      {footer}
+      <div ref={headerRef} className="shrink-0">
+        {header}
+      </div>
+      <AnimatedHeight style={chrome === null ? undefined : { '--modal-chrome': `${chrome}px` }}>
+        {children}
+      </AnimatedHeight>
+      <div ref={footerRef} className="shrink-0">
+        {footer}
+      </div>
     </>
   );
 }

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/animated-height-late-growth.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/animated-height-late-growth.test.tsx
@@ -26,6 +26,14 @@ const INITIAL_HEIGHT = 200;
 const GROWN_HEIGHT = 420;
 const FOOTER_HEIGHT = 56;
 
+/**
+ * Sub-pixel residue from the height animation, which a loaded CI runner can
+ * leave a fraction short of its target. The regression this guards against is
+ * two orders of magnitude larger — the wrapper stuck at its pre-growth height —
+ * so a couple of pixels of slack costs the assertions nothing.
+ */
+const TOLERANCE = 2;
+
 let container: HTMLDivElement | null = null;
 let root: Root | null = null;
 
@@ -74,13 +82,17 @@ function wrapperOf(el: HTMLDivElement): HTMLElement {
 async function settle(el: HTMLDivElement): Promise<void> {
   const wrapper = wrapperOf(el);
   let previous = -1;
-  for (let i = 0; i < 30; i++) {
+  let stableReads = 0;
+  for (let i = 0; i < 60; i++) {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
     });
     const current = Math.round(wrapper.getBoundingClientRect().height);
-    if (current === previous) return;
+    // Easing crawls at the end, so a single repeated read is not proof the
+    // animation is over — one starved frame looks the same.
+    stableReads = current === previous ? stableReads + 1 : 0;
     previous = current;
+    if (stableReads >= 3) return;
   }
 }
 
@@ -102,7 +114,9 @@ describe('AnimatedHeight late growth', () => {
     // Guard the guard: a body that never grew would satisfy the containment
     // check below while proving nothing.
     expect(body.getBoundingClientRect().height).toBeCloseTo(GROWN_HEIGHT, 0);
-    expect(wrapper.getBoundingClientRect().height).toBeCloseTo(GROWN_HEIGHT, 0);
+    expect(Math.abs(wrapper.getBoundingClientRect().height - GROWN_HEIGHT)).toBeLessThanOrEqual(
+      TOLERANCE
+    );
   });
 
   it('keeps grown content inside its box, clear of what follows', async () => {
@@ -118,14 +132,16 @@ describe('AnimatedHeight late growth', () => {
 
     // The content must not spill past the box that positions the footer, and
     // must not reach into the footer itself.
-    expect(bodyRect.bottom).toBeLessThanOrEqual(wrapper.getBoundingClientRect().bottom + 0.5);
-    expect(bodyRect.bottom).toBeLessThanOrEqual(footerRect.top + 0.5);
+    expect(bodyRect.bottom).toBeLessThanOrEqual(wrapper.getBoundingClientRect().bottom + TOLERANCE);
+    expect(bodyRect.bottom).toBeLessThanOrEqual(footerRect.top + TOLERANCE);
   });
 
   it('leaves a wrapper whose content never changed at its measured height', async () => {
     const el = await render(false);
     await settle(el);
 
-    expect(wrapperOf(el).getBoundingClientRect().height).toBeCloseTo(INITIAL_HEIGHT, 0);
+    expect(
+      Math.abs(wrapperOf(el).getBoundingClientRect().height - INITIAL_HEIGHT)
+    ).toBeLessThanOrEqual(TOLERANCE);
   });
 });

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/animated-height-late-growth.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/animated-height-late-growth.test.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AnimatedHeight } from '@renderer/lib/ui/animated-height';
+import '@renderer/index.css';
+
+/**
+ * `AnimatedHeight` pins its wrapper to a measured pixel height and, while idle,
+ * lets content overflow that box visibly. It used to discard the
+ * ResizeObserver's first delivery on the theory that the synchronous mount
+ * measurement had already captured the size. Content that grows between those
+ * two moments — the New agent modal opens its Settings section by itself once
+ * the messaging-app lookup settles, which on a warm cache lands in the same
+ * commit as mount — is reported only in that discarded callback, so the wrapper
+ * stayed short and the body painted on underneath the modal's footer
+ * (CHOO-2243).
+ *
+ * These assertions are on measured geometry, not class strings: every class was
+ * correct while the bug was live, and only a real layout shows the content
+ * escaping its box.
+ */
+
+const CONTENT_WIDTH = 480;
+const INITIAL_HEIGHT = 200;
+const GROWN_HEIGHT = 420;
+const FOOTER_HEIGHT = 56;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+/** Mirrors ModalLayout: header, AnimatedHeight-wrapped body, footer. */
+function GrowsOnMount({ grow }: { grow: boolean }) {
+  const [tall, setTall] = useState(false);
+
+  // Growing from an effect on mount is the timing that matters: it commits
+  // before the observer's first delivery, so that delivery is the only report
+  // of the new size.
+  useEffect(() => {
+    if (grow) setTall(true);
+  }, [grow]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', width: `${CONTENT_WIDTH}px` }}>
+      <div data-testid="header" style={{ flexShrink: 0, height: '40px' }} />
+      <AnimatedHeight>
+        <div data-testid="body" style={{ height: `${tall ? GROWN_HEIGHT : INITIAL_HEIGHT}px` }} />
+      </AnimatedHeight>
+      <div data-testid="footer" style={{ flexShrink: 0, height: `${FOOTER_HEIGHT}px` }} />
+    </div>
+  );
+}
+
+async function render(grow: boolean): Promise<HTMLDivElement> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => root!.render(<GrowsOnMount grow={grow} />));
+  return container;
+}
+
+function wrapperOf(el: HTMLDivElement): HTMLElement {
+  const body = el.querySelector('[data-testid="body"]');
+  // body -> contentRef div -> motion.div
+  return body!.parentElement!.parentElement as HTMLElement;
+}
+
+/**
+ * The wrapper animates to each new height, so measure only once it has stopped
+ * moving. Polling rather than sleeping a fixed span keeps the assertions off
+ * the animation's timing: a wrapper that never tracks its content settles just
+ * as readily, at the wrong height.
+ */
+async function settle(el: HTMLDivElement): Promise<void> {
+  const wrapper = wrapperOf(el);
+  let previous = -1;
+  for (let i = 0; i < 30; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+    const current = Math.round(wrapper.getBoundingClientRect().height);
+    if (current === previous) return;
+    previous = current;
+  }
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+describe('AnimatedHeight late growth', () => {
+  it('tracks content that grows in the same commit as mount', async () => {
+    const el = await render(true);
+    await settle(el);
+
+    const wrapper = wrapperOf(el);
+    const body = el.querySelector('[data-testid="body"]')!;
+
+    // Guard the guard: a body that never grew would satisfy the containment
+    // check below while proving nothing.
+    expect(body.getBoundingClientRect().height).toBeCloseTo(GROWN_HEIGHT, 0);
+    expect(wrapper.getBoundingClientRect().height).toBeCloseTo(GROWN_HEIGHT, 0);
+  });
+
+  it('keeps grown content inside its box, clear of what follows', async () => {
+    const el = await render(true);
+    await settle(el);
+
+    const wrapper = wrapperOf(el);
+    const footer = el.querySelector('[data-testid="footer"]')!;
+    const body = el.querySelector('[data-testid="body"]')!;
+
+    const bodyRect = body.getBoundingClientRect();
+    const footerRect = footer.getBoundingClientRect();
+
+    // The content must not spill past the box that positions the footer, and
+    // must not reach into the footer itself.
+    expect(bodyRect.bottom).toBeLessThanOrEqual(wrapper.getBoundingClientRect().bottom + 0.5);
+    expect(bodyRect.bottom).toBeLessThanOrEqual(footerRect.top + 0.5);
+  });
+
+  it('leaves a wrapper whose content never changed at its measured height', async () => {
+    const el = await render(false);
+    await settle(el);
+
+    expect(wrapperOf(el).getBoundingClientRect().height).toBeCloseTo(INITIAL_HEIGHT, 0);
+  });
+});

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/modal-layout-chrome.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/modal-layout-chrome.test.tsx
@@ -20,6 +20,13 @@ const HEADER_HEIGHT = 40;
 const SHORT_FOOTER = 56;
 const TALL_FOOTER = 120;
 
+/**
+ * Sub-pixel residue from the body wrapper's height animation, which a loaded CI
+ * runner can leave a fraction short. The regression here is the footer pushed
+ * clean out of the popup, so a couple of pixels of slack costs nothing.
+ */
+const TOLERANCE = 2;
+
 let container: HTMLDivElement | null = null;
 let root: Root | null = null;
 
@@ -67,11 +74,21 @@ async function rerender(footerHeight: number): Promise<void> {
   await settle();
 }
 
+/** Wait for the body wrapper to stop animating rather than sleeping a fixed
+ * span: easing crawls at the end, so one repeated read is not proof it is over. */
 async function settle(): Promise<void> {
-  for (let i = 0; i < 12; i++) {
+  const footer = container?.querySelector('[data-testid="footer"]');
+  let previous = -1;
+  let stableReads = 0;
+  for (let i = 0; i < 60; i++) {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
     });
+    if (!footer) continue;
+    const current = Math.round(footer.getBoundingClientRect().top);
+    stableReads = current === previous ? stableReads + 1 : 0;
+    previous = current;
+    if (stableReads >= 3) return;
   }
 }
 
@@ -109,8 +126,8 @@ describe('ModalLayout chrome reservation', () => {
     // doing any work.
     expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
 
-    expect(bottomOf(footer)).toBeLessThanOrEqual(bottomOf(popup) + 0.5);
-    expect(bottomOf(body)).toBeLessThanOrEqual(footer.getBoundingClientRect().top + 0.5);
+    expect(bottomOf(footer)).toBeLessThanOrEqual(bottomOf(popup) + TOLERANCE);
+    expect(bottomOf(body)).toBeLessThanOrEqual(footer.getBoundingClientRect().top + TOLERANCE);
   });
 
   it('follows the footer when it grows a row', async () => {
@@ -124,7 +141,7 @@ describe('ModalLayout chrome reservation', () => {
     expect(getComputedStyle(body).getPropertyValue('--modal-chrome').trim()).toBe(
       `${HEADER_HEIGHT + TALL_FOOTER}px`
     );
-    expect(bottomOf(footer)).toBeLessThanOrEqual(bottomOf(popup) + 0.5);
-    expect(bottomOf(body)).toBeLessThanOrEqual(footer.getBoundingClientRect().top + 0.5);
+    expect(bottomOf(footer)).toBeLessThanOrEqual(bottomOf(popup) + TOLERANCE);
+    expect(bottomOf(body)).toBeLessThanOrEqual(footer.getBoundingClientRect().top + TOLERANCE);
   });
 });

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/modal-layout-chrome.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/modal-layout-chrome.test.tsx
@@ -1,0 +1,130 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ModalLayout } from '@renderer/lib/ui/modal-layout';
+import '@renderer/index.css';
+
+/**
+ * The body's cap used to be a constant standing in for the header and footer,
+ * which over-reserved by ~80px on a normal window and would have under-reserved
+ * had the footer ever grown a row — putting content back underneath it
+ * (CHOO-2243). `ModalLayout` measures them instead and publishes the total as
+ * `--modal-chrome`.
+ *
+ * Geometry, not class strings: the point is that the popup's own cap is
+ * respected, which only a real layout can show.
+ */
+
+const POPUP_HEIGHT = 400;
+const HEADER_HEIGHT = 40;
+const SHORT_FOOTER = 56;
+const TALL_FOOTER = 120;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function Harness({ footerHeight }: { footerHeight: number }) {
+  return (
+    <div
+      data-testid="popup"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        maxHeight: `${POPUP_HEIGHT}px`,
+        overflow: 'hidden',
+        width: '480px',
+      }}
+    >
+      <ModalLayout
+        header={<div data-testid="header" style={{ height: `${HEADER_HEIGHT}px` }} />}
+        footer={<div data-testid="footer" style={{ height: `${footerHeight}px` }} />}
+      >
+        <div
+          data-testid="body"
+          style={{
+            overflowY: 'auto',
+            maxHeight: `calc(${POPUP_HEIGHT}px - var(--modal-chrome, 136px))`,
+          }}
+        >
+          <div style={{ height: '2000px' }} />
+        </div>
+      </ModalLayout>
+    </div>
+  );
+}
+
+async function render(footerHeight: number): Promise<HTMLDivElement> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => root!.render(<Harness footerHeight={footerHeight} />));
+  await settle();
+  return container;
+}
+
+async function rerender(footerHeight: number): Promise<void> {
+  await act(async () => root!.render(<Harness footerHeight={footerHeight} />));
+  await settle();
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 12; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+  }
+}
+
+function bottomOf(el: Element): number {
+  return el.getBoundingClientRect().bottom;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+describe('ModalLayout chrome reservation', () => {
+  it('reserves exactly what the header and footer measure', async () => {
+    const el = await render(SHORT_FOOTER);
+    const body = el.querySelector('[data-testid="body"]')!;
+
+    expect(getComputedStyle(body).getPropertyValue('--modal-chrome').trim()).toBe(
+      `${HEADER_HEIGHT + SHORT_FOOTER}px`
+    );
+    expect(getComputedStyle(body).maxHeight).toBe(
+      `${POPUP_HEIGHT - HEADER_HEIGHT - SHORT_FOOTER}px`
+    );
+  });
+
+  it('keeps the footer inside the popup when the body is taller than the space', async () => {
+    const el = await render(SHORT_FOOTER);
+    const popup = el.querySelector('[data-testid="popup"]')!;
+    const footer = el.querySelector('[data-testid="footer"]')!;
+    const body = el.querySelector('[data-testid="body"]')!;
+
+    // Guard the guard: a body that fits would satisfy this without the cap
+    // doing any work.
+    expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
+
+    expect(bottomOf(footer)).toBeLessThanOrEqual(bottomOf(popup) + 0.5);
+    expect(bottomOf(body)).toBeLessThanOrEqual(footer.getBoundingClientRect().top + 0.5);
+  });
+
+  it('follows the footer when it grows a row', async () => {
+    const el = await render(SHORT_FOOTER);
+    await rerender(TALL_FOOTER);
+
+    const popup = el.querySelector('[data-testid="popup"]')!;
+    const footer = el.querySelector('[data-testid="footer"]')!;
+    const body = el.querySelector('[data-testid="body"]')!;
+
+    expect(getComputedStyle(body).getPropertyValue('--modal-chrome').trim()).toBe(
+      `${HEADER_HEIGHT + TALL_FOOTER}px`
+    );
+    expect(bottomOf(footer)).toBeLessThanOrEqual(bottomOf(popup) + 0.5);
+    expect(bottomOf(body)).toBeLessThanOrEqual(footer.getBoundingClientRect().top + 0.5);
+  });
+});


### PR DESCRIPTION
## The bug

Scrolled to the bottom of the **New agent** modal, the Cancel / Add agent footer sits over the amber "you have not linked a messaging account" callout and half-hides its **Open Messaging apps** link.

That link is the only actionable thing in the warning, and the warning exists to say the agent will silently answer nobody in those rooms — so a layout defect was hiding the remedy for a silent-failure condition.

Two commits: the defect, then the guess that would have brought it back.

## 1. The dropped resize (the reported bug)

The footer is **not** sticky and nothing overlays anything — worth stating, because "sticky footer overlaps" suggests a z-index or padding fix and neither would have helped.

`AnimatedHeight` pins its wrapper to a height measured synchronously on mount and, while idle, is `overflow-visible`. It also discarded the ResizeObserver's **first** delivery, reasoning that the mount measurement had already captured the size. That holds only while nothing changes in between:

1. The modal mounts. `useLayoutEffect` measures the body and pins the wrapper to it.
2. The Settings section opens itself as soon as the messaging-app lookup reports the warning applies. On a warm cache that lands in the **same commit as mount** — before the observer's first delivery.
3. That growth is therefore reported *only* in the discarded callback. The wrapper keeps the stale height.
4. The footer is laid out against the bottom of the too-short wrapper, and the body paints on underneath it.

Measured on the reported window (1413×903): a **695px body inside a 658px wrapper**, putting **37px** of the callout under the footer — beyond the reach of scrolling, since the body is already at its end.

Fix: drop the skip. `lastHeightRef` already suppresses an unchanged observation, which is what the skip was reaching for, so nothing starts animating on mount that did not before.

## 2. The reservation the body was capped by

The cap was `100dvh - 13rem` — a constant standing in for the header and footer. They measure 129px against the 208px reserved, so the modal ran ~47px shorter than the window allowed.

Wrong the other way it puts content back under the footer. The popup caps itself at `100dvh - 2rem`, so any header + footer over 176px makes body + chrome exceed that, and the body — pinned to a pixel height and `overflow-visible` while idle — paints past its box rather than shrinking. The footer wraps to a second row below `sm` and grows another while waiting on a remote host: **169px on a narrow window**, closer to that ceiling than a guess should be.

Fix: measure the header and footer, publish the total as `--modal-chrome`, and cap the body with `calc(100dvh-2rem-var(--modal-chrome))`. Arithmetic instead of an estimate, and it follows the footer when it grows.

`offsetHeight`, not a bounding rect — the popup zooms as it opens, and a rect read mid-animation is scaled with it. That measured 122.55px for a 129px chrome, which under-reserved and clipped the footer by 6px. Caught by running it, not by reading it.

## Blast radius

`AddAgentModal` is the **only** consumer of `ModalLayout`, and `ModalLayout` the only consumer of `AnimatedHeight`. Every other modal renders header, body and footer as direct flex children and was never affected.

## Verification

Verified **in the running app against the real signed-in state**, with the actual callout on screen: body 742px in an 871px popup, callout fully visible, its link 31px clear of the footer, nothing clipped. Swept ~40 window sizes including narrow ones where the footer wraps to two rows — no clipping, no overflow, popup always within its cap.

Two real-browser regression tests asserting **measured geometry** rather than class strings — this bug had every class correct, so a markup-level test would have sailed past it. Both were confirmed to fail against the old behaviour before being kept:

- `animated-height-late-growth.test.tsx` — content growing in the same commit as mount must stay inside its box (old behaviour: 220px outside).
- `modal-layout-chrome.test.tsx` — the reservation equals the measured chrome and follows a footer that grows a row.

Browser project green (25 files / 152 tests). `oxfmt`, `oxlint`, `tsc --noEmit` clean. One unrelated pre-existing `session-spawner` failure in the node project, present at the branch point too.

Before/after screenshots are in the Switch room — not inlined here because the full-window captures carry agent and room names, and this repo is public.

## Honest limitation

The original trigger needs the body to be shorter than its cap at mount *and* the query to resolve in that same commit. I reproduced the resulting geometry exactly by forcing the stale height, and the regression test drives the timing directly — but I never got the untouched code to fail spontaneously on my machine, only on the reporter's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)