### PR TITLE
fix(slack): a card that has gone is one thread's problem, not the workspace's

### DIFF
--- a/core/switch_core/bridges/collaboration/slack/adapter.py
+++ b/core/switch_core/bridges/collaboration/slack/adapter.py
@@ -1089,11 +1089,13 @@ class SlackAdapter(CollaborationAdapter):
                         ),
                         agent_name=agent_name,
                         channel_id=channel_id,
+                        stream_key=key,
                     )
                 await self._call_session_api(
                     lambda: client.chat_stopStream(channel=channel_id, ts=closing_ts),
                     agent_name=agent_name,
                     channel_id=channel_id,
+                    stream_key=key,
                 )
                 # The card is a progress indicator, not a record. Once the turn
                 # is over the agent's own reply is the thing worth reading, so
@@ -1151,7 +1153,7 @@ class SlackAdapter(CollaborationAdapter):
         # every time stacked eight identical links under one card.
         first_link = deeplink_url if self._stream_step.get(key) is None else None
         stream_ts = open_ts
-        await self._call_session_api(
+        pushed = await self._call_session_api(
             lambda: client.chat_appendStream(
                 channel=channel_id,
                 ts=stream_ts,
@@ -1159,7 +1161,12 @@ class SlackAdapter(CollaborationAdapter):
             ),
             agent_name=agent_name,
             channel_id=channel_id,
+            stream_key=key,
         )
+        if pushed is None:
+            # The step never landed, so it is not what the card is showing —
+            # and recording it would tell the next one the link had been sent.
+            return
         self._stream_step[key] = step
 
     async def _call_session_api(
@@ -1168,16 +1175,24 @@ class SlackAdapter(CollaborationAdapter):
         *,
         agent_name: str,
         channel_id: str,
+        stream_key: tuple[str, str] | None = None,
     ) -> str | None:
         """Make a session call, routing a refusal through the same give-up path.
 
         Returns the response's `ts` on success (empty string when it has none)
         and None on failure, so a caller that needs the stream's id cannot
-        mistake a refusal for a stream it can append to."""
+        mistake a refusal for a stream it can append to.
+
+        `stream_key` names the card being written to, where there is one, so a
+        card that has gone can be forgotten instead of counted against the app.
+        """
         try:
             result = await call()
         except SlackApiError as e:
             error = str(e.response.get("error", ""))
+            if error == "message_not_found":
+                self._forget_stream(stream_key, agent_name)
+                return None
             self._note_session_failure(
                 error,
                 agent_name,
@@ -1188,6 +1203,24 @@ class SlackAdapter(CollaborationAdapter):
         self._session_failures = 0
         self._sessions_throttled_until = None
         return str(result.get("ts", ""))
+
+    def _forget_stream(self, key: tuple[str, str] | None, agent_name: str) -> None:
+        """Drop a card Slack says is no longer there.
+
+        The card is deleted when a turn ends, so a state report that arrives
+        just behind the teardown writes to something that has gone — as does a
+        card a user deleted by hand. It says nothing about whether this app can
+        host sessions, and counting it as if it did took the card away from
+        every agent in the workspace over one stale thread. The turn falls back
+        to the posted status message, and the next one opens a fresh card.
+        """
+        if key is not None:
+            self._stream_ts.pop(key, None)
+            self._stream_step.pop(key, None)
+            self._session_owner.pop(key, None)
+        logger.debug(
+            _TRACE + "card for %s is gone; forgetting it and carrying on", agent_name
+        )
 
     def _disable_agent_sessions(
         self, error: str, *, retry_in: int | None = None

--- a/core/tests/switch_core/bridges/collaboration/test_slack_agent_sessions.py
+++ b/core/tests/switch_core/bridges/collaboration/test_slack_agent_sessions.py
@@ -777,3 +777,56 @@ def test_a_refusal_that_named_its_cause_is_not_retried() -> None:
     _run(_state(adapter, "working", detail="reading again"))
 
     assert "chat.startStream" not in _methods(client)
+
+
+# ── A card that has gone ─────────────────────────────────────────────────────
+
+
+def test_a_card_that_has_gone_does_not_count_against_the_app() -> None:
+    """We delete the card ourselves at the end of a turn, so a state report a
+    moment behind the teardown writes to something that is no longer there."""
+    adapter, client = _adapter()
+    _run(_state(adapter, "working", detail="reading"))
+
+    client.stream_error = "message_not_found"
+    for _ in range(_AGENT_SESSIONS_FAILURE_LIMIT + 3):
+        _run(_state(adapter, "working", detail="still reading"))
+
+    assert adapter._agent_sessions_off_reason is None
+
+
+def test_a_card_that_has_gone_is_forgotten() -> None:
+    adapter, client = _adapter()
+    _run(_state(adapter, "working", detail="reading"))
+    assert adapter._stream_ts
+
+    client.stream_error = "message_not_found"
+    _run(_state(adapter, "working", detail="still reading"))
+
+    assert adapter._stream_ts == {}
+    assert adapter._stream_step == {}
+
+
+def test_the_turn_falls_back_to_the_posted_message_once_its_card_is_gone() -> None:
+    adapter, client = _adapter()
+    _run(_state(adapter, "working", detail="reading"))
+    client.stream_error = "message_not_found"
+    _run(_state(adapter, "working", detail="still reading"))
+
+    client.stream_error = None
+    _run(_state(adapter, "working", detail="reading on"))
+
+    assert len(client.posted) == 1
+    assert _methods(client).count("chat.startStream") == 2
+
+
+def test_a_step_that_never_landed_is_not_recorded_as_shown() -> None:
+    """Recording it would tell the next step the console link had been sent."""
+    adapter, client = _adapter()
+    _run(_state(adapter, "working", detail="reading", deeplink="https://x/1"))
+    adapter._stream_step.clear()
+    client.stream_error = "not_in_channel"
+
+    _run(_state(adapter, "working", detail="a step that fails"))
+
+    assert adapter._stream_step == {}


### PR DESCRIPTION
Found in the cluster logs, and the actual cause of the regression #276 was chasing: at 19:21 the bridge gave up on agent cards after three consecutive `message_not_found`, and no agent in that workspace got a card again for the next six hours.

**The error is self-inflicted.** The card is deleted when a turn ends, so a state report arriving just behind the teardown writes to a message that is no longer there. A user deleting the card by hand does the same. Either way it says nothing about whether the app can host sessions — which is the only thing the give-up is for — and one stale thread turned the feature off for everyone.

Such a card is now **forgotten** rather than counted: the turn falls back to the posted status message, and the next one opens a fresh card.

**Also fixed:** a step that failed to land was still recorded as the card's current step. That misreported what the card was showing, and told the step after it that the console link had already been sent — so the link went missing from a card that never received it.

## Tests

Four new ones: a gone card doesn't count toward the give-up; it is forgotten; the turn falls back to the posted message and the next turn opens a fresh card; a step that never landed is not recorded as shown.

1761 backend tests pass, ruff and mypy clean.

## Not in this PR

The rate limits in the same logs are downstream of this: with cards off, every agent reverted to editing a posted status message on each state change, which hits Slack's `chat.update` limit and leaves the fallback stale. Coalescing those edits is a separate change — deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)