### PR TITLE
release: batch — core 0.21.0, console 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,11 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.21.0] - 2026-08-25
+
 #### Added
+- The gateway's **registration keys** page can now search agent keys, and its
+  table fills the page height rather than being capped short (#177).
 - Switch's commands appear in Teams' `/` autocomplete picker. The shipped
   manifest moves to schema v1.29 and declares `supportsTargetedMessages` plus a
   second command list with `triggers: ["slash"]`. The two surfaces disagree
@@ -54,6 +58,15 @@ version of their own to them without also giving them a release of their own.
   privately to Switch and needs no `@`-mention.
 
 #### Fixed
+- A Slack turn triggered by another app's post — a workflow, a scheduled summary
+  — is handled as an ordinary request: `bot_id` was read as "nobody asked", so
+  the 👀 went on the thread root (which in such a channel need not be a message)
+  and Slack answered `message_not_found`. The message that asked is now
+  remembered whoever sent it; a mark Slack cannot place is recorded as
+  unmarkable rather than retried every progress report; and the warning names
+  the message, not just the channel. A workflow-triggered turn still gets the
+  status message and mark but no card, since Slack will not open a session
+  addressed to an app (#288).
 - A Teams message that merely began with a slash is no longer swallowed as a
   command. Pasting `/Users/ada/notes.md` came back "unknown command" instead of
   reaching an agent. `/` is not Switch's prefix — it opens paths, dates and
@@ -1058,6 +1071,8 @@ version of their own to them without also giving them a release of their own.
 ## switch-console
 
 ### [Unreleased]
+
+### [0.31.0] - 2026-08-25
 #### Added
 - Creating an agent, starting a session and adding a server now report whether
   they worked, and an enumerated reason when they did not. Previously only the
@@ -1098,6 +1113,12 @@ version of their own to them without also giving them a release of their own.
 - Installing an update no longer reports that it both worked and failed. The
   success was sent before handing over to the installer, so an install that then
   failed to take was counted twice, in both directions.
+
+#### Changed
+- Local-server mode now bundles and pulls **switch-core `0.21.0`** (was
+  `0.19.0`): the bundle pin / `COMPATIBLE_SWITCH_VERSION` is raised to the
+  current core release.
+- Third-party dependency updates (#193).
 
 ### [0.30.0] - 2026-08-24
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,13 +60,13 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.20.0
+    version: 0.21.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 
   switch-console:
     description: The desktop app.
-    version: 0.30.0
+    version: 0.31.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.19.0
+      switch-core: 0.21.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.19.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.21.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.19.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.21.0';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.20.0',
-  'switch-console': '0.30.0',
+  'switch-core': '0.21.0',
+  'switch-console': '0.31.0',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
-  gateway: '0.20.0',
-  setup: '0.20.0',
-  'helm-chart': '0.20.0',
-  compose: '0.20.0',
+  gateway: '0.21.0',
+  setup: '0.21.0',
+  'helm-chart': '0.21.0',
+  compose: '0.21.0',
   'switch-connector': '0.9.8',
   'switch-connector-codex': '0.3.9',
   'switch-connector-opencode': '0.1.5',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.20.0',
-  'switch-console': '0.30.0',
+  'switch-core': '0.21.0',
+  'switch-console': '0.31.0',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
-  gateway: '0.20.0',
-  setup: '0.20.0',
-  'helm-chart': '0.20.0',
-  compose: '0.20.0',
+  gateway: '0.21.0',
+  setup: '0.21.0',
+  'helm-chart': '0.21.0',
+  compose: '0.21.0',
   'switch-connector': '0.9.8',
   'switch-connector-codex': '0.3.9',
   'switch-connector-opencode': '0.1.5',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.20.0"
+version = "0.21.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.20.0",
-    "switch-console": "0.30.0",
+    "switch-core": "0.21.0",
+    "switch-console": "0.31.0",
     "agent-runtime": "0.3.2",
     "sidecar": "1.9.4",
-    "gateway": "0.20.0",
-    "setup": "0.20.0",
-    "helm-chart": "0.20.0",
-    "compose": "0.20.0",
+    "gateway": "0.21.0",
+    "setup": "0.21.0",
+    "helm-chart": "0.21.0",
+    "compose": "0.21.0",
     "switch-connector": "0.9.8",
     "switch-connector-codex": "0.3.9",
     "switch-connector-opencode": "0.1.5",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Batch release cut from the Switch Releases room — everything on main since core `0.20.0` / console `0.30.0`, including the just-merged Teams PR #208.

## switch-core `0.20.0 → 0.21.0` (minor)
- **feat (#208):** Teams bridge made deployable, connectable, and honest when it fails — Helm chart publishes/routes the listener, credential verification before save, channel-capture persistence across restarts, mention/rendering fixes, rewritten setup docs
- **feat(gateway, #177):** registration-keys page can search agent keys; table fills the page height
- **fix(slack, #288):** a workflow/other-app-triggered turn is handled as an ordinary request (no more `message_not_found` on the mark)

## switch-console `0.30.0 → 0.31.0` (minor)
- **feat (#280):** telemetry extended to the remaining user events
- **deps:** npm group bumps (#193 prod, #194 dev)
- **Changed:** bundle pin / `COMPATIBLE_SWITCH_VERSION` → **core `0.21.0`** (managed local server now bundles the new core, per request)

## Not released / unchanged
- Connector plugins, agent-runtime (`0.3.2`), sidecar (`1.9.4`) — no changes.

## Registry / contracts
- `artifacts.yaml` + generated modules regenerated; `artifacts-check` passes.
- Contracts stay `1/1` — Teams is additive collaboration-bridge + gateway-api; no db models/migrations or agent-bridge surface changed.
- Authored the missing `#177` and `#288` changelog entries (the rest authored their own).

On merge: tag `switch-v0.21.0` first (ungated), then `switch-console-v0.31.0` (macOS build gated on approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)