### PR TITLE
docs(skills): Telegram has no DM, so stop telling agents to wait for one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -690,6 +690,11 @@ version of their own to them without also giving them a release of their own.
 ## switch-console
 
 ### [Unreleased]
+#### Fixed
+- The OpenCode connector the app writes carries its own copy of the
+  room-workflow skill, so it picked up the same wrong claim that a Telegram DM
+  is adopted like Mattermost's. Corrected alongside the connector directory
+  (CHOO-2314).
 
 #### Changed
 - Every **Docs** affordance opens the published documentation at
@@ -2176,6 +2181,13 @@ compatibility signal. History for those is in the git log.
 `.claude-plugin/plugin.json`.
 
 ### [Unreleased]
+#### Fixed
+- The room-workflow skill said a Telegram DM is adopted the way Mattermost's
+  is, so an agent asked for a 1:1 on Telegram would tell the user to message
+  the bot and wait for a room that never arrives. Telegram has no DM: a private
+  chat with the bot is the lobby, which answers with setup guidance and
+  provisions nothing. The skill now says so, and points at a group of two as
+  the way to get DM-like behaviour (CHOO-2314).
 
 ### [0.9.6] - 2026-08-19
 
@@ -2370,6 +2382,13 @@ manifest history.
 `connectors/codex-plugin/`. Version lives in `.codex-plugin/plugin.json`.
 
 ### [Unreleased]
+#### Fixed
+- The room-workflow skill said a Telegram DM is adopted the way Mattermost's
+  is, so an agent asked for a 1:1 on Telegram would tell the user to message
+  the bot and wait for a room that never arrives. Telegram has no DM: a private
+  chat with the bot is the lobby, which answers with setup guidance and
+  provisions nothing. The skill now says so, and points at a group of two as
+  the way to get DM-like behaviour (CHOO-2314).
 
 ### [0.3.7] - 2026-08-19
 
@@ -2518,6 +2537,13 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+#### Fixed
+- The room-workflow skill said a Telegram DM is adopted the way Mattermost's
+  is, so an agent asked for a 1:1 on Telegram would tell the user to message
+  the bot and wait for a room that never arrives. Telegram has no DM: a private
+  chat with the bot is the lobby, which answers with setup guidance and
+  provisions nothing. The skill now says so, and points at a group of two as
+  the way to get DM-like behaviour (CHOO-2314).
 
 ### [0.1.4] - 2026-08-19
 

--- a/connectors/claude-code-plugin/skills/switch/SKILL.md
+++ b/connectors/claude-code-plugin/skills/switch/SKILL.md
@@ -450,14 +450,20 @@ For a private 1:1 between one agent and one human, create a room with
 - **Mattermost**: DMs are user-initiated from the client, so creating a
   `direct` room here fails — the user starts the DM with the agent's bot and
   Switch picks it up automatically.
