### PR TITLE
feat(console): verify the Authenticode signature of Windows updates (CHOO-1468)

### DIFF
--- a/.github/workflows/switch-console-release.yml
+++ b/.github/workflows/switch-console-release.yml
@@ -74,11 +74,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version="${GITHUB_REF_NAME#switch-console-v}"
-          notes="Switch Console desktop app $version — macOS Apple silicon + Intel, and Linux x64 + arm64.
+          notes="Switch Console desktop app $version — macOS Apple silicon + Intel, Linux x64 + arm64, and Windows x64.
 
           **macOS:** download the .dmg for your Mac — \`switch-console-arm64.dmg\` for Apple silicon (M1 and later), \`switch-console-x64.dmg\` for Intel. Not sure which you have? Apple menu → About This Mac. Open it and drag Switch Console to Applications. Both are signed and notarized with SandboxAQ's Developer ID — they open without a Gatekeeper bypass, and both receive in-app updates.
 
-          **Linux (x64 and arm64):** match your \`dpkg --print-architecture\`. Download the .AppImage (\`chmod +x\` then run), the .deb (\`sudo apt install ./<file>.deb\`) or the .rpm (\`sudo dnf install ./<file>.rpm\`). Linux builds are unsigned."
+          **Linux (x64 and arm64):** match your \`dpkg --print-architecture\`. Download the .AppImage (\`chmod +x\` then run), the .deb (\`sudo apt install ./<file>.deb\`) or the .rpm (\`sudo dnf install ./<file>.rpm\`). Linux builds are unsigned.
+
+          **Windows (x64):** run \`switch-console-x64.exe\`, or use \`switch-console-x64.msi\` for an \`msiexec\` install. Both are Authenticode signed as SandboxAQ, so no SmartScreen bypass is needed, and in-app updates verify that signature before installing."
           gh release create "$GITHUB_REF_NAME" \
             --repo "$GITHUB_REPOSITORY" \
             --title "Switch Console $version" \
@@ -553,7 +555,7 @@ jobs:
         working-directory: console/apps/switch-console-desktop
         run: pnpm exec electron-builder --win --publish never --config electron-builder.config.ts
 
-      - name: Report whether the installer was signed
+      - name: Verify the installer's signature and update manifest
         # The build logs "signing with signtool.exe" whether or not a certificate
         # was found, so the log cannot answer this. Read the PE certificate table
         # instead, and fail a signed run that silently produced nothing.
@@ -567,18 +569,49 @@ jobs:
             const dirs = pe + 24 + (magic === 0x20b ? 112 : 96);
             process.stdout.write(String(d.readUInt32LE(dirs + 4 * 8 + 4)));
           ')"
+          # The manifest electron-updater reads at runtime; the publisher name it
+          # will demand of every later update is written here, or not at all.
+          manifest=release/win-unpacked/resources/app-update.yml
+          if [ ! -f "$manifest" ]; then
+            echo "::error::$manifest is missing — the build produced no update manifest to check."
+            exit 1
+          fi
           if [ "$signed" != "0" ]; then
             echo "Authenticode signature present ($signed bytes)."
-            # The subject's CN is the string `publisherName` has to match before
-            # verifyUpdateCodeSignature can be turned on, and the certificate is
-            # the only authoritative source for it.
-            powershell -NoProfile -Command \
-              '$s = Get-AuthenticodeSignature "release\switch-console-x64.exe"; Write-Host "status: $($s.Status)"; Write-Host "subject: $($s.SignerCertificate.Subject)"'
+            status="$(powershell -NoProfile -Command \
+              '(Get-AuthenticodeSignature "release\switch-console-x64.exe").Status' | tr -d '\r')"
+            subject="$(powershell -NoProfile -Command \
+              '(Get-AuthenticodeSignature "release\switch-console-x64.exe").SignerCertificate.Subject' | tr -d '\r')"
+            echo "status: $status"
+            echo "subject: $subject"
+            if [ "$status" != "Valid" ]; then
+              echo "::error::Authenticode status is $status, not Valid."
+              exit 1
+            fi
+            # A certificate that stops matching the manifest has to fail the
+            # release here: installs already in the field would otherwise go on
+            # refusing updates, silently and indefinitely.
+            if ! grep -q '^publisherName' "$manifest"; then
+              echo "::error::Installer is signed but $manifest declares no publisherName — updates would install unverified."
+              exit 1
+            fi
+            if ! grep -qF "$subject" "$manifest"; then
+              echo "::error::$manifest does not name the signing certificate's subject ($subject). Update win.azureSignOptions.publisherName to match."
+              cat "$manifest"
+              exit 1
+            fi
+            echo "app-update.yml names the signing certificate — updates will verify."
           elif [ -n "$AZURE_CLIENT_ID" ]; then
             echo "::error::Azure credentials were present but the installer is unsigned."
             exit 1
           else
             echo "::notice::No Azure credentials on this run — installer is unsigned, as expected."
+            # An unsigned build must not claim a publisher either: electron-updater
+            # would then reject its own unsigned successors.
+            if grep -q '^publisherName' "$manifest"; then
+              echo "::error::Unsigned build declared a publisherName — updates from it would never verify."
+              exit 1
+            fi
           fi
 
       - name: Upload to GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -757,6 +757,15 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+#### Changed
+
+- **Windows in-app updates now verify the installer's Authenticode signature**
+  before installing it, against SandboxAQ's certificate. The check was held off
+  until a signed release confirmed the certificate's subject verbatim; a
+  mismatched name would have blocked updates for every existing install rather
+  than warning. The release build now fails if the signature and the name it
+  ships for the updater ever diverge (CHOO-1468).
+
 ### [0.29.0] - 2026-08-22
 #### Added
 - Switch Console now sends a small, fixed set of product events — the app

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,7 +92,8 @@ this and fails on mismatch). Procedure: bump `package.json`, cut the
 `## switch-console` `CHANGELOG.md` section, merge to `main`, tag, push. The workflow
 publishes a **GitHub Release** (macOS arm64 and x64, signed + notarized; Linux
 x64 and arm64 AppImage/deb/rpm, unsigned — one job per arch, each on a runner of
-that arch).
+that arch; Windows x64 nsis and msi, Authenticode signed via Azure Trusted
+Signing).
 
 macOS also gets a `merge-mac-manifest` job. electron-updater reads one channel
 file for macOS, `latest-mac.yml`, so the two mac jobs upload installers only and

