### PR TITLE
release: switch-console 0.27.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -670,6 +670,18 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.27.4] - 2026-08-20
+
+#### Fixed
+- Search results show an agent's own icon rather than its provider logo, so two
+  agents on the same provider are no longer the same picture; the provider mark
+  now follows the "Agent type mark" toggle in both the sidebar and the palette
+  (CHOO-2203).
+- A long instruction no longer takes over the agent page. Multi-line boxes cap
+  at roughly a dozen lines and scroll inside themselves, and the agent's
+  instructions field gains an Expand control for when you want the ceiling
+  lifted (CHOO-2203).
+
 ### [0.27.3] - 2026-08-19
 
 #### Added

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.27.3
+    version: 0.27.4
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.17.3',
-  'switch-console': '0.27.3',
+  'switch-console': '0.27.4',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
   gateway: '0.17.3',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.17.3',
-  'switch-console': '0.27.3',
+  'switch-console': '0.27.4',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
   gateway: '0.17.3',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,7 +21,7 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.17.3",
-    "switch-console": "0.27.3",
+    "switch-console": "0.27.4",
     "agent-runtime": "0.3.2",
     "sidecar": "1.9.4",
     "gateway": "0.17.3",


### PR DESCRIPTION
Patch release of Switch Console — console bug round-up 2 (#267, CHOO-2203).

## Contents
- **switch-console `0.27.3 → 0.27.4`** (patch):
  - Search shows an agent's own icon rather than its provider logo; the provider mark follows the "Agent type mark" toggle in both the sidebar and the palette.
  - A long instruction no longer takes over the agent page — multi-line boxes cap and scroll, with an Expand control on the instructions field.

*Changelog entry authored here — the PR added none.*

## Not releasing
core (`0.17.3`), sidecar (`1.9.4`), agent-runtime (`0.3.2`), plugins — unchanged. Bundle pin stays at core `0.17.3`. No contract changes. (#266 switch-expert is internal-only, out of scope.)

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes.

## Tagging plan
`switch-console-v0.27.4` off the merge commit — macOS gated on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)