### PR TITLE
release: batch — core 0.18.0, console 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,23 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.18.0] - 2026-08-21
+
+#### Added
+- Each agent gets a Slack **user group**, so its `@name` autocompletes in the
+  composer and arrives as a structured mention rather than plain text that only
+  looks like one. A single app still fronts every agent; the groups are minted
+  empty (mentioning one notifies nobody) and exist only to be mentionable.
+  Inbound, a `<!subteam^…>` mention resolves back to the agent's name before the
+  addressing layer sees it — including a name folded into a legal handle — and
+  outbound mentions render as the same pill. Slack owns the objects, so the
+  id↔name maps are rebuilt by reading them back, and only groups carrying
+  Switch's marker are adopted (CHOO-2277).
+- An agent's turn is mirrored onto **Slack's native agent-session status** — the
+  streamed "in progress / complete" indicator Slack renders for an app — pinned
+  to the message being worked on. It needs the app's `assistant:write` scope;
+  without it the bridge says so rather than failing silently (CHOO-2277).
+
 ### [0.17.3] - 2026-08-19
 
 #### Fixed
@@ -669,6 +686,23 @@ version of their own to them without also giving them a release of their own.
 ## switch-console
 
 ### [Unreleased]
+
+### [0.28.0] - 2026-08-21
+
+#### Added
+- Connecting a Slack app can enable per-agent **user groups** — the mentionable
+  `@name` handles Switch mints for each agent — from the Connect-messaging-app
+  dialog (CHOO-2277).
+
+#### Changed
+- Local-server mode now bundles and pulls **switch-core `0.18.0`** (was
+  `0.17.3`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release.
+
+#### Fixed
+- The New-agent modal's Cancel / Add-agent footer no longer overlaps the "you
+  have not linked a messaging account" callout at the bottom of the form, which
+  had half-hidden its Open-Messaging-apps link (CHOO-2243).
 
 ### [0.27.4] - 2026-08-20
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.17.3
+    version: 0.18.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.27.4
+    version: 0.28.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.17.3
+      switch-core: 0.18.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.27.4",
+  "version": "0.28.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.17.3';
+export const COMPATIBLE_SWITCH_VERSION = '0.18.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.17.3';
+export const COMPATIBLE_SWITCH_VERSION = '0.18.0';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.17.3',
-  'switch-console': '0.27.4',
+  'switch-core': '0.18.0',
+  'switch-console': '0.28.0',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
-  gateway: '0.17.3',
-  setup: '0.17.3',
-  'helm-chart': '0.17.3',
-  compose: '0.17.3',
+  gateway: '0.18.0',
+  setup: '0.18.0',
+  'helm-chart': '0.18.0',
+  compose: '0.18.0',
   'switch-connector': '0.9.6',
   'switch-connector-codex': '0.3.7',
   'switch-connector-opencode': '0.1.4',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.17.3',
-  'switch-console': '0.27.4',
+  'switch-core': '0.18.0',
+  'switch-console': '0.28.0',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
-  gateway: '0.17.3',
-  setup: '0.17.3',
-  'helm-chart': '0.17.3',
-  compose: '0.17.3',
+  gateway: '0.18.0',
+  setup: '0.18.0',
+  'helm-chart': '0.18.0',
+  compose: '0.18.0',
   'switch-connector': '0.9.6',
   'switch-connector-codex': '0.3.7',
   'switch-connector-opencode': '0.1.4',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.17.3"
+version = "0.18.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.17.3",
-    "switch-console": "0.27.4",
+    "switch-core": "0.18.0",
+    "switch-console": "0.28.0",
     "agent-runtime": "0.3.2",
     "sidecar": "1.9.4",
-    "gateway": "0.17.3",
-    "setup": "0.17.3",
-    "helm-chart": "0.17.3",
-    "compose": "0.17.3",
+    "gateway": "0.18.0",
+    "setup": "0.18.0",
+    "helm-chart": "0.18.0",
+    "compose": "0.18.0",
     "switch-connector": "0.9.6",
     "switch-connector-codex": "0.3.7",
     "switch-connector-opencode": "0.1.4",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.17.3"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Proper mainline release — the CHOO-2277 Slack work (#269) plus a console fix (#263).

## Contents
- **switch-core `0.17.3 → 0.18.0`** (minor) — each agent gets a Slack **user group** so its `@name` autocompletes and arrives as a structured mention (inbound `<!subteam^…>` resolves back to the agent name); an agent's turn is mirrored onto **Slack's native agent-session status** (streamed, needs `assistant:write`) (#269, CHOO-2277).
- **switch-console `0.27.4 → 0.28.0`** (minor) — Connect-messaging-app UI for the per-agent user-group option (#269); New-agent modal footer no longer overlaps the link-an-account callout (#263, CHOO-2243). **Bundle pin → core `0.18.0`**.
- **Not releasing:** agent-runtime (`0.3.2`, generated-file churn), sidecar (`1.9.4`), plugins — unchanged. #266 switch-expert is internal-only.

## Note on the rc tags
`switch-v0.18.0-rc.1…rc.6` were branch pre-releases of this line; this is the real `switch-v0.18.0` (distinct tag, no collision).

## Authored changelog entries (please eyeball)
#269 (core + console) and #263 — both `[Unreleased]` sections were empty.

## Contracts
No changes — the Slack user-group bridge-config addition is additive gateway-api.

## Registry
`artifacts.yaml` + generated modules regenerated; `just artifacts-check` passes.

## Tagging plan (off the merge commit)
1. `switch-v0.18.0` — ungated.
2. `switch-console-v0.28.0` — macOS gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)