-- **Telegram**: same as Mattermost — the user messages the bot first and
-  Switch adopts the chat. Telegram bots cannot create chats at all, so
-  `create_room` fails on a Telegram bridge for *every* channel type, not just
-  `direct`; the chat is made in a Telegram client and the bot added to it.
-  `list_bridges` reports this as `can_create_channels: false`, so check there
-  before offering to make a room rather than finding out from the failure —
-  and note an operator can withhold channel creation from any platform, so a
-  false answer is not Telegram-specific.
+- **Telegram**: there is **no DM at all**, and this one is not a "create it
+  from the other side" case. A private chat with the bot is the *lobby*: the
+  bridge answers it with setup guidance and never provisions a room, so no
+  agent is reachable there and nothing you do in Telegram adopts it. One bot
+  fronts every agent, so a 1:1 could not say which agent it was with anyway.
+  Offer a **group containing just that user and the bot**, with the one agent
+  invited — that behaves like a DM and the agent is addressable by name.
+  Separately, Telegram bots cannot create chats at all, so `create_room` fails
+  on a Telegram bridge for *every* channel type, not just `direct`; the chat is
+  made in a Telegram client and the bot added to it. `list_bridges` reports
+  this as `can_create_channels: false`, so check there before offering to make
+  a room rather than finding out from the failure — and note an operator can
+  withhold channel creation from any platform, so a false answer is not
+  Telegram-specific.
 
 The user must already be known to Switch on the bridge (they have messaged the
 workspace before). If not, creation fails loudly with `no user '<name>' is

--- a/connectors/codex-plugin/skills/switch/SKILL.md
+++ b/connectors/codex-plugin/skills/switch/SKILL.md
@@ -448,14 +448,20 @@ For a private 1:1 between one agent and one human, create a room with
 - **Mattermost**: DMs are user-initiated from the client, so creating a
   `direct` room here fails — the user starts the DM with the agent's bot and
   Switch picks it up automatically.
-- **Telegram**: same as Mattermost — the user messages the bot first and
-  Switch adopts the chat. Telegram bots cannot create chats at all, so
-  `create_room` fails on a Telegram bridge for *every* channel type, not just
-  `direct`; the chat is made in a Telegram client and the bot added to it.
-  `list_bridges` reports this as `can_create_channels: false`, so check there
-  before offering to make a room rather than finding out from the failure —
-  and note an operator can withhold channel creation from any platform, so a
-  false answer is not Telegram-specific.
+- **Telegram**: there is **no DM at all**, and this one is not a "create it
+  from the other side" case. A private chat with the bot is the *lobby*: the
+  bridge answers it with setup guidance and never provisions a room, so no
+  agent is reachable there and nothing you do in Telegram adopts it. One bot
+  fronts every agent, so a 1:1 could not say which agent it was with anyway.
+  Offer a **group containing just that user and the bot**, with the one agent
+  invited — that behaves like a DM and the agent is addressable by name.
+  Separately, Telegram bots cannot create chats at all, so `create_room` fails
+  on a Telegram bridge for *every* channel type, not just `direct`; the chat is
+  made in a Telegram client and the bot added to it. `list_bridges` reports
+  this as `can_create_channels: false`, so check there before offering to make
+  a room rather than finding out from the failure — and note an operator can
+  withhold channel creation from any platform, so a false answer is not
+  Telegram-specific.
 
 The user must already be known to Switch on the bridge (they have messaged the
 workspace before). If not, creation fails loudly with `no user '<name>' is

--- a/connectors/opencode-plugin/skills/switch/SKILL.md
+++ b/connectors/opencode-plugin/skills/switch/SKILL.md
@@ -456,14 +456,20 @@ For a private 1:1 between one agent and one human, create a room with
 - **Mattermost**: DMs are user-initiated from the client, so creating a
   `direct` room here fails — the user starts the DM with the agent's bot and
   Switch picks it up automatically.
