### PR TITLE
Require room access on room-scoped resource endpoints

### DIFF
--- a/core/switch_core/gateway/documents.py
+++ b/core/switch_core/gateway/documents.py
@@ -8,11 +8,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from switch_core.bridges.resource.service import ResourceService
 from switch_core.db.models import Document, User
 from switch_core.db.stores.agent_store import AgentStore
+from switch_core.db.stores.room_store import RoomStore
 from switch_core.db.stores.user_store import UserStore
-from switch_core.gateway.auth import get_current_user
+from switch_core.gateway.auth import get_current_user, require_room_access
 from switch_core.gateway.dependencies import (
     get_agent_store,
     get_resource_service,
+    get_room_store,
     get_session,
     get_user_store,
 )
@@ -296,8 +298,10 @@ async def list_room_documents(
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
     user_store: Annotated[UserStore, Depends(get_user_store)],
     agent_store: Annotated[AgentStore, Depends(get_agent_store)],
-    _user: Annotated[User, Depends(get_current_user)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> list[DocumentSummary]:
+    await require_room_access(session, room_store, room_id, user, "read")
     docs = await resource_service.list_room_documents(session, room_id)
     return await _enrich_summaries(
         session, docs, resource_service, user_store, agent_store
@@ -312,8 +316,10 @@ async def attach_document_to_room(
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
     user_store: Annotated[UserStore, Depends(get_user_store)],
     agent_store: Annotated[AgentStore, Depends(get_agent_store)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> DocumentDetail:
+    await require_room_access(session, room_store, room_id, user, "write")
     try:
         await resource_service.attach_document_to_room(
             session,
@@ -339,10 +345,12 @@ async def detach_document_from_room(
     document_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
-    _user: Annotated[User, Depends(get_current_user)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> None:
     """For globally-owned docs: detach from the room. For room-scoped docs:
     hard-delete them entirely (since they live only in this room)."""
+    await require_room_access(session, room_store, room_id, user, "write")
     doc = await resource_service.get_room_scoped_document_or_none(
         session, room_id, document_id
     )
@@ -363,11 +371,13 @@ async def get_room_document(
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
     user_store: Annotated[UserStore, Depends(get_user_store)],
     agent_store: Annotated[AgentStore, Depends(get_agent_store)],
-    _user: Annotated[User, Depends(get_current_user)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> DocumentDetail:
     """Fetch a document by id within the context of a room. Accepts both
-    room-scoped documents (read-only) and globally-attached documents.
-    Bypasses visibility checks since room access implies access to its docs."""
+    room-scoped documents (read-only) and globally-attached documents. Room
+    read access is required and, once granted, implies access to its docs."""
+    await require_room_access(session, room_store, room_id, user, "read")
     docs = await resource_service.list_room_documents(session, room_id)
     doc = next((d for d in docs if d.id == document_id), None)
     if doc is None:

--- a/core/switch_core/gateway/packages.py
+++ b/core/switch_core/gateway/packages.py
@@ -8,11 +8,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from switch_core.bridges.resource.service import ResourceService
 from switch_core.db.models import Package, User
 from switch_core.db.stores.agent_store import AgentStore
+from switch_core.db.stores.room_store import RoomStore
 from switch_core.db.stores.user_store import UserStore
-from switch_core.gateway.auth import get_current_user
+from switch_core.gateway.auth import get_current_user, require_room_access
 from switch_core.gateway.dependencies import (
     get_agent_store,
     get_resource_service,
+    get_room_store,
     get_session,
     get_user_store,
 )
@@ -378,9 +380,11 @@ async def list_room_packages(
     room_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
     user_store: Annotated[UserStore, Depends(get_user_store)],
-    _user: Annotated[User, Depends(get_current_user)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> list[PackageDetail]:
+    await require_room_access(session, room_store, room_id, user, "read")
     pkgs = await resource_service.list_room_packages(session, room_id)
     return await _enrich(session, pkgs, resource_service, user_store)
 
@@ -391,9 +395,11 @@ async def attach_package_to_room(
     package_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
     user_store: Annotated[UserStore, Depends(get_user_store)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> PackageDetail:
+    await require_room_access(session, room_store, room_id, user, "write")
     try:
         await resource_service.attach_package_to_room(
             session,
@@ -419,7 +425,9 @@ async def detach_package_from_room(
     package_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
-    _user: Annotated[User, Depends(get_current_user)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> None:
+    await require_room_access(session, room_store, room_id, user, "write")
     await resource_service.detach_package_from_room(session, room_id, package_id)
     await session.commit()

--- a/core/switch_core/gateway/references.py
+++ b/core/switch_core/gateway/references.py
@@ -246,9 +246,11 @@ async def list_room_references(
     room_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
     user_store: Annotated[UserStore, Depends(get_user_store)],
-    _user: Annotated[User, Depends(get_current_user)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> list[ReferenceDetail]:
+    await require_room_access(session, room_store, room_id, user, "read")
     refs = await resource_service.list_room_references(session, room_id)
     return await _enrich(session, refs, resource_service, user_store)
 
@@ -289,7 +291,9 @@ async def detach_reference_from_room(
     reference_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
-    _user: Annotated[User, Depends(get_current_user)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> None:
+    await require_room_access(session, room_store, room_id, user, "write")
     await resource_service.detach_reference_from_room(session, room_id, reference_id)
     await session.commit()

--- a/core/switch_core/gateway/room_links.py
+++ b/core/switch_core/gateway/room_links.py
@@ -39,8 +39,10 @@ async def list_linked_rooms(
     room_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
-    _user: Annotated[User, Depends(get_current_user)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> list[LinkedRoomDetail]:
+    await require_room_access(session, room_store, room_id, user, "read")
     rows = await resource_service.list_linked_rooms_for_room(session, room_id)
     return [LinkedRoomDetail(**row) for row in rows]
 
@@ -50,8 +52,10 @@ async def list_inbound_linked_rooms(
     room_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
     resource_service: Annotated[ResourceService, Depends(get_resource_service)],
-    _user: Annotated[User, Depends(get_current_user)],
+    room_store: Annotated[RoomStore, Depends(get_room_store)],
+    user: Annotated[User, Depends(get_current_user)],
 ) -> list[InboundLinkedRoomDetail]:
+    await require_room_access(session, room_store, room_id, user, "read")
     rows = await resource_service.list_inbound_linked_rooms(session, room_id)
     return [InboundLinkedRoomDetail(**row) for row in rows]
 

--- a/core/tests/switch_core/gateway/test_room_resource_read_authz.py
+++ b/core/tests/switch_core/gateway/test_room_resource_read_authz.py
@@ -1,0 +1,191 @@
+"""Room-scoped resource reads/detaches must check room access (IDOR fix).
+
+The room-scoped document/reference/package endpoints authenticated the caller
+but never checked access to the room, so any authenticated user could read a
+private room's document content or detach (hard-delete) its resources by id.
+These tests pin the added `require_room_access` guard: a non-owner is refused
+(403) and the owner still gets through.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.bridges.resource.service import ResourceService
+from switch_core.db.models import Room, User
+from switch_core.db.stores.agent_store import AgentStore
+from switch_core.db.stores.document_store import DocumentStore
+from switch_core.db.stores.package_store import PackageStore
+from switch_core.db.stores.reference_store import ReferenceStore
+from switch_core.db.stores.room_link_store import RoomLinkStore
+from switch_core.db.stores.room_store import RoomStore
+from switch_core.db.stores.user_store import UserStore
+from switch_core.gateway.documents import (
+    detach_document_from_room,
+    get_room_document,
+    list_room_documents,
+)
+from switch_core.gateway.packages import detach_package_from_room
+from switch_core.gateway.references import detach_reference_from_room
+
+_ROOM_STORE = RoomStore()
+_USER_STORE = UserStore()
+_AGENT_STORE = AgentStore()
+
+
+def _svc(session_factory: async_sessionmaker[AsyncSession]) -> ResourceService:
+    return ResourceService(
+        reference_store=ReferenceStore(),
+        document_store=DocumentStore(),
+        package_store=PackageStore(),
+        room_link_store=RoomLinkStore(),
+        session_factory=session_factory,
+    )
+
+
+async def _add_user(session: AsyncSession, *, name: str, role: str = "user") -> User:
+    user = User(name=name, email=f"{name}@example.com", role=role)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _add_private_room(session: AsyncSession, *, owner_id: str) -> Room:
+    room = Room(
+        matrix_room_id="!r:test",
+        name="r",
+        description="d",
+        owner_id=owner_id,
+        read_visibility="private",
+        write_visibility="private",
+    )
+    session.add(room)
+    await session.flush()
+    return room
+
+
+class TestRoomResourceReadAuthz:
+    async def test_non_owner_cannot_read_room_document(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            owner = await _add_user(session, name="owner")
+            other = await _add_user(session, name="other")
+            room = await _add_private_room(session, owner_id=owner.id)
+            svc = _svc(session_factory)
+
+            with pytest.raises(HTTPException) as exc:
+                await get_room_document(
+                    room.id,
+                    "any-doc",
+                    session,
+                    svc,
+                    _USER_STORE,
+                    _AGENT_STORE,
+                    _ROOM_STORE,
+                    other,
+                )
+            assert exc.value.status_code == 403
+
+    async def test_non_owner_cannot_list_room_documents(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            owner = await _add_user(session, name="owner")
+            other = await _add_user(session, name="other")
+            room = await _add_private_room(session, owner_id=owner.id)
+            svc = _svc(session_factory)
+
+            with pytest.raises(HTTPException) as exc:
+                await list_room_documents(
+                    room.id,
+                    session,
+                    svc,
+                    _USER_STORE,
+                    _AGENT_STORE,
+                    _ROOM_STORE,
+                    other,
+                )
+            assert exc.value.status_code == 403
+
+    async def test_non_owner_cannot_detach_room_document(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            owner = await _add_user(session, name="owner")
+            other = await _add_user(session, name="other")
+            room = await _add_private_room(session, owner_id=owner.id)
+            svc = _svc(session_factory)
+
+            with pytest.raises(HTTPException) as exc:
+                await detach_document_from_room(
+                    room.id, "any-doc", session, svc, _ROOM_STORE, other
+                )
+            assert exc.value.status_code == 403
+
+    async def test_non_owner_cannot_detach_reference(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            owner = await _add_user(session, name="owner")
+            other = await _add_user(session, name="other")
+            room = await _add_private_room(session, owner_id=owner.id)
+            svc = _svc(session_factory)
+
+            with pytest.raises(HTTPException) as exc:
+                await detach_reference_from_room(
+                    room.id, "any-ref", session, svc, _ROOM_STORE, other
+                )
+            assert exc.value.status_code == 403
+
+    async def test_non_owner_cannot_detach_package(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            owner = await _add_user(session, name="owner")
+            other = await _add_user(session, name="other")
+            room = await _add_private_room(session, owner_id=owner.id)
+            svc = _svc(session_factory)
+
+            with pytest.raises(HTTPException) as exc:
+                await detach_package_from_room(
+                    room.id, "any-pkg", session, svc, _ROOM_STORE, other
+                )
+            assert exc.value.status_code == 403
+
+    async def test_owner_read_passes_authz(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # Owner is past the authz gate: an empty room lists no documents, and a
+        # missing document is 404 (not 403), proving access was granted.
+        async with session_factory() as session:
+            owner = await _add_user(session, name="owner")
+            room = await _add_private_room(session, owner_id=owner.id)
+            svc = _svc(session_factory)
+
+            assert (
+                await list_room_documents(
+                    room.id,
+                    session,
+                    svc,
+                    _USER_STORE,
+                    _AGENT_STORE,
+                    _ROOM_STORE,
+                    owner,
+                )
+                == []
+            )
+            with pytest.raises(HTTPException) as exc:
+                await get_room_document(
+                    room.id,
+                    "missing",
+                    session,
+                    svc,
+                    _USER_STORE,
+                    _AGENT_STORE,
+                    _ROOM_STORE,
+                    owner,
+                )
+            assert exc.value.status_code == 404


### PR DESCRIPTION
The room-scoped document / reference / package / linked-room endpoints authenticated the caller but never checked access to the room, so any authenticated user could read a private room's document content, list its resources, or detach (hard-delete) them by id. IDOR.

Fix: add `require_room_access` (read for GETs, write for attach/detach) to the document, reference, package, and linked-room room-scoped endpoints, matching the guard the reference-attach / room-link write paths already had. Adds regression tests.