### PR TITLE
fix(ci): route CLA signature writes through the CLA App token (CHOO-2389)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,6 +41,15 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-signatures: signatures/version1/cla.json
+          # These name this very repository, which looks redundant but is not:
+          # the action only reaches for PERSONAL_ACCESS_TOKEN (the CLA App
+          # token above) to read and write the signature file when a remote
+          # org or repo is set. Left unset, it writes with GITHUB_TOKEN, which
+          # is contents:read here — so signing fails with "Resource not
+          # accessible by integration". Do not remove without also granting
+          # this workflow contents:write.
+          remote-organization-name: sandbox-quantum
+          remote-repository-name: switch
           path-to-document: https://github.com/sandbox-quantum/switch/blob/main/CLA.md
           branch: main
           allowlist: dependabot[bot],renovate[bot],socket-fix[bot]


### PR DESCRIPTION
Fixes CHOO-2389 — https://sandboxquantum.atlassian.net/browse/CHOO-2389

## The symptom

Contributors post the sign comment, the CLA run fails, and nobody is ever recorded as signed — so every new contributor stays "unsigned" and their PRs stall on the CLA check. Currently blocking all 5 of James Howe's PRs.

```
##[error]Could not update the JSON file: Resource not accessible by integration
```

Broken since 2026-08-05 (#111, the H3 hardening). Last recorded signature: 2026-07-23. Every `issue_comment` run since has failed; `pull_request_target` runs still pass because they only comment and never write.

## The cause — not the one that was reported

The report attributed this to the CLA GitHub App missing `Contents: write`. It isn't that. **The App has the permission**, and the app-token step in every failing run mints a token with `permission-contents: write` successfully — `create-github-app-token` would hard-fail with a 422 otherwise. The token is just never used for the write.

`contributor-assistant/github-action` picks the client for the signature file in `persistence.ts`:

```ts
const octokitInstance = isRemoteRepoOrOrgConfigured()
  ? getPATOctokit()            // PERSONAL_ACCESS_TOKEN — the App token
  : getDefaultOctokitClient()  // GITHUB_TOKEN
```

`isRemoteRepoOrOrgConfigured()` is true only when `remote-repository-name` or `remote-organization-name` is set. Neither was, so all three signature-file operations used `GITHUB_TOKEN` — which #111 downgraded to `contents: read` at exactly the moment it moved the write path onto an App token. Hence the 403.

## The fix

Name this repository as the remote org/repo, so the flag flips and the signature file is read and written with the App token that is already wired up on the step. The target repo is unchanged; only the credential moves. `GITHUB_TOKEN` stays `contents: read`, so #111's hardening is preserved rather than reverted.

The two inputs name the repo they already run in, which reads as redundant — there's a comment on them explaining why they aren't, so nobody deletes them and silently re-breaks signing.

## Alternatives rejected

- **Grant the workflow `contents: write`.** One word, but hands write access to the whole job and undoes what #111 deliberately did.
- **Allowlist the affected contributor.** Per-person workaround; leaves the bot broken for the next contributor and skips a signature we actually want.

## Verification

Confirmed from the live repo rather than by inference:
- Pulled the logs of failing run `32872564855` — app-token step succeeds with `permission-contents: write`, CLA step then 403s on the write.
- Read `persistence.ts` **at the pinned SHA** `ca4a40a` (not just at `HEAD`) to confirm the token-selection logic is what ships.
- Checked that `remote-*` inputs are referenced nowhere outside `persistence.ts`, so this changes the credential and nothing else.
- `main` is unprotected, so there is no branch-protection interaction.

Not verifiable before merge: the workflow runs from `main`, so the end-to-end signing flow can only be exercised once this lands. Suggested check afterwards — have someone comment `recheck` on one of the stalled PRs and confirm a signature commit appears in `signatures/version1/cla.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)