-- **Telegram**: same as Mattermost — the user messages the bot first and
-  Switch adopts the chat. Telegram bots cannot create chats at all, so
-  `create_room` fails on a Telegram bridge for *every* channel type, not just
-  `direct`; the chat is made in a Telegram client and the bot added to it.
-  `list_bridges` reports this as `can_create_channels: false`, so check there
-  before offering to make a room rather than finding out from the failure —
-  and note an operator can withhold channel creation from any platform, so a
-  false answer is not Telegram-specific.
+- **Telegram**: there is **no DM at all**, and this one is not a "create it
+  from the other side" case. A private chat with the bot is the *lobby*: the
+  bridge answers it with setup guidance and never provisions a room, so no
+  agent is reachable there and nothing you do in Telegram adopts it. One bot
+  fronts every agent, so a 1:1 could not say which agent it was with anyway.
+  Offer a **group containing just that user and the bot**, with the one agent
+  invited — that behaves like a DM and the agent is addressable by name.
+  Separately, Telegram bots cannot create chats at all, so `create_room` fails
+  on a Telegram bridge for *every* channel type, not just `direct`; the chat is
+  made in a Telegram client and the bot added to it. `list_bridges` reports
+  this as `can_create_channels: false`, so check there before offering to make
+  a room rather than finding out from the failure — and note an operator can
+  withhold channel creation from any platform, so a false answer is not
+  Telegram-specific.
 
 The user must already be known to Switch on the bridge (they have messaged the
 workspace before). If not, creation fails loudly with `no user '<name>' is

--- a/console/packages/plugins/src/agents/impl/opencode/skill-file.ts
+++ b/console/packages/plugins/src/agents/impl/opencode/skill-file.ts
@@ -464,14 +464,20 @@ For a private 1:1 between one agent and one human, create a room with
 - **Mattermost**: DMs are user-initiated from the client, so creating a
   \`direct\` room here fails — the user starts the DM with the agent's bot and
   Switch picks it up automatically.
-- **Telegram**: same as Mattermost — the user messages the bot first and
-  Switch adopts the chat. Telegram bots cannot create chats at all, so
-  \`create_room\` fails on a Telegram bridge for *every* channel type, not just
-  \`direct\`; the chat is made in a Telegram client and the bot added to it.
-  \`list_bridges\` reports this as \`can_create_channels: false\`, so check there
-  before offering to make a room rather than finding out from the failure —
-  and note an operator can withhold channel creation from any platform, so a
-  false answer is not Telegram-specific.
+- **Telegram**: there is **no DM at all**, and this one is not a "create it
+  from the other side" case. A private chat with the bot is the *lobby*: the
+  bridge answers it with setup guidance and never provisions a room, so no
+  agent is reachable there and nothing you do in Telegram adopts it. One bot
+  fronts every agent, so a 1:1 could not say which agent it was with anyway.
+  Offer a **group containing just that user and the bot**, with the one agent
+  invited — that behaves like a DM and the agent is addressable by name.
+  Separately, Telegram bots cannot create chats at all, so \`create_room\` fails
+  on a Telegram bridge for *every* channel type, not just \`direct\`; the chat is
+  made in a Telegram client and the bot added to it. \`list_bridges\` reports
+  this as \`can_create_channels: false\`, so check there before offering to make
+  a room rather than finding out from the failure — and note an operator can
+  withhold channel creation from any platform, so a false answer is not
+  Telegram-specific.
 
 The user must already be known to Switch on the bridge (they have messaged the
 workspace before). If not, creation fails loudly with \`no user '<name>' is


### PR DESCRIPTION
Documentation only. Split out of #274 so that PR stays to one adapter.

## The bug

All three room-workflow skills said this:

> **Telegram**: same as Mattermost — the user messages the bot first and Switch adopts the chat.

That is not what happens. A Telegram private chat maps to channel type `lobby`, and `bridge_core` short-circuits lobby messages before any room exists — it replies with setup guidance and returns. No room is provisioned, no agent is reachable, and nothing the user does in Telegram changes that.

**The failure mode is a dead end rather than an error.** An agent asked for a 1:1 on Telegram followed the skill, told the user to message the bot and wait, and the room never arrived. Nobody gets an error message to search for.

## The fix

The skills now say there is no DM, why — one bot fronts every agent, so a 1:1 cannot express which agent it is with — and what to offer instead: **a group containing just that user and the bot**, with the one agent invited. That behaves like a DM and keeps the agent addressable by name.

The rest of the Telegram bullet (bots cannot create chats, `can_create_channels: false`, check `list_bridges` first) was already correct and is kept.

## Where

Per `CLAUDE.md`, a room-workflow change lands in all three connector plugins:

- `connectors/claude-code-plugin/skills/switch/SKILL.md`
- `connectors/codex-plugin/skills/switch/SKILL.md`
- `connectors/opencode-plugin/skills/switch/SKILL.md`

Plus `console/packages/plugins/src/agents/impl/opencode/skill-file.ts` — the app writes the OpenCode connector itself rather than fetching it, so it embeds a verbatim copy. `connector-assets.test.ts` fails on drift; it passes.

The three skills were diffed against each other after editing. The hunk is identical in each, and the remaining differences are the intended host-specific ones.

**No version bumps** — versioning belongs to the releaser.

## Testing

`@switch-console/plugins`: 202 tests pass, including the drift check. Format and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)