### PR TITLE
release: batch — core 0.19.0, console 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.19.0] - 2026-08-22
+
 #### Added
 - Telegram marks the message an agent is working on with **👀**, and clears it
   when the turn ends — in groups, channels and 1:1 chats alike, with no
@@ -71,6 +73,22 @@ version of their own to them without also giving them a release of their own.
 #### Changed
 - The gateway's **Docs** button opens the published documentation at
   `docs.flintai.dev` rather than the GitHub repository (CHOO-2313).
+
+#### Fixed
+- Slack's native agent-session card could vanish from a workspace and never come
+  back until the pod was replaced. A burst of Slack rate limits was being counted
+  as the app being unfit to host sessions and tripped the permanent give-up after
+  three in a row; throttling now makes the bridge stand down for the `Retry-After`
+  Slack sent rather than counting against it, and a give-up over an unrecognised
+  error expires after ten minutes instead of lasting the life of the process
+  (#276).
+- A stale or hand-deleted Slack agent card no longer turns cards off for the
+  whole workspace. A status update arriving just after a card is torn down — or a
+  user deleting the card by hand — wrote to a message that was gone, and three in
+  a row tripped the same permanent give-up. Such a card is now forgotten: the
+  turn falls back to the posted status message and the next turn opens a fresh
+  card. A step that failed to land is also no longer recorded as the card's
+  current step (#283).
 
 ### [0.18.0] - 2026-08-21
 
@@ -714,6 +732,8 @@ version of their own to them without also giving them a release of their own.
 ## switch-console
 
 ### [Unreleased]
+
+### [0.29.0] - 2026-08-22
 #### Added
 - Switch Console now sends a small, fixed set of product events — the app
   launching, an agent being created, a session starting and ending, a server
@@ -732,6 +752,9 @@ version of their own to them without also giving them a release of their own.
   (CHOO-2314).
 
 #### Changed
+- Local-server mode now bundles and pulls **switch-core `0.19.0`** (was
+  `0.18.0`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release.
 - Every **Docs** affordance opens the published documentation at
   `docs.flintai.dev` instead of the GitHub repository, deep-linked to the page
   that answers the question: the sidebar and app-menu Docs entries and the
@@ -2222,6 +2245,8 @@ compatibility signal. History for those is in the git log.
 `.claude-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.9.7] - 2026-08-22
 #### Fixed
 - The room-workflow skill said a Telegram DM is adopted the way Mattermost's
   is, so an agent asked for a 1:1 on Telegram would tell the user to message
@@ -2423,6 +2448,8 @@ manifest history.
 `connectors/codex-plugin/`. Version lives in `.codex-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.3.8] - 2026-08-22
 #### Fixed
 - The room-workflow skill said a Telegram DM is adopted the way Mattermost's
   is, so an agent asked for a 1:1 on Telegram would tell the user to message
@@ -2578,6 +2605,8 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.5] - 2026-08-22
 #### Fixed
 - The room-workflow skill said a Telegram DM is adopted the way Mattermost's
   is, so an agent asked for a 1:1 on Telegram would tell the user to message

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.18.0
+    version: 0.19.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.28.0
+    version: 0.29.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.18.0
+      switch-core: 0.19.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.6
+    version: 0.9.7
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.7
+    version: 0.3.8
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.4
+    version: 0.1.5
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.18.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.19.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.18.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.19.0';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.18.0',
-  'switch-console': '0.28.0',
+  'switch-core': '0.19.0',
+  'switch-console': '0.29.0',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
-  gateway: '0.18.0',
-  setup: '0.18.0',
-  'helm-chart': '0.18.0',
-  compose: '0.18.0',
-  'switch-connector': '0.9.6',
-  'switch-connector-codex': '0.3.7',
-  'switch-connector-opencode': '0.1.4',
+  gateway: '0.19.0',
+  setup: '0.19.0',
+  'helm-chart': '0.19.0',
+  compose: '0.19.0',
+  'switch-connector': '0.9.7',
+  'switch-connector-codex': '0.3.8',
+  'switch-connector-opencode': '0.1.5',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,17 +20,17 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.18.0',
-  'switch-console': '0.28.0',
+  'switch-core': '0.19.0',
+  'switch-console': '0.29.0',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
-  gateway: '0.18.0',
-  setup: '0.18.0',
-  'helm-chart': '0.18.0',
-  compose: '0.18.0',
-  'switch-connector': '0.9.6',
-  'switch-connector-codex': '0.3.7',
-  'switch-connector-opencode': '0.1.4',
+  gateway: '0.19.0',
+  setup: '0.19.0',
+  'helm-chart': '0.19.0',
+  compose: '0.19.0',
+  'switch-connector': '0.9.7',
+  'switch-connector-codex': '0.3.8',
+  'switch-connector-opencode': '0.1.5',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.18.0"
+version = "0.19.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,17 +20,17 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.18.0",
-    "switch-console": "0.28.0",
+    "switch-core": "0.19.0",
+    "switch-console": "0.29.0",
     "agent-runtime": "0.3.2",
     "sidecar": "1.9.4",
-    "gateway": "0.18.0",
-    "setup": "0.18.0",
-    "helm-chart": "0.18.0",
-    "compose": "0.18.0",
-    "switch-connector": "0.9.6",
-    "switch-connector-codex": "0.3.7",
-    "switch-connector-opencode": "0.1.4",
+    "gateway": "0.19.0",
+    "setup": "0.19.0",
+    "helm-chart": "0.19.0",
+    "compose": "0.19.0",
+    "switch-connector": "0.9.7",
+    "switch-connector-codex": "0.3.8",
+    "switch-connector-opencode": "0.1.5",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Batch release cut from the Switch Releases room (patch/minor of everything that needs releasing since core 0.18.0 / console 0.28.0).

## switch-core `0.18.0 → 0.19.0` (minor)
- **Added:** Telegram (#274) and Mattermost (#277) mark the message an agent is working on with 👀
- **Fixed:** two Slack agent-card resilience fixes — rate-limit bursts no longer permanently kill the card (#276); a stale/deleted card is one thread's problem, not the whole workspace's (#283). *(Authored here — neither was in the changelog.)*
- **Changed:** gateway Docs button → published docs site (#273)

## switch-console `0.28.0 → 0.29.0` (minor)
- **Added:** opt-in product telemetry to Amplitude, default **off** (#247)
- **Changed:** every Docs link → published docs site (#273); bundle pin / `COMPATIBLE_SWITCH_VERSION` raised to switch-core `0.19.0`

## Connector plugins (patch — so the #278 Telegram-no-DM skill fix re-downloads)
- switch-connector `0.9.6 → 0.9.7`, switch-connector-codex `0.3.7 → 0.3.8`, switch-connector-opencode `0.1.4 → 0.1.5`

## Not released
- agent-runtime (`0.3.2`) and sidecar (`1.9.4`) — no source changes.

## Registry / contracts
- `artifacts.yaml` + generated modules regenerated (`just artifacts`); `just artifacts-check` passes.
- No contract changes — everything is additive/behavioural, wire unchanged per the changelogs.

On merge: tag `switch-v0.19.0` first (ungated), then `switch-console-v0.29.0` (macOS build gated on approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)