--- a/console/apps/switch-console-desktop/electron-builder.config.ts
+++ b/console/apps/switch-console-desktop/electron-builder.config.ts
@@ -166,27 +166,28 @@ const config: Configuration = {
       { target: 'nsis', arch: ['x64'] },
       { target: 'msi', arch: ['x64'] },
     ],
-    // Off until the certificate's subject common name is known verbatim. This
-    // flag is what decides whether `publisherName` below is copied into
-    // app-update.yml, and electron-updater rejects any update whose signature
-    // does not match the name it finds there. A wrong name therefore breaks
-    // updating for everyone already installed, and does so silently and later —
-    // whereas leaving the field out of the manifest merely skips the check.
-    // Turn this on in the same change that sets the real name.
-    verifyUpdateCodeSignature: false,
+    // Copies `publisherName` below into app-update.yml, so electron-updater
+    // refuses any downloaded update whose Authenticode subject does not match
+    // it. Only meaningful on a signed build: an unsigned one has no
+    // azureSignOptions, electron-builder then has no publisher to write, and
+    // the manifest simply carries no name for the updater to check.
+    verifyUpdateCodeSignature: true,
     ...(hasAzureSigning
       ? {
           azureSignOptions: {
             endpoint: 'https://eus.codesigning.azure.net/',
             codeSigningAccountName: 'cg-asa-basic-eastus',
             certificateProfileName: 'cg-public',
-            // Required by electron-builder's schema, so it cannot be omitted, but
-            // it is stripped before the signing call and never reaches the
-            // certificate — the signature's real publisher comes from the
-            // certificate itself. Its only effect is on app-update.yml, which
-            // verifyUpdateCodeSignature: false above suppresses. Treat it as
-            // unverified until a signed build confirms the actual subject.
-            publisherName: 'SandboxAQ',
+            // The certificate's subject, verbatim, as read off a signed
+            // installer produced by this config. electron-builder strips this
+            // before the signing call — it never reaches the certificate — so
+            // its sole effect is the name written into app-update.yml. Given
+            // as a full distinguished name rather than the bare CN because
+            // electron-updater compares every component it is given and warns
+            // when handed a CN alone. It must be updated in step with the
+            // certificate: a stale name here breaks updates for every existing
+            // install, silently and only at update time.
+            publisherName: 'CN=SandboxAQ, O=SandboxAQ, L=Tarrytown, S=New York, C=US',
           },
         }
       : {}),

