### PR TITLE
docs(telegram): the reaction section contradicted the no-DM section

### DIFF
--- a/docs/bridges/TELEGRAM_SETUP.md
+++ b/docs/bridges/TELEGRAM_SETUP.md
@@ -278,13 +278,12 @@ answers it itself instead of passing it on as an unknown command.
 
 ## Knowing an agent is working on it
 
-Two signals, and which you get depends on the kind of chat.
+Two signals, both in every bridged chat.
 
-**👀 on the message that asked — everywhere.** When an agent starts a turn the
-bot reacts to the message it is answering, and clears the reaction when the
-turn ends. This works in groups, supergroups, channels and 1:1 chats, needs no
-administrator rights, and is the same reaction the Slack bridge uses, so a room
-bridged to either place reads the same.
+**👀 on the message that asked.** When an agent starts a turn the bot reacts to
+the message it is answering, and clears the reaction when the turn ends. It
+needs no administrator rights, and it is the same reaction the Slack and
+Mattermost bridges use, so a room reads the same wherever it is bridged.
 
 It marks the *last thing a person said* in the chat, because outside forum
 topics Telegram has no threads — only reply chains — so there is no thread for


### PR DESCRIPTION
Follow-up to #274, which I merged past. One paragraph, no code.

The "Knowing an agent is working on it" section still said the 👀 works "in groups, supergroups, channels **and 1:1 chats**", and that which signal you get "depends on the kind of chat". Both sentences were written while that branch still had a native 1:1 placeholder behind a config flag. When that was dropped they were left standing — two sections above **Why there is no Telegram DM**, which explains that Switch bridges no Telegram 1:1 chats at all.

So the page told a reader to expect a mark in a chat it had just finished explaining cannot exist.

Now: both signals apply in every bridged chat, and there is nothing to choose between. Also names Mattermost alongside Slack, since #277 landed the same reaction there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)