### PR TITLE
Generate the Teams values nobody should be typing, and verify credentials on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,29 @@ version of their own to them without also giving them a release of their own.
   surfaces have to be reachable from where. Only the Teams listener needs the
   public internet; every other bridge connects outbound.
 
+- Bridge credentials are verified before a bridge is saved. Adapters start in a
+  background task whose exceptions are logged and swallowed, so credentials that
+  the platform rejects used to be stored, reported as success, and surface hours
+  later as an unrelated-looking failure. Registering a Teams bridge now asks
+  Azure for both tokens it will need first, and a refusal comes back as a 400
+  carrying Microsoft's own explanation — which names the mistake outright,
+  including the client secret **value** vs secret **ID** mix-up. Adapters opt in
+  by implementing `verify_credentials`; the default still accepts anything,
+  because an adapter that cannot check cheaply should not pretend to.
+
 #### Changed
+- A Teams bridge is five fields instead of nine. The `clientState` shared secret
+  and the Graph encryption certificate, public key and private key are generated
+  when the bridge is created rather than asked for: they are values the operator
+  invents rather than gets from Microsoft, and asking meant an invented secret,
+  an `openssl` invocation, and three PEM fields whose only symptom when pasted
+  wrong is channel capture that silently never decrypts. Supplying your own
+  through the API still wins, all three or none. Existing bridges are untouched,
+  including any left without encryption material.
+- The Teams Graph private key is no longer typed into a plaintext form field.
+  The gateway decides which inputs to mask by matching the field name against
+  `token|password|secret|api_key`, which `encryption_private_key` does not match;
+  generating it removes the field from the form entirely.
 - `docs/bridges/TEAMS_SETUP.md` rewritten. It now walks through Azure setup
   value by value and says where each one comes from, documents the deployment
   and public-ingress requirements (previously absent), and adds verification and

--- a/core/switch_core/bridges/collaboration/adapter.py
+++ b/core/switch_core/bridges/collaboration/adapter.py
@@ -61,6 +61,32 @@ class CollaborationAdapter(ABC):
     def set_max_attachment_bytes(self, max_bytes: int) -> None:
         self._max_attachment_bytes = max_bytes
 
+    @classmethod
+    def prepare_config(cls, connection_config: dict[str, object]) -> dict[str, object]:
+        """Fill in values the operator should not have to supply, at create time.
+
+        Called once, when a bridge is registered — never on start, so a value
+        minted here is persisted and stable for the life of the bridge. An
+        adapter that generates key material must do it here rather than in a
+        model default, or every restart would mint a fresh one and quietly
+        invalidate whatever the last one signed or encrypted.
+        """
+        return connection_config
+
+    @classmethod
+    async def verify_credentials(cls, connection_config: dict[str, object]) -> None:
+        """Prove the credentials work, before the bridge is persisted.
+
+        Raise :class:`BridgeCredentialError` with a message fit for an operator
+        to read. Adapters start in a background task whose exceptions are logged
+        and swallowed, so without this a wrong password looks like success and
+        surfaces hours later as an unrelated-looking failure.
+
+        The default accepts anything: an adapter that cannot check cheaply
+        should not pretend to.
+        """
+        return None
+
     @abstractmethod
     async def start(
         self,

--- a/core/switch_core/bridges/collaboration/lifecycle_service.py
+++ b/core/switch_core/bridges/collaboration/lifecycle_service.py
@@ -110,7 +110,19 @@ class CollaborationBridgeLifecycleService:
         if adapter_cls is None or config_cls is None:
             raise ValueError(f"Unknown bridge type: {bridge_type}")
 
-        config_cls.model_validate(connection_config)
+        # Fill in what the adapter generates, validate the result, and persist
+        # the validated form — not the raw request — so a value minted here is
+        # stored once and never re-derived.
+        connection_config = adapter_cls.prepare_config(connection_config)
+        validated = config_cls.model_validate(connection_config)
+        connection_config = validated.model_dump(mode="json")
+
+        # Before anything is written. The adapter runs in a background task
+        # whose failures are logged and swallowed, so credentials that are wrong
+        # would otherwise be stored, reported as success, and only surface later
+        # as an unrelated-looking error. Failing here also avoids leaving an
+        # orphan Matrix identity behind for a bridge that was never viable.
+        await adapter_cls.verify_credentials(connection_config)
 
         safe_name = re.sub(r"[^a-z0-9._=-]", "-", display_name.lower())[:16]
         bridge_client_record = await self._client_lifecycle.create_client(

--- a/core/switch_core/bridges/collaboration/models.py
+++ b/core/switch_core/bridges/collaboration/models.py
@@ -106,3 +106,12 @@ class InboundAppJoin(BaseModel):
 
 class BridgeConnectionConfig(BaseModel):
     pass
+
+
+class BridgeCredentialError(Exception):
+    """A bridge's credentials were rejected by the platform.
+
+    Carries a message intended for the operator who typed them, so it is
+    surfaced verbatim rather than being reduced to "invalid configuration" —
+    the platform's own explanation is almost always the actionable part.
+    """

--- a/core/switch_core/bridges/collaboration/teams/adapter.py
+++ b/core/switch_core/bridges/collaboration/teams/adapter.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import html
+import json
 import logging
 import re
+import secrets
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
@@ -13,6 +15,7 @@ from urllib.parse import quote
 
 import httpx
 from aiohttp import web
+from pydantic import model_validator
 from pydantic.json_schema import SkipJsonSchema
 
 from switch_core.bridges.collaboration.adapter import (
@@ -21,6 +24,7 @@ from switch_core.bridges.collaboration.adapter import (
 )
 from switch_core.bridges.collaboration.models import (
     BridgeConnectionConfig,
+    BridgeCredentialError,
     ChannelType,
     InboundAgentJoin,
     InboundAppJoin,
@@ -39,6 +43,7 @@ from switch_core.bridges.collaboration.teams.cards import (
 from switch_core.bridges.collaboration.teams.connector import BotConnectorClient
 from switch_core.bridges.collaboration.teams.crypto import (
     decrypt_resource_data,
+    generate_encryption_keypair,
     load_certificate_der_b64,
 )
 from switch_core.bridges.collaboration.teams.graph import GraphClient
@@ -82,6 +87,30 @@ def _strip_leading_mention(text: str) -> str:
     return _LEADING_MENTION_TAG.sub("", text, count=1)
 
 
+def _aad_failure_message(exc: Exception) -> str:
+    """Reduce an AAD token failure to the sentence an operator can act on.
+
+    The raw failure carries the whole OAuth error body — trace ids, correlation
+    ids, timestamps — wrapped around one useful sentence. Microsoft writes that
+    sentence well (it names the client-secret value-vs-ID mix-up outright), so
+    surface it and drop the rest. Falls back to the full text if the body is not
+    the shape we expect, rather than losing the detail.
+    """
+    text = str(exc)
+    start = text.find("{")
+    if start != -1:
+        try:
+            body = json.loads(text[start:])
+        except json.JSONDecodeError:
+            body = None
+        if isinstance(body, dict):
+            description = body.get("error_description")
+            if isinstance(description, str) and description:
+                sentence = description.split("Trace ID:")[0].strip().rstrip(".")
+                return f"Microsoft rejected these credentials — {sentence}."
+    return f"Microsoft rejected these credentials — {text}"
+
+
 # Channel-message subscriptions with resource data live at most 60 minutes; we
 # request 55 and proactively renew well before expiry.
 _SUBSCRIPTION_TTL = timedelta(minutes=55)
@@ -122,17 +151,29 @@ class TeamsConnectionConfig(BridgeConnectionConfig):
 
     # Graph change-notification resource-data encryption. Graph encrypts message
     # bodies with the public certificate; the private key decrypts them on
-    # delivery. Required once channel-message subscriptions are enabled.
-    encryption_certificate_id: str | None = None
-    encryption_public_certificate: str | None = None
-    encryption_private_key: str | None = None
+    # delivery. Required once channel-message subscriptions are enabled, so the
+    # trio is generated on creation rather than asked for — an operator pasting
+    # PEMs into a form is three chances to disable channel capture silently, and
+    # the certificate is key transport that Graph never validates against a trust
+    # store, so there is nothing an operator-supplied one would buy. Hidden from
+    # the gateway form; supplying your own through the API still wins.
+    encryption_certificate_id: SkipJsonSchema[str | None] = None
+    encryption_public_certificate: SkipJsonSchema[str | None] = None
+    encryption_private_key: SkipJsonSchema[str | None] = None
 
     # Shared secret echoed back in every change notification and validated on
-    # receipt. Required, and the ONLY control that authenticates a notification's
-    # origin: Graph resource-data encryption proves integrity but NOT origin (the
-    # wrapping key is the public certificate, which anyone can encrypt to), so
-    # without clientState the notification endpoint is spoofable.
-    client_state: str
+    # receipt. The ONLY control that authenticates a notification's origin: Graph
+    # resource-data encryption proves integrity but NOT origin (the wrapping key
+    # is the public certificate, which anyone can encrypt to), so without
+    # clientState the notification endpoint is spoofable.
+    #
+    # Generated, not asked for: it is a secret with no external meaning, so
+    # prompting an operator to invent one only invites a weak or reused value.
+    # Required rather than defaulted, and minted in prepare_config at
+    # registration — a default here would mint a fresh secret every time a stored
+    # config was validated, and every live subscription would start failing its
+    # origin check with nothing to point at.
+    client_state: SkipJsonSchema[str]
 
     # Bot Connector serviceUrl (the per-tenant outbound endpoint). It is learned
     # from inbound Bot Framework activities and persisted here so outbound
@@ -145,6 +186,27 @@ class TeamsConnectionConfig(BridgeConnectionConfig):
     # hidden from the gateway config form (SkipJsonSchema).
     service_url: SkipJsonSchema[str | None] = None
 
+    @model_validator(mode="after")
+    def _encryption_material_is_all_or_nothing(self) -> TeamsConnectionConfig:
+        """A half-supplied encryption trio is a mistake, not a partial request.
+
+        Completing it for them would pair someone's certificate with a private
+        key they do not hold, and the only symptom would be channel capture that
+        never decrypts.
+        """
+        supplied = [
+            self.encryption_certificate_id,
+            self.encryption_public_certificate,
+            self.encryption_private_key,
+        ]
+        if any(supplied) and not all(supplied):
+            raise ValueError(
+                "encryption_certificate_id, encryption_public_certificate and "
+                "encryption_private_key must be supplied together, or all left "
+                "unset to have them generated"
+            )
+        return self
+
 
 class TeamsAdapter(CollaborationAdapter):
     """Microsoft Teams collaboration adapter.
@@ -156,6 +218,61 @@ class TeamsAdapter(CollaborationAdapter):
     aiohttp listener. Full (non-@mention) channel-message capture via Microsoft
     Graph subscriptions is layered on in a later phase.
     """
+
+    @classmethod
+    def prepare_config(cls, connection_config: dict[str, object]) -> dict[str, object]:
+        """Mint the clientState secret and the Graph encryption trio.
+
+        Here rather than as model defaults because this runs only at
+        registration, so what it produces is persisted once and never re-derived.
+        A default on the model would mint fresh values every time a stored config
+        was validated — a new certificate and a new shared secret on every
+        restart, while Graph carried on encrypting to the old certificate and
+        echoing the old secret. Capture would fail its origin check and its
+        decryption, with nothing in the logs pointing at why.
+        """
+        prepared = dict(connection_config)
+        if not prepared.get("client_state"):
+            prepared["client_state"] = secrets.token_urlsafe(32)
+        keys = (
+            "encryption_certificate_id",
+            "encryption_public_certificate",
+            "encryption_private_key",
+        )
+        if any(prepared.get(k) for k in keys):
+            return prepared
+        cert_pem, key_pem = generate_encryption_keypair()
+        prepared["encryption_certificate_id"] = f"switch-teams-{secrets.token_hex(8)}"
+        prepared["encryption_public_certificate"] = cert_pem
+        prepared["encryption_private_key"] = key_pem
+        return prepared
+
+    @classmethod
+    async def verify_credentials(cls, connection_config: dict[str, object]) -> None:
+        """Ask Azure AD for both tokens the bridge will need.
+
+        This is the call that fails on a wrong client secret, and Microsoft's
+        error names the mistake precisely — including the classic case of the
+        secret's ID being pasted instead of its value. Getting that to the
+        operator at save time is the whole point.
+        """
+        config = TeamsConnectionConfig.model_validate(connection_config)
+        async with httpx.AsyncClient(timeout=30) as http:
+            tokens = TeamsTokenProvider(
+                tenant_id=config.tenant_id,
+                app_id=config.app_id,
+                app_password=config.app_password,
+                http=http,
+            )
+            try:
+                await tokens.graph_token()
+                await tokens.bot_token()
+            except RuntimeError as exc:
+                raise BridgeCredentialError(_aad_failure_message(exc)) from exc
+            except httpx.HTTPError as exc:
+                raise BridgeCredentialError(
+                    f"Could not reach Microsoft to verify these credentials: {exc}"
+                ) from exc
 
     def __init__(self, *, config: TeamsConnectionConfig) -> None:
         super().__init__()

--- a/core/switch_core/bridges/collaboration/teams/crypto.py
+++ b/core/switch_core/bridges/collaboration/teams/crypto.py
@@ -4,15 +4,18 @@ import base64
 import hashlib
 import hmac
 import json
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
+from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.primitives.hashes import SHA1
+from cryptography.hazmat.primitives.hashes import SHA1, SHA256
 from cryptography.hazmat.primitives.padding import PKCS7
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.x509.oid import NameOID
 
 
 class ResourceDataError(RuntimeError):
@@ -81,6 +84,44 @@ def decrypt_resource_data(
     except json.JSONDecodeError as e:
         raise ResourceDataError(f"decrypted resource is not valid JSON: {e}") from e
     return result
+
+
+def generate_encryption_keypair() -> tuple[str, str]:
+    """Mint a self-signed X.509 keypair for Graph resource-data encryption.
+
+    Graph uses the certificate purely as key transport for the per-notification
+    symmetric key: it encrypts to the public key and never validates a chain, an
+    issuer or an expiry against any trust store. So a self-signed certificate is
+    not a compromise here — there is no party for a CA to vouch to.
+
+    Returns ``(certificate_pem, private_key_pem)``.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "switch-teams-bridge")]
+    )
+    # Graph rejects a subscription whose certificate is outside its validity
+    # window, so this has to outlive the bridge in practice. Rotation replaces
+    # the pair rather than renewing it.
+    not_before = datetime(2000, 1, 1, tzinfo=UTC)
+    not_after = not_before + timedelta(days=365 * 100)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .sign(key, SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    return cert_pem, key_pem
 
 
 def load_certificate_der_b64(cert_pem: str) -> str:

--- a/core/switch_core/gateway/collaborations.py
+++ b/core/switch_core/gateway/collaborations.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from switch_core.bridges.collaboration.lifecycle_service import (
     CollaborationBridgeLifecycleService,
 )
+from switch_core.bridges.collaboration.models import BridgeCredentialError
 from switch_core.db.models import CollaborationBridge, User
 from switch_core.db.stores.collaboration_bridge_store import CollaborationBridgeStore
 from switch_core.db.stores.external_user_store import ExternalUserStore
@@ -114,6 +115,10 @@ async def create_bridge(
             display_name=req.display_name,
             connection_config=dict(req.connection_config),
         )
+    except BridgeCredentialError as exc:
+        # The platform's own words, verbatim — it knows what is wrong with the
+        # credentials and we do not.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except ValueError as exc:

--- a/core/tests/switch_core/bridges/collaboration/test_bridge_type_registry.py
+++ b/core/tests/switch_core/bridges/collaboration/test_bridge_type_registry.py
@@ -88,31 +88,29 @@ def test_teams_adapter_registers_with_expected_required_fields() -> None:
     assert "teams" in service.get_registered_types()
 
     schema = service.get_config_schema("teams")
-    # The credentials + endpoint fields with no default are required; the
-    # subscription/encryption fields are optional. client_state is required —
-    # it is the only control that authenticates a notification's origin.
+    # Every field on the form is a value the operator has to fetch from Azure,
+    # and all of them are required — there is no such thing as a half-configured
+    # Teams bridge.
     assert set(schema["required"]) == {
         "app_id",
         "app_password",
         "tenant_id",
         "team_id",
         "public_base_url",
-        "client_state",
     }
-    # Switch-internal fields (the listener bind, the runtime-learned serviceUrl)
-    # are hidden from the admin config form — the admin only supplies genuine
-    # Teams/Azure credentials + endpoint.
-    assert set(schema["properties"]) == {
-        "app_id",
-        "app_password",
-        "tenant_id",
-        "team_id",
-        "public_base_url",
+    assert set(schema["properties"]) == set(schema["required"])
+    # Switch-internal fields are hidden: the listener bind and the
+    # runtime-learned serviceUrl, plus everything Switch generates for itself —
+    # the clientState shared secret and the Graph encryption trio. Asking an
+    # operator to invent a secret or paste PEMs is three ways to get a silently
+    # broken bridge.
+    for hidden in (
+        "listen_host",
+        "listen_port",
+        "service_url",
         "client_state",
         "encryption_certificate_id",
         "encryption_public_certificate",
         "encryption_private_key",
-    }
-    assert "listen_host" not in schema["properties"]
-    assert "listen_port" not in schema["properties"]
-    assert "service_url" not in schema["properties"]
+    ):
+        assert hidden not in schema["properties"]

--- a/core/tests/switch_core/bridges/collaboration/test_teams_zero_config.py
+++ b/core/tests/switch_core/bridges/collaboration/test_teams_zero_config.py
@@ -1,0 +1,356 @@
+"""Values Switch generates for a Teams bridge, and the save-time credential check."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from pydantic import ValidationError
+
+from switch_core.bridges.collaboration.adapter import CollaborationAdapter
+from switch_core.bridges.collaboration.lifecycle_service import (
+    CollaborationBridgeLifecycleService,
+)
+from switch_core.bridges.collaboration.models import (
+    BridgeConnectionConfig,
+    BridgeCredentialError,
+)
+from switch_core.bridges.collaboration.teams.adapter import (
+    TeamsAdapter,
+    TeamsConnectionConfig,
+)
+from switch_core.bridges.collaboration.teams.crypto import (
+    generate_encryption_keypair,
+    load_certificate_der_b64,
+)
+
+
+def _raw_config(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "app_id": "app-id",
+        "app_password": "app-password",
+        "tenant_id": "tenant-id",
+        "team_id": "team-id",
+        "public_base_url": "https://teams.example.com",
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Generated values ─────────────────────────────────────────────────────────
+
+
+def test_client_state_is_generated_and_unguessable() -> None:
+    first = TeamsAdapter.prepare_config(_raw_config())
+    second = TeamsAdapter.prepare_config(_raw_config())
+
+    assert len(str(first["client_state"])) >= 32
+    assert first["client_state"] != second["client_state"]
+
+
+def test_client_state_supplied_by_caller_wins() -> None:
+    prepared = TeamsAdapter.prepare_config(_raw_config(client_state="mine"))
+
+    assert prepared["client_state"] == "mine"
+
+
+def test_a_config_with_no_client_state_is_rejected_not_filled_in() -> None:
+    """Silently minting one would break every live subscription's origin check."""
+    with pytest.raises(ValidationError, match="client_state"):
+        TeamsConnectionConfig.model_validate(_raw_config())
+
+
+def test_prepare_config_generates_a_usable_encryption_trio() -> None:
+    prepared = TeamsAdapter.prepare_config(_raw_config())
+
+    assert prepared["encryption_certificate_id"]
+    # The certificate has to survive the exact round trip the subscription path
+    # puts it through, and the private key has to parse.
+    assert load_certificate_der_b64(str(prepared["encryption_public_certificate"]))
+    assert load_pem_private_key(
+        str(prepared["encryption_private_key"]).encode(), password=None
+    )
+
+
+def test_generated_certificate_matches_its_private_key() -> None:
+    cert_pem, key_pem = generate_encryption_keypair()
+
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    key = load_pem_private_key(key_pem.encode(), password=None)
+
+    assert cert.public_key().public_numbers() == key.public_key().public_numbers()
+
+
+def test_prepare_config_leaves_a_supplied_trio_alone() -> None:
+    cert_pem, key_pem = generate_encryption_keypair()
+    prepared = TeamsAdapter.prepare_config(
+        _raw_config(
+            encryption_certificate_id="mine",
+            encryption_public_certificate=cert_pem,
+            encryption_private_key=key_pem,
+        )
+    )
+
+    assert prepared["encryption_certificate_id"] == "mine"
+    assert prepared["encryption_public_certificate"] == cert_pem
+
+
+def test_prepare_config_does_not_mutate_its_argument() -> None:
+    raw = _raw_config()
+    TeamsAdapter.prepare_config(raw)
+
+    assert "encryption_private_key" not in raw
+
+
+def test_validating_a_stored_config_never_regenerates_key_material() -> None:
+    """The pair is minted once, at registration.
+
+    Regenerating on every validate would mean a fresh certificate each restart
+    while Graph kept encrypting to the previous one, and capture would fail to
+    decrypt with nothing to point at.
+    """
+    stored = TeamsAdapter.prepare_config(_raw_config())
+
+    first = TeamsConnectionConfig.model_validate(stored)
+    second = TeamsConnectionConfig.model_validate(stored)
+
+    assert first.encryption_private_key == second.encryption_private_key
+    assert first.client_state == second.client_state
+
+
+def test_a_config_with_no_encryption_material_stays_empty() -> None:
+    """A bridge registered before generation existed keeps its degraded state.
+
+    Filling it in here would silently pair it with a certificate Graph was never
+    told about.
+    """
+    config = TeamsConnectionConfig.model_validate(_raw_config(client_state="s"))
+
+    assert config.encryption_private_key is None
+    assert config.encryption_public_certificate is None
+
+
+def test_half_an_encryption_trio_is_rejected() -> None:
+    cert_pem, _ = generate_encryption_keypair()
+
+    with pytest.raises(ValidationError, match="must be supplied together"):
+        TeamsConnectionConfig.model_validate(
+            _raw_config(client_state="s", encryption_public_certificate=cert_pem)
+        )
+
+
+# ── Save-time credential verification ────────────────────────────────────────
+
+
+class _FakeHttp:
+    """Stands in for httpx.AsyncClient as an async context manager."""
+
+    def __init__(self, status: int, body: Any) -> None:
+        self.status = status
+        self.body = body
+        self.calls: list[str] = []
+
+    async def __aenter__(self) -> _FakeHttp:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def post(self, url: str, data: dict[str, str]) -> httpx.Response:
+        self.calls.append(data["scope"])
+        return httpx.Response(
+            status_code=self.status,
+            json=self.body,
+            request=httpx.Request("POST", url),
+        )
+
+
+@pytest.fixture
+def fake_http(monkeypatch: pytest.MonkeyPatch) -> Any:
+    def _install(status: int, body: Any) -> _FakeHttp:
+        client = _FakeHttp(status, body)
+        monkeypatch.setattr(
+            "switch_core.bridges.collaboration.teams.adapter.httpx.AsyncClient",
+            lambda **_: client,
+        )
+        return client
+
+    return _install
+
+
+async def test_verify_credentials_requests_both_scopes(fake_http: Any) -> None:
+    client = fake_http(200, {"access_token": "tok", "expires_in": 3600})
+
+    await TeamsAdapter.verify_credentials(TeamsAdapter.prepare_config(_raw_config()))
+
+    assert client.calls == [
+        "https://graph.microsoft.com/.default",
+        "https://api.botframework.com/.default",
+    ]
+
+
+async def test_verify_credentials_surfaces_the_secret_id_mistake(
+    fake_http: Any,
+) -> None:
+    """The failure that cost this the most time must reach the operator intact."""
+    fake_http(
+        401,
+        {
+            "error": "invalid_client",
+            "error_description": (
+                "AADSTS7000215: Invalid client secret provided. Ensure the secret "
+                "being sent in the request is the client secret value, not the "
+                "client secret ID, for a secret added to app 'abc'. "
+                "Trace ID: 1234 Correlation ID: 5678"
+            ),
+        },
+    )
+
+    with pytest.raises(BridgeCredentialError) as excinfo:
+        await TeamsAdapter.verify_credentials(_raw_config(client_state="s"))
+
+    message = str(excinfo.value)
+    assert "not the client secret ID" in message
+    # The trace and correlation ids are noise to the person reading a form error.
+    assert "Trace ID" not in message
+
+
+async def test_verify_credentials_keeps_an_unparseable_body(fake_http: Any) -> None:
+    fake_http(500, "upstream exploded")
+
+    with pytest.raises(BridgeCredentialError, match="upstream exploded"):
+        await TeamsAdapter.verify_credentials(_raw_config(client_state="s"))
+
+
+async def test_verify_credentials_reports_an_unreachable_microsoft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Unreachable(_FakeHttp):
+        async def post(self, url: str, data: dict[str, str]) -> httpx.Response:
+            raise httpx.ConnectError("no route to host")
+
+    monkeypatch.setattr(
+        "switch_core.bridges.collaboration.teams.adapter.httpx.AsyncClient",
+        lambda **_: _Unreachable(200, {}),
+    )
+
+    with pytest.raises(BridgeCredentialError, match="Could not reach Microsoft"):
+        await TeamsAdapter.verify_credentials(_raw_config(client_state="s"))
+
+
+# ── register() wiring ────────────────────────────────────────────────────────
+
+
+class _RecordingAdapter(CollaborationAdapter):
+    """Records the order register() drives the two hooks in."""
+
+    events: list[str] = []
+    seen_config: dict[str, object] = {}
+    fail_verification = False
+
+    @classmethod
+    def prepare_config(cls, connection_config: dict[str, object]) -> dict[str, object]:
+        cls.events.append("prepare")
+        return {**connection_config, "generated": "yes"}
+
+    @classmethod
+    async def verify_credentials(cls, connection_config: dict[str, object]) -> None:
+        cls.events.append("verify")
+        cls.seen_config = dict(connection_config)
+        if cls.fail_verification:
+            raise BridgeCredentialError("platform said no")
+
+    async def start(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+        raise AssertionError("start must not run when verification fails")
+
+    async def stop(self) -> None:  # pragma: no cover
+        return None
+
+    async def send_message(self, *args: Any, **kwargs: Any) -> str | None:
+        return None
+
+    async def create_channel(self, *args: Any, **kwargs: Any) -> str:
+        return "c"
+
+    async def get_channel_type(self, *args: Any, **kwargs: Any) -> Any:
+        return None
+
+    async def add_agents_to_channel(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def add_users_to_channel(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def create_agent_identity(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def remove_agent_identity(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def get_channel_agent_names(self, *args: Any, **kwargs: Any) -> list[str]:
+        return []
+
+
+class _RecordingConfig(BridgeConnectionConfig):
+    app_id: str
+    generated: str
+
+
+def _lifecycle() -> CollaborationBridgeLifecycleService:
+    service = CollaborationBridgeLifecycleService(
+        bridge_store=MagicMock(),
+        external_user_store=MagicMock(),
+        bridge_message_map_store=MagicMock(),
+        room_store=MagicMock(),
+        agent_store=MagicMock(),
+        client_store=MagicMock(),
+        client_lifecycle=MagicMock(),
+        room_service=MagicMock(),
+        matrix_admin=MagicMock(),
+        session_factory=MagicMock(),
+        config=MagicMock(),
+    )
+    service.register_adapter("recording", _RecordingAdapter, _RecordingConfig)
+    return service
+
+
+async def test_register_prepares_then_verifies_before_touching_anything() -> None:
+    """Verification has to precede the Matrix identity and the DB write.
+
+    Otherwise a bridge that was never viable still leaves an orphan client
+    behind, and the row has to be cleaned up by hand.
+    """
+    _RecordingAdapter.events = []
+    _RecordingAdapter.fail_verification = True
+    service = _lifecycle()
+
+    with pytest.raises(BridgeCredentialError, match="platform said no"):
+        await service.register(
+            bridge_type="recording",
+            display_name="Recording",
+            connection_config={"app_id": "a"},
+        )
+
+    assert _RecordingAdapter.events == ["prepare", "verify"]
+    # No Matrix identity was minted for a bridge that cannot work.
+    service._client_lifecycle.create_client.assert_not_called()  # type: ignore[attr-defined]
+
+
+async def test_register_verifies_the_prepared_config_not_the_raw_request() -> None:
+    """A generated credential must be the one that gets checked."""
+    _RecordingAdapter.events = []
+    _RecordingAdapter.fail_verification = True
+    service = _lifecycle()
+
+    with pytest.raises(BridgeCredentialError):
+        await service.register(
+            bridge_type="recording",
+            display_name="Recording",
+            connection_config={"app_id": "a"},
+        )
+
+    assert _RecordingAdapter.seen_config["generated"] == "yes"

--- a/docs/bridges/TEAMS_SETUP.md
+++ b/docs/bridges/TEAMS_SETUP.md
@@ -26,8 +26,8 @@ Both produce confusing failures. Neither is obvious from the error you see.
 When you create a client secret, the Azure portal shows two columns: **Value**
 and **Secret ID**. Both look like opaque strings. You want the **Value**.
 
-Pasting the Secret ID gives you this, at the moment the bridge first calls
-Microsoft — typically when you add the first room:
+Pasting the Secret ID is rejected when you save the bridge, with Microsoft's
+own words:
 
 ```
 AADSTS7000215: Invalid client secret provided. Ensure the secret being sent
@@ -147,29 +147,25 @@ consented behave as if absent, and the resulting Graph errors say
 > subscription quota**. A tenant already using Graph subscriptions heavily can
 > hit that ceiling.
 
-### 1.5 Encryption certificate
+### 1.5 Encryption certificate — nothing to do
 
-Required for full channel capture (not for `@mention`-only operation). Graph
-encrypts message bodies to a public certificate; the bridge decrypts with the
-private key.
+Full channel capture needs an X.509 keypair: Graph encrypts message bodies to a
+public certificate and the bridge decrypts with the private key. **Switch
+generates it when you create the bridge**, so there is no step here and no
+`openssl` to run.
 
-Any X.509 keypair works — it is used purely as a key transport, and Microsoft
-never validates a chain, so self-signed is fine:
+The certificate is pure key transport — Microsoft never validates it against a
+trust store, checks an issuer, or cares who signed it — so a generated
+self-signed pair is not a compromise. There is no party for a CA to vouch to.
 
-```bash
-openssl req -x509 -newkey rsa:2048 -keyout teams-key.pem -out teams-cert.pem \
-  -days 730 -nodes -subj "/CN=switch-teams-bridge"
-```
+If your organisation insists on supplying its own, the three fields still exist
+on the API (`encryption_certificate_id`, `encryption_public_certificate`,
+`encryption_private_key`) and a supplied set takes precedence. Supply all three
+or none; a partial set is rejected, because pairing someone's certificate with a
+private key they do not hold fails only at decryption time, long after the
+mistake.
 
-You supply three values in Part 3:
-
-- `encryption_certificate_id` — any stable string you choose (e.g.
-  `switch-teams-v1`). It labels the key so you can rotate later.
-- `encryption_public_certificate` — contents of `teams-cert.pem`
-- `encryption_private_key` — contents of `teams-key.pem`
-
-Rotating means generating a new pair, giving it a **new** id, and updating all
-three together.
+Rotating means creating a new bridge, which mints a new pair.
 
 ### 1.6 Teams app package
 
@@ -345,32 +341,41 @@ and its own ingress route.
 As a gateway admin: **Messaging Apps → Add bridge → Teams**, give it a display
 name (e.g. "Acme Teams"), and fill in the fields.
 
-Fields (`TeamsConnectionConfig`), with where each value came from:
+There are five, and every one is a value Azure gave you in Part 1:
 
-| Field | Required | Value | From |
-| --- | --- | --- | --- |
-| `app_id` | yes | Application (client) ID | 1.1 |
-| `app_password` | yes | Client secret **Value** — not the Secret ID | 1.2 |
-| `tenant_id` | yes | Directory (tenant) ID | 1.1 |
-| `team_id` | yes | AAD group id of the team new channels go into | 1.6 |
-| `public_base_url` | yes | Public HTTPS origin **of the listener** — scheme + host, no path. Under `mode: dedicated` that is the Teams host (`https://teams.example.com`), not the gateway's; a Helm install prints the exact value to use | Part 2 |
-| `client_state` | yes | A shared secret you invent. Echoed in every Graph notification and validated on receipt — the only control authenticating a notification's origin | — |
-| `encryption_certificate_id` | for channel capture | Stable id you chose | 1.5 |
-| `encryption_public_certificate` | for channel capture | PEM public certificate | 1.5 |
-| `encryption_private_key` | for channel capture | PEM private key | 1.5 |
+| Field | Value | From |
+| --- | --- | --- |
+| `app_id` | Application (client) ID | 1.1 |
+| `app_password` | Client secret **Value** — not the Secret ID | 1.2 |
+| `tenant_id` | Directory (tenant) ID | 1.1 |
+| `team_id` | AAD group id of the team new channels go into | 1.6 |
+| `public_base_url` | Public HTTPS origin **of the listener** — scheme + host, no path. Under `mode: dedicated` that is the Teams host (`https://teams.example.com`), not the gateway's; a Helm install prints the exact value to use | Part 2 |
 
-Switch-internal fields, hidden from the gateway form:
+**Switch checks these before saving.** It requests both Azure tokens the bridge
+needs, and if Microsoft refuses, the form fails with Microsoft's own
+explanation instead of accepting the values and going quiet. So a wrong secret
+is a red message in front of you, not a mystery hours later.
 
+That also means creating a bridge requires Switch to reach
+`login.microsoftonline.com`. On a restricted network, allow that egress first.
+
+Everything else is generated or learned, and hidden from the form:
+
+- `client_state` — the shared secret echoed in every Graph notification and
+  validated on receipt. Minted per bridge; there is nothing to invent.
+- The **encryption trio** — generated (1.5), so channel capture works out of the
+  box rather than only once someone pastes three PEMs correctly.
 - `listen_host` / `listen_port` (default `0.0.0.0:3978`) — the listener bind.
   Override via the stored `connection_config` only when running more than one
   Teams bridge on a host.
 - `service_url` — the Bot Connector outbound endpoint, learned at runtime from
   inbound activities and persisted automatically.
 
-Without the three encryption fields the bridge still runs — outbound, chats and
-`@mention` capture all work — but per-channel Graph subscriptions are skipped
-and an error is logged. **Full channel capture is disabled until they are
-supplied.**
+**Bridges created before Switch generated this material keep their original
+values**, including no encryption material at all — in which case channel
+capture stays off and an error is logged. There is no way to edit a bridge's
+credentials, so adopting the generated ones means deleting it and creating it
+again.
 
 ---
 
@@ -430,14 +435,16 @@ passes 5 and fails 6 is the signature of unreachable ingress.
 
 Symptoms as they actually appear, and what each one means.
 
-**`AADSTS7000215: Invalid client secret provided`**
+**`AADSTS7000215: Invalid client secret provided`**, when saving the bridge
 The `app_password` is the secret **ID** instead of the secret **value**, or the
 secret has expired. Create a new secret and use the Value column. See 1.2.
 
 **`Could not list existing Graph subscriptions on start`** (at startup)
-The first Graph call failed. Same causes as above, plus missing admin consent on
-the Graph permissions. The bridge starts anyway and fails later, at the first
-real operation.
+The first Graph call failed — missing admin consent on the Graph permissions, or
+a secret that expired after the bridge was created. The bridge starts anyway and
+fails at the first real operation. Credentials are checked when the bridge is
+saved, so on a bridge created since then this points at consent or expiry rather
+than a typo.
 
 **Adding a room to the bridge returns an error**
 Channel provisioning called Graph and Graph refused. The switch-core logs carry
@@ -460,8 +467,9 @@ DNS.
 
 **`Cannot subscribe to channel <id> messages: encryption certificate not
 configured on the Teams bridge`**
-The three encryption fields are absent. Expected if you deliberately run
-`@mention`-only; otherwise supply them (1.5).
+The bridge has no encryption material. Switch generates it at creation, so this
+means a bridge created before it did — or one deliberately registered without
+it. There is no way to add it to an existing bridge; delete and re-create.
 
 **`no Bot Connector serviceUrl known for channel <id> — the bot has not yet
 received an activity from this tenant`**


### PR DESCRIPTION
Stacked on #208 — review that first; this diff is only the second commit.

## Why

Connecting a Teams bridge asked for nine values. Four were not values Microsoft
gives you, they were values you **invent**: the `clientState` shared secret, and
an X.509 keypair the docs told you to generate with `openssl` and paste in as
three fields.

Each is a way to end up with a bridge that looks configured and silently is not.
A mistyped PEM disables channel capture with no symptom until somebody notices
messages are missing. And the fifth field, the client secret, had its own trap:
paste the secret's **ID** instead of its **value** and the bridge saves happily,
then fails hours later with an error nobody sees.

## What changed

**Five fields instead of nine.** `client_state` and the encryption trio are
generated at registration. Supplying your own still wins — all three or none, since
pairing a certificate with a private key you do not hold also fails only at
decryption time.

They are minted in a new `prepare_config` hook that runs **once**, at
registration. That placement is the point: as model defaults they would be
regenerated on every validate, so each restart would bring a fresh certificate
while Graph carried on encrypting to the previous one, and a fresh `clientState`
while Graph echoed the old. Capture would fail its origin check and its
decryption with nothing to point at. For the same reason `client_state` stays
*required* on the model rather than defaulted: a stored config missing it should
fail loudly, not quietly acquire a new secret. There is a test for each of these.

**Credentials are verified before anything is written.** Adapters start in a
background task whose exceptions are logged and swallowed, so a rejected
credential was stored, reported as success, and surfaced later as something
unrelated-looking — which is how the parent ticket began. `register()` now calls
`verify_credentials` first; Teams asks Azure for both tokens it needs and passes
Microsoft's refusal through as a `400`, trace ids stripped. Microsoft names the
value-vs-ID mistake outright, so that message is the useful part.

Running before the Matrix identity is minted also stops a non-viable bridge
leaving an orphan client behind.

The default hook accepts anything — an adapter that cannot check cheaply should
not pretend to. The cost of the Teams one: registering a bridge now needs egress
to `login.microsoftonline.com`, which the setup doc states.

**Incidental fix.** The gateway decides which inputs to mask by matching the
field name against `token|password|secret|api_key`. `encryption_private_key`
does not match, so the Graph private key was being typed into a **plaintext**
field. Generating it removes the field from the form.

## Notes

- **No frontend change needed** — the bridge form is generated from the config
  model's JSON schema, so hiding a field with `SkipJsonSchema` removes it from
  both the gateway dashboard and the Console desktop app.
- **Existing bridges are untouched**, including any left with no encryption
  material. There is no endpoint to edit a bridge's credentials at all, so
  adopting the generated ones means delete and re-create. That missing endpoint
  is worth its own fix.
- 16 new tests. Full suite: 988 passed, no failures. (147 errors in the run are
  Postgres fixtures with no Docker locally — identical on the base commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)