--- a/console/docs/INSTALL.md
+++ b/console/docs/INSTALL.md
@@ -117,23 +117,22 @@ Pick the format your distro uses:
 2. Choose an install location if you want a non-default one, and finish the
    installer.
 
-### First launch — SmartScreen warning
+### Code signing
 
-Windows builds are **not code signed** — there is no Authenticode certificate for
-this app yet (CHOO-1468). Windows therefore shows a full-screen blue **"Windows
-protected your PC"** prompt the first time you run the installer:
+Windows builds from **0.27.2** onwards are Authenticode signed, via Azure Trusted
+Signing, as `SandboxAQ`. The installer no longer trips the blue **"Windows
+protected your PC"** SmartScreen prompt, and AppLocker / WDAC policies that block
+unsigned binaries no longer refuse it outright (CHOO-1468).
 
-1. Click **More info**.
-2. Click **Run anyway**.
+Two caveats:
 
-This is expected, and it recurs for each new version until the app is signed. Two
-consequences worth knowing:
-
-- Antivirus software occasionally quarantines unsigned Electron installers. If
-  the download vanishes, check your AV quarantine.
-- **Managed / corporate Windows may refuse to install it outright.** AppLocker
-  and WDAC policies commonly block unsigned binaries, and there is no
-  click-through for that — the install simply fails. Signing is the only fix.
+- **0.27.1 and earlier are unsigned.** They still show the SmartScreen prompt —
+  click **More info**, then **Run anyway** — and managed Windows may refuse them.
+  Installing a current version is the fix.
+- SmartScreen also weighs a certificate's reputation, so a brand-new one can
+  still warn on early downloads. That fades as installs accumulate; it is not a
+  sign the signature is missing. To check one yourself: right-click the `.exe` →
+  **Properties** → **Digital Signatures**.
 
 The `.msi` supports the usual `msiexec` flow if you would rather not run the
 installer interactively.


### PR DESCRIPTION
## What

Turns on `verifyUpdateCodeSignature` for Windows, now that a signed release has told us the certificate's subject verbatim:

```
CN=SandboxAQ, O=SandboxAQ, L=Tarrytown, S=New York, C=US
```

read off `switch-console-x64.exe` in the 0.27.3 release run (`status: Valid`).

That flag copies `publisherName` into `app-update.yml`, and electron-updater refuses any update whose Authenticode subject does not match the name it finds there. It was deliberately off until the name was known: a guessed name breaks updating for every existing install, silently, and only at update time.

`publisherName` is given as the **full distinguished name** rather than the bare CN — electron-updater compares every component it is handed, and warns when given a CN alone.

## Guardrail

The release job's signature step now asserts the two agree, rather than just printing the subject:

- Authenticode status is `Valid`.
- `app-update.yml` declares a `publisherName` on a signed build, and it names the subject the certificate actually carries.
- An unsigned build declares none — otherwise its own unsigned successors would be rejected.

So a future certificate change fails the release instead of stranding installs in the field on the version they already have.

## Also

- `console/docs/INSTALL.md` still told Windows users the app is unsigned and to click through SmartScreen. Rewritten: signed from 0.27.2, with the 0.27.1-and-earlier caveat and the certificate-reputation caveat kept.
- The GitHub Release notes listed macOS and Linux only, while shipping `.exe` and `.msi` assets with no instructions. Windows paragraph added.
- `RELEASING.md` now mentions the Windows job in the list of what the workflow publishes.

## Testing

- Both shapes of the `win` config (signed and unsigned) validated against electron-builder 26's real `scheme.json` — the check missed before #256.
- The new step's script extracted from the workflow and syntax-checked; workflow YAML parses.
- The signed path itself can only run from `main` or a tag, where the `release` environment supplies the OIDC credentials. Worth a dispatch from `main` before the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)