### PR TITLE
fix(slack): a workflow asking an agent something is a request like any other

### DIFF
--- a/core/switch_core/bridges/collaboration/slack/adapter.py
+++ b/core/switch_core/bridges/collaboration/slack/adapter.py
@@ -307,6 +307,11 @@ class SlackAdapter(CollaborationAdapter):
         self._agent_eyes: dict[tuple[str, str], set[str]] = {}
         # (channel_id, thread_ts) -> ts of the last message asking in it.
         self._thread_trigger: dict[tuple[str, str], str] = {}
+        # (channel_id, ts) Slack says it cannot find. Retrying it on every
+        # progress report of a long turn is how one unmarkable message became
+        # a warning a second for as long as the agent worked.
+        self._unmarkable: OrderedDict[tuple[str, str], None] = OrderedDict()
+        self._unmarkable_max = 500
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
 
@@ -855,6 +860,8 @@ class SlackAdapter(CollaborationAdapter):
         key = (channel_id, ts)
         if working == (key in self._eyes):
             return
+        if key in self._unmarkable:
+            return
 
         try:
             if working:
@@ -874,9 +881,15 @@ class SlackAdapter(CollaborationAdapter):
             if error in ("already_reacted", "no_reaction"):
                 self._eyes.add(key) if working else self._eyes.discard(key)
                 return
+            if error == "message_not_found":
+                # There is no message to mark, and there will not be one later.
+                self._unmarkable[key] = None
+                if len(self._unmarkable) > self._unmarkable_max:
+                    self._unmarkable.popitem(last=False)
             logger.warning(
-                "Could not %s the working reaction on %s: %s",
+                "Could not %s the working reaction on %s in %s: %s",
                 "add" if working else "remove",
+                ts,
                 channel_id,
                 error or e,
             )
@@ -1972,15 +1985,21 @@ class SlackAdapter(CollaborationAdapter):
         # Remember the thread this message belongs to so the "thinking"
         # indicator can be posted into the same conversation.
         self._last_thread_ts[channel_id] = thread_ts or message_ts
+        root = thread_ts or message_ts
+        # The message that actually asked. Inside a thread this is a reply, not
+        # the root, and the mark belongs on what was said — not on the
+        # conversation it happens to sit in. An app's post counts: a Slack
+        # workflow asking an agent something is a request like any other, and
+        # treating it as nobody asking left the mark aimed at a thread root
+        # that need not be a message at all.
+        self._thread_trigger[(channel_id, root)] = message_ts
         # Streaming a reply into a channel has to name who it is for, and the
-        # runtime-state path never sees the asker — so keep it per thread.
+        # runtime-state path never sees the asker — so keep it per thread. This
+        # one does need a person: Slack will not open a session addressed to an
+        # app, so a workflow-triggered turn has the posted status message and
+        # the mark, and no card.
         if user_id and not bot_id:
-            root = thread_ts or message_ts
             self._thread_requester[(channel_id, root)] = user_id
-            # The message that actually asked. Inside a thread this is a reply,
-            # not the root, and the mark belongs on what was said — not on the
-            # conversation it happens to sit in.
-            self._thread_trigger[(channel_id, root)] = message_ts
 
         message_ref = f"{channel_id}:{message_ts}"
         stripped = text.strip()

--- a/core/tests/switch_core/bridges/collaboration/test_slack_agent_sessions.py
+++ b/core/tests/switch_core/bridges/collaboration/test_slack_agent_sessions.py
@@ -830,3 +830,55 @@ def test_a_step_that_never_landed_is_not_recorded_as_shown() -> None:
     _run(_state(adapter, "working", detail="a step that fails"))
 
     assert adapter._stream_step == {}
+
+
+# ── Turns nobody in Slack asked for ──────────────────────────────────────────
+
+
+def _bot_message(adapter: SlackAdapter, ts: str, thread_ts: str | None = None) -> None:
+    event: dict[str, Any] = {
+        "channel": "C1",
+        "ts": ts,
+        "bot_id": "B0WORKFLOW",
+        "username": "Daily summary",
+        "text": "@flint-tracker summarise yesterday",
+        "channel_type": "channel",
+    }
+    if thread_ts:
+        event["thread_ts"] = thread_ts
+    _run(adapter._handle_message_event(event))
+
+
+def test_a_workflow_post_is_marked_like_any_other_request() -> None:
+    """A Slack workflow asking an agent something is a request like any other."""
+    adapter, client = _adapter()
+    adapter._bot_user_id = "UBOT"
+    _bot_message(adapter, "777.0", thread_ts="111.0")
+
+    _run(_state(adapter, "working", detail="reading"))
+
+    assert ("add", "777.0", "eyes") in client.reactions
+
+
+def test_a_message_slack_cannot_find_is_marked_once_not_every_report() -> None:
+    adapter, client = _adapter()
+    client.reaction_error = "message_not_found"
+
+    for _ in range(8):
+        _run(_state(adapter, "working", detail="reading"))
+
+    assert client.reactions == []
+
+
+def test_the_warning_names_the_message_not_just_the_channel(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    adapter, client = _adapter()
+    client.reaction_error = "message_not_found"
+
+    with caplog.at_level("WARNING"):
+        _run(_state(adapter, "working", detail="reading"))
+
+    warnings = [r for r in caplog.records if "working reaction" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "111.0" in warnings[0].getMessage()


### PR DESCRIPTION
Seen live in the cluster: `Could not add the working reaction on C…: message_not_found`, repeating about once a second for the length of a turn, in a room fed by a Slack workflow.

**The cause.** A turn triggered by an app's post — a workflow, a scheduled summary — recorded neither who asked nor which message asked, because the code read "carries a `bot_id`" as "nobody asked". The 👀 then fell back to the thread root, which in such a channel need not be a message at all, and Slack answered `message_not_found`.

The message that asked is now remembered whoever sent it. Our own posts are dropped earlier in the same handler, so this is about *other* apps.

The **asker** is still only recorded for a person, deliberately: Slack will not open a session addressed to an app. A workflow-triggered turn gets the posted status message and the mark, and no card — which is also why that turn looked like the card had regressed.

**Two things made one bad message loud rather than harmless:**
- A failed mark was not remembered, so every progress report retried it. One unmarkable message produced a warning a second for as long as the agent worked. It is now marked unmarkable and left alone.
- The warning named the channel but not the message — the one thing needed to identify it. It now names both.

## Tests

Three new ones: a workflow post is marked like any other request; a message Slack cannot find is attempted once rather than on every report; the warning names the message.

1817 backend tests pass, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)