### PR TITLE
feat(docs): point every docs link at the published documentation site (CHOO-2313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+#### Changed
+- The gateway's **Docs** button opens the published documentation at
+  `docs.flintai.dev` rather than the GitHub repository (CHOO-2313).
+
 ### [0.18.0] - 2026-08-21
 
 #### Added
@@ -686,6 +690,20 @@ version of their own to them without also giving them a release of their own.
 ## switch-console
 
 ### [Unreleased]
+
+#### Changed
+- Every **Docs** affordance opens the published documentation at
+  `docs.flintai.dev` instead of the GitHub repository, deep-linked to the page
+  that answers the question: the sidebar and app-menu Docs entries and the
+  Settings Docs tab go to getting-started, the remote-hosts hint and the
+  hosting cards to *Host remotely*, the messaging-app cards to *Messaging
+  apps*, and the Rooms card to *Rooms and agents*. The welcome footer's GitHub
+  link keeps pointing at the repository (CHOO-2313).
+- The "How to set up {Platform}" link on the connect-messaging-app form opens
+  the platform's published setup page — Slack, Mattermost, Discord, Microsoft
+  Teams or Telegram — rather than the repository's markdown, with the
+  messaging-apps index as the fallback for an unrecognised platform
+  (CHOO-2313, unblocking CHOO-2269).
 
 ### [0.28.0] - 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 **Create organizations where AI agents and humans work side by side.**
 
 [![License: Apache 2.0 + Commons Clause](https://img.shields.io/badge/license-Apache%202.0%20%2B%20Commons%20Clause-blue)](LICENSE)
-[![Documentation](https://img.shields.io/badge/docs-read-FF895E)](docs/)
+[![Documentation](https://img.shields.io/badge/docs-read-FF895E)](https://docs.flintai.dev/flintai/switch/getting-started)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md)
 
 </div>
@@ -176,6 +176,18 @@ Module layout under `core/switch_core/`:
 
 The operator dashboard frontend lives in [`gateway/`](gateway/)
 (Node/Vite, served via nginx).
+
+## Documentation
+
+User-facing documentation is published at
+**[docs.flintai.dev](https://docs.flintai.dev/flintai/switch/getting-started)** —
+installing Switch Console, adding a server, onboarding agents, creating rooms,
+[connecting a messaging app](https://docs.flintai.dev/flintai/switch/deploy/messaging-apps)
+and [hosting remotely](https://docs.flintai.dev/flintai/switch/deploy/host-remotely).
+
+Design and protocol references for contributors live in [`docs/`](docs/):
+[`ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the system overview and
+[`api/AGENT_PROTOCOL.md`](docs/api/AGENT_PROTOCOL.md) for the agent protocol.
 
 ## Repository layout
 

--- a/console/README.md
+++ b/console/README.md
@@ -5,6 +5,10 @@ coding-agent sessions that participate in [Agent Switch](../README.md) — which
 rooms an agent belongs to, its configuration (working directory, identity),
 and the scheduling that starts and drives its sessions.
 
-> **Note:** a full install guide and user documentation are coming as part of
-> the docs effort. For now, see [`console/AGENTS.md`](AGENTS.md) for developer
-> notes on working in the app.
+## Documentation
+
+- [Install Switch Console](https://docs.flintai.dev/flintai/switch/getting-started/install-switch-console)
+  — the published install guide.
+- [Setting up Switch](https://docs.flintai.dev/flintai/switch/getting-started) —
+  user documentation for the whole product.
+- [`console/AGENTS.md`](AGENTS.md) — developer notes on working in the app.

--- a/console/apps/switch-console-desktop/src/renderer/features/onboarding/onboarding-checklist.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/onboarding/onboarding-checklist.tsx
@@ -4,7 +4,11 @@ import { openExternalUrl } from '@renderer/lib/open-external';
 import { SectionLabel } from '@renderer/lib/ui/label';
 import { cn } from '@renderer/utils/utils';
 import type { OnboardingStep, OnboardingStepId } from '@shared/core/onboarding/checklist';
-import { SWITCH_CONSOLE_DOCS_URL } from '@shared/urls';
+import {
+  SWITCH_DOCS_MESSAGING_APPS_URL,
+  SWITCH_DOCS_REMOTE_HOSTING_URL,
+  SWITCH_DOCS_ROOMS_URL,
+} from '@shared/urls';
 
 /**
  * The first-run setup checklist (CHOO-2022), in two shapes:
@@ -18,26 +22,22 @@ import { SWITCH_CONSOLE_DOCS_URL } from '@shared/urls';
  *   land on the welcome screen.
  */
 
-/**
- * Where "Learn more" points, for now. These are placeholders agreed with the
- * dev on CHOO-2022: the docs site does not exist yet, so all three go to the
- * repository README rather than to a dead page. Repoint them when it does.
- */
+/** Where "Learn more" points. Mirrors the welcome screen's shelf. */
 const LEARN_MORE_LINKS: { label: string; linkText: string; url: string }[] = [
   {
     label: 'Remote or cloud ',
     linkText: 'hosting',
-    url: SWITCH_CONSOLE_DOCS_URL,
+    url: SWITCH_DOCS_REMOTE_HOSTING_URL,
   },
   {
     label: 'Connect to ',
     linkText: 'messaging apps',
-    url: SWITCH_CONSOLE_DOCS_URL,
+    url: SWITCH_DOCS_MESSAGING_APPS_URL,
   },
   {
     label: 'Best ways to use ',
     linkText: 'Rooms',
-    url: SWITCH_CONSOLE_DOCS_URL,
+    url: SWITCH_DOCS_ROOMS_URL,
   },
 ];
 

--- a/console/apps/switch-console-desktop/src/renderer/features/onboarding/welcome-learn-more.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/onboarding/welcome-learn-more.tsx
@@ -1,19 +1,19 @@
 import { ArrowUpRight } from 'lucide-react';
 import { openExternalUrl } from '@renderer/lib/open-external';
 import { SectionLabel } from '@renderer/lib/ui/label';
-import { SWITCH_CONSOLE_DOCS_URL } from '@shared/urls';
+import {
+  SWITCH_CONSOLE_DOCS_URL,
+  SWITCH_CONSOLE_REPO_URL,
+  SWITCH_DOCS_MESSAGING_APPS_URL,
+  SWITCH_DOCS_REMOTE_HOSTING_URL,
+  SWITCH_DOCS_ROOMS_URL,
+} from '@shared/urls';
 
-/**
- * The welcome screen's "Learn more" shelf (CHOO-2022).
- *
- * Every card points at the repository README for now — the docs site does not
- * exist yet, and a card that opens nothing is worse than one that opens the
- * README. Give each its own URL when there is one.
- */
+/** The welcome screen's "Learn more" shelf (CHOO-2022). */
 const LEARN_MORE_CARDS: { title: string; url: string }[] = [
-  { title: 'Hosting Switch on a SSH device or a cloud', url: SWITCH_CONSOLE_DOCS_URL },
-  { title: 'Connecting to message apps', url: SWITCH_CONSOLE_DOCS_URL },
-  { title: 'Best ways to use Rooms', url: SWITCH_CONSOLE_DOCS_URL },
+  { title: 'Hosting Switch on a SSH device or a cloud', url: SWITCH_DOCS_REMOTE_HOSTING_URL },
+  { title: 'Connecting to message apps', url: SWITCH_DOCS_MESSAGING_APPS_URL },
+  { title: 'Best ways to use Rooms', url: SWITCH_DOCS_ROOMS_URL },
 ];
 
 export function WelcomeLearnMore() {
@@ -69,7 +69,7 @@ export function WelcomeFooter() {
       <button
         type="button"
         className="hover:text-foreground"
-        onClick={() => openExternalUrl(SWITCH_CONSOLE_DOCS_URL, 'Could not open the repository')}
+        onClick={() => openExternalUrl(SWITCH_CONSOLE_REPO_URL, 'Could not open the repository')}
       >
         GitHub
       </button>

--- a/console/apps/switch-console-desktop/src/renderer/features/remote-hosts/views/remote-hosts-view.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/remote-hosts/views/remote-hosts-view.tsx
@@ -29,13 +29,11 @@ import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { log } from '@renderer/utils/logger';
 import { deriveHostStatus, type HostStatus } from '@shared/core/remote-hosts/host-status';
 import type { HostSetupPlan } from '@shared/core/remote-hosts/setup';
+import { SWITCH_DOCS_REMOTE_HOSTING_URL } from '@shared/urls';
 import { hostReachabilityStore } from '../host-reachability-store';
 import { useAllHostSetupPlans } from '../setup/use-host-setup';
 
 export const REMOTE_HOSTS_QUERY_KEY = ['remote-hosts'];
-
-/** Same destination as the Docs tab in Settings, until a cloud-hosting page exists to point at. */
-const CLOUD_HOSTING_DOC_URL = 'https://github.com/sandbox-quantum/switch';
 
 type HostFilter = 'all' | 'ready' | 'attention';
 
@@ -171,7 +169,10 @@ export const RemoteHostsSettingsPage = observer(function RemoteHostsSettingsPage
               type="button"
               className="cursor-pointer underline underline-offset-2 hover:text-foreground"
               onClick={() =>
-                void openExternalUrl(CLOUD_HOSTING_DOC_URL, 'Could not open the documentation')
+                void openExternalUrl(
+                  SWITCH_DOCS_REMOTE_HOSTING_URL,
+                  'Could not open the documentation'
+                )
               }
             >
               doc for cloud hosting ↗︎

--- a/console/apps/switch-console-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { RemoteHostsSettingsPage } from '@renderer/features/remote-hosts/views/r
 import { PageHeader } from '@renderer/lib/components/page-header';
 import { PageContent, PageLayout, PageSidebarMenu } from '@renderer/lib/components/page-layout';
 import { openExternalUrl } from '@renderer/lib/open-external';
+import { SWITCH_CONSOLE_DOCS_URL } from '@shared/urls';
 import { AgentsSettingsPage } from '../agents-page/AgentsSettingsPage';
 import NotificationSettingsCard from './NotificationSettingsCard';
 import { OnboardingChecklistRow } from './OnboardingSettingsRow';
@@ -101,10 +102,7 @@ export function SettingsPage({
   onTabChange: (tab: SettingsPageTab) => void;
 }) {
   const handleDocsClick = useCallback(() => {
-    void openExternalUrl(
-      'https://github.com/sandbox-quantum/switch',
-      'Could not open the documentation'
-    );
+    void openExternalUrl(SWITCH_CONSOLE_DOCS_URL, 'Could not open the documentation');
   }, []);
 
   const tabs: Array<{

--- a/console/apps/switch-console-desktop/src/renderer/lib/components/bridge-platform.test.ts
+++ b/console/apps/switch-console-desktop/src/renderer/lib/components/bridge-platform.test.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { SWITCH_DOCS_MESSAGING_APPS_URL } from '@shared/urls';
 import { hasBridgeIcon } from './bridge-icon';
 import { bridgePlatformLabel, bridgeSetupDocsUrl } from './bridge-platform';
 
@@ -12,9 +13,6 @@ const BRIDGE_ICON_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
   '../../../assets/images/bridges'
 );
-
-/** Repo root, for checking the setup guides the docs links point at. */
-const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../../../../../..');
 
 describe('bridgePlatformLabel', () => {
   it('names each platform the way its own docs do', () => {
@@ -38,23 +36,23 @@ describe('bridgePlatformLabel', () => {
 });
 
 describe('bridgeSetupDocsUrl', () => {
-  it('points at the per-platform setup guide', () => {
-    expect(bridgeSetupDocsUrl('slack')).toMatch(/docs\/bridges\/SLACK_SETUP\.md$/);
-    expect(bridgeSetupDocsUrl('teams')).toMatch(/docs\/bridges\/TEAMS_SETUP\.md$/);
+  it('points at the per-platform page on the documentation site', () => {
+    expect(bridgeSetupDocsUrl('slack')).toBe(`${SWITCH_DOCS_MESSAGING_APPS_URL}/slack`);
+    // `teams` is published under its full name, so the bridge key is not a
+    // usable slug — the one mapping in here that is not the identity.
+    expect(bridgeSetupDocsUrl('teams')).toBe(`${SWITCH_DOCS_MESSAGING_APPS_URL}/microsoft-teams`);
   });
 
   it('falls back to the index rather than a dead link', () => {
-    expect(bridgeSetupDocsUrl('zulip')).toMatch(/docs\/bridges\/README\.md$/);
+    expect(bridgeSetupDocsUrl('zulip')).toBe(SWITCH_DOCS_MESSAGING_APPS_URL);
   });
 
-  it.each(BRIDGE_TYPES)('the guide linked for %s exists in the repo', (type) => {
-    // The links are repo paths for now, so a renamed or moved guide should
-    // fail here rather than 404 for a user mid-setup.
-    const path = bridgeSetupDocsUrl(type).replace(
-      'https://github.com/sandbox-quantum/switch/blob/main/',
-      ''
-    );
-    expect(existsSync(join(REPO_ROOT, path))).toBe(true);
+  it.each(BRIDGE_TYPES)('%s has its own page rather than the index', (type) => {
+    // Falling back is right for a bridge type this build has never heard of,
+    // but silently doing it for one we ship is a mapping we forgot to add.
+    const url = bridgeSetupDocsUrl(type);
+    expect(url).not.toBe(SWITCH_DOCS_MESSAGING_APPS_URL);
+    expect(url.startsWith(`${SWITCH_DOCS_MESSAGING_APPS_URL}/`)).toBe(true);
   });
 });
 

--- a/console/apps/switch-console-desktop/src/renderer/lib/components/bridge-platform.ts
+++ b/console/apps/switch-console-desktop/src/renderer/lib/components/bridge-platform.ts
@@ -1,3 +1,5 @@
+import { SWITCH_DOCS_MESSAGING_APPS_URL } from '@shared/urls';
+
 /**
  * Display names and setup guides for collaboration bridge platforms, keyed by
  * the gateway's `bridge_type`.
@@ -24,23 +26,20 @@ export function bridgePlatformLabel(bridgeType: string | null | undefined): stri
   return PLATFORM_LABELS[bridgeType] ?? bridgeType;
 }
 
-/** Where the setup guides live. */
-const DOCS_BASE = 'https://github.com/sandbox-quantum/switch/blob/main/docs/bridges';
-
 /**
  * Per-platform setup guide, for the "how do I get these credentials" link on
  * the attach form.
  *
- * These point at the repository's own markdown on `main`, which is a stopgap:
- * they are expected to move to published documentation, so they are collected
- * here rather than spread through the JSX — changing them later is one edit.
+ * The slugs are the documentation site's, not the bridge keys: `teams` is
+ * published as `microsoft-teams`. Collected here rather than spread through the
+ * JSX so the mapping is checkable in one place.
  */
 const PLATFORM_DOCS: Record<string, string> = {
-  slack: `${DOCS_BASE}/SLACK_SETUP.md`,
-  mattermost: `${DOCS_BASE}/MATTERMOST_SETUP.md`,
-  discord: `${DOCS_BASE}/DISCORD_SETUP.md`,
-  teams: `${DOCS_BASE}/TEAMS_SETUP.md`,
-  telegram: `${DOCS_BASE}/TELEGRAM_SETUP.md`,
+  slack: `${SWITCH_DOCS_MESSAGING_APPS_URL}/slack`,
+  mattermost: `${SWITCH_DOCS_MESSAGING_APPS_URL}/mattermost`,
+  discord: `${SWITCH_DOCS_MESSAGING_APPS_URL}/discord`,
+  teams: `${SWITCH_DOCS_MESSAGING_APPS_URL}/microsoft-teams`,
+  telegram: `${SWITCH_DOCS_MESSAGING_APPS_URL}/telegram`,
 };
 
 /**
@@ -49,5 +48,5 @@ const PLATFORM_DOCS: Record<string, string> = {
  * a link that lands somewhere useful instead of a 404.
  */
 export function bridgeSetupDocsUrl(bridgeType: string): string {
-  return PLATFORM_DOCS[bridgeType] ?? `${DOCS_BASE}/README.md`;
+  return PLATFORM_DOCS[bridgeType] ?? SWITCH_DOCS_MESSAGING_APPS_URL;
 }

--- a/console/apps/switch-console-desktop/src/shared/urls.ts
+++ b/console/apps/switch-console-desktop/src/shared/urls.ts
@@ -1,4 +1,7 @@
-export const SWITCH_CONSOLE_RELEASES_URL = 'https://github.com/sandbox-quantum/switch/releases';
+/** The source repository. Not documentation — see {@link SWITCH_CONSOLE_DOCS_URL}. */
+export const SWITCH_CONSOLE_REPO_URL = 'https://github.com/sandbox-quantum/switch';
+
+export const SWITCH_CONSOLE_RELEASES_URL = `${SWITCH_CONSOLE_REPO_URL}/releases`;
 const SWITCH_CONSOLE_RELEASES_API_URL =
   'https://api.github.com/repos/sandbox-quantum/switch/releases';
 
@@ -24,7 +27,17 @@ export function switchConsoleReleaseUrl(version: string | undefined): string {
 export function switchConsoleReleaseApiUrl(version: string): string {
   return `${SWITCH_CONSOLE_RELEASES_API_URL}/tags/${switchConsoleReleaseTag(version)}`;
 }
-export const SWITCH_CONSOLE_DOCS_URL = 'https://github.com/sandbox-quantum/switch';
-export const SWITCH_CONSOLE_ISSUES_URL = 'https://github.com/sandbox-quantum/switch/issues';
-export const SWITCH_CONSOLE_ISSUES_NEW_URL =
-  'https://github.com/sandbox-quantum/switch/issues/new/choose';
+/**
+ * The published documentation site. Deep-link to the page that answers the
+ * question at hand; {@link SWITCH_CONSOLE_DOCS_URL} is the entry point for a
+ * bare "Docs" affordance that is not about anything in particular.
+ */
+const SWITCH_DOCS_BASE = 'https://docs.flintai.dev/flintai/switch';
+
+export const SWITCH_CONSOLE_DOCS_URL = `${SWITCH_DOCS_BASE}/getting-started`;
+export const SWITCH_DOCS_REMOTE_HOSTING_URL = `${SWITCH_DOCS_BASE}/deploy/host-remotely`;
+export const SWITCH_DOCS_MESSAGING_APPS_URL = `${SWITCH_DOCS_BASE}/deploy/messaging-apps`;
+export const SWITCH_DOCS_ROOMS_URL = `${SWITCH_DOCS_BASE}/using/rooms-and-agents`;
+
+export const SWITCH_CONSOLE_ISSUES_URL = `${SWITCH_CONSOLE_REPO_URL}/issues`;
+export const SWITCH_CONSOLE_ISSUES_NEW_URL = `${SWITCH_CONSOLE_REPO_URL}/issues/new/choose`;

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -19,4 +19,7 @@ a copy of `hoot.css` plus that command. The formatting conventions Hoot is
 prescriptive about (dates, numbers, empty values, identifiers) live in
 `src/theme/hootFormat.ts`.
 
-> **Note:** full documentation is coming as part of the docs effort.
+## Documentation
+
+User-facing documentation for Switch is published at
+[docs.flintai.dev](https://docs.flintai.dev/flintai/switch/getting-started).

--- a/gateway/src/layout/TopBar.tsx
+++ b/gateway/src/layout/TopBar.tsx
@@ -12,7 +12,7 @@ const SECTION_LABELS: [prefix: string, label: string][] = [
   ["/users", "Users"],
 ];
 
-const DOCS_URL = "https://github.com/sandbox-quantum/switch";
+const DOCS_URL = "https://docs.flintai.dev/flintai/switch/getting-started";
 
 export default function TopBar() {
   const { pathname } = useLocation();


### PR DESCRIPTION
Closes **CHOO-2313**. Also delivers **CHOO-2269** in full and the docs half of **CHOO-2234** — see *Ticket reconciliation* below.

## The problem

Everywhere the product says "docs", it sent the user to the GitHub repository or to markdown inside it. Nothing was *broken* — every one of those links resolves — but none of them were documentation. A published site now exists at `docs.flintai.dev`, so this points all three surfaces at it, deep-linked to the page that answers the question rather than collapsed onto getting-started.

## What changed, by surface

**Gateway** — the top-bar **Docs** button now opens getting-started.

**READMEs** — the root README's Documentation badge pointed at the bare `docs/` directory, which has no index and renders as a file listing; it now points at the site, and the README gains a real Documentation section (it had none, only the badge). `gateway/README.md` and `console/README.md` both carried a "full documentation is coming as part of the docs effort" placeholder; both are replaced with real links.

**Console** — three separate files hardcoded the same repository URL alongside the shared constant. Those collapse into `@shared/urls`, and the destinations are split by intent:

- Sidebar Docs, app-menu Docs, Settings Docs tab, welcome footer → getting-started
- Remote hosts "doc for cloud hosting", plus the hosting card and checklist item → *Host remotely*
- Messaging-app card and checklist item → *Messaging apps*
- "Best ways to use Rooms" card and checklist item → *Rooms and agents*

One trap worth naming: the welcome footer's **GitHub** button was reusing the docs constant. Left alone it would have silently become a docs link. `SWITCH_CONSOLE_REPO_URL` is now separate from the documentation entry point, so the repo link stays a repo link.

The placeholder comments explaining that these all pointed at the README "because the docs site does not exist yet" are gone with the thing they explained.

**Messaging-app setup links (CHOO-2269)** — the "How to set up {Platform}" link on the connect-messaging-app form pointed at the repo's `docs/bridges/*_SETUP.md`. All five platform pages plus the overview are published, so it now opens the platform's real page, with the messaging-apps index as the fallback for a platform this build does not recognise. The slugs are the site's, not the bridge keys — `teams` publishes as `microsoft-teams`, the one mapping that is not the identity.

The test previously checked the linked markdown file existed on disk. It cannot do that against a URL, so it now pins the published slugs and asserts that a bridge type we actually ship never silently falls back to the index — falling back is correct for an unknown platform, but for one we ship it means a mapping was forgotten.

## Verification

Acceptance for this ticket is that the links were **followed**, not eyeballed.

- All ten destinations return **200**. A deliberately bogus docs path returns a real **404**, so the site is not an SPA answering 200 to everything — the checks mean something.
- Every GitHub URL the apps still use resolves publicly too. There are **no dead or private links** on any of the three surfaces — nothing to report upstream.
- Tests, lint, format and typecheck pass on the changed files. (`pnpm typecheck` reports pre-existing errors elsewhere in the app from unbuilt workspace packages; none are in files this PR touches.)

## Ticket reconciliation

- **CHOO-2269** — fold in and close. Its only blocker was the per-platform pages not being published. They are, and this PR is exactly its scope.
- **CHOO-2234** — the docs half lands here. Its other concern was stale or private links after the repo move; all were followed and are fine. Nothing actionable looks left in it, but whether to close it or keep it open for a wider sweep is Louis's call.

## Deliberately out of scope

- The install guide's GitHub **release download** URLs — downloads, not docs, and correct.
- Links *inside* the repo's own `docs/` files — the docs-migration ticket's problem, not user-facing.
- Third-party doc links (Claude Code, Cursor, Stripe, Slack, …) — all checked; none accidentally points at Switch.
- Console's `package.json` `docs` script points at a directory that does not exist, so it just fails. Found it, did not touch it — say the word if you want it in.

No version numbers were bumped; the changelog entries go under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)