### PR TITLE
Verify Mattermost TLS by default

### DIFF
--- a/core/switch_core/bridges/collaboration/mattermost/adapter.py
+++ b/core/switch_core/bridges/collaboration/mattermost/adapter.py
@@ -71,6 +71,10 @@ class MattermostConnectionConfig(BridgeConnectionConfig):
     # could not read the room at all. Unset for bridges where membership is
     # managed on the platform.
     default_member: str | None = None
+    # Verify the Mattermost server's TLS certificate. Defaults to True so admin
+    # credentials and bot tokens are never sent over an unverified https
+    # connection. Set False only for a self-signed internal CA you trust.
+    verify_tls: bool = True
 
 
 class MattermostAdapter(CollaborationAdapter):
@@ -1603,7 +1607,7 @@ class MattermostAdapter(CollaborationAdapter):
             "url": host,
             "scheme": scheme,
             "port": port,
-            "verify": False,
+            "verify": self._config.verify_tls,
         }
         if token:
             opts["token"] = token

--- a/core/tests/switch_core/bridges/collaboration/test_mattermost_tls.py
+++ b/core/tests/switch_core/bridges/collaboration/test_mattermost_tls.py
@@ -1,0 +1,33 @@
+"""The Mattermost driver verifies TLS by default (security fix).
+
+_create_driver used to hardcode ``verify=False`` for every driver, so the admin
+password and bot tokens were sent over an unverified https connection. TLS
+verification now defaults on, with an explicit opt-out for a trusted self-signed
+CA.
+"""
+
+from __future__ import annotations
+
+from switch_core.bridges.collaboration.mattermost.adapter import (
+    MattermostAdapter,
+    MattermostConnectionConfig,
+)
+
+
+def _adapter(**overrides: object) -> MattermostAdapter:
+    cfg = MattermostConnectionConfig(
+        url="https://mm.example",
+        admin_user="a",
+        admin_password="p",
+        team_name="t",
+        **overrides,  # type: ignore[arg-type]
+    )
+    return MattermostAdapter(config=cfg)
+
+
+def test_tls_verification_on_by_default() -> None:
+    assert _adapter()._create_driver().options["verify"] is True
+
+
+def test_tls_verification_can_be_opted_out() -> None:
+    assert _adapter(verify_tls=False)._create_driver().options["verify"] is False


### PR DESCRIPTION
The Mattermost driver hardcoded `verify=False`, so the admin password and bot tokens were sent over an unverified https connection (a MITM could capture them).

Fix: default TLS verification on; add a `verify_tls` opt-out for a trusted self-signed internal CA.