### PR TITLE
Label the Windows and Linux Switch Console builds early access

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ It covers the whole path properly. The short version:
 |---|---|
 | macOS (Apple Silicon) | [.dmg](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-arm64.dmg) |
 | macOS (Intel) | [.dmg](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-x64.dmg) |
-| Linux (x64) | [.AppImage](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-x86_64.AppImage) · [.deb](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-amd64.deb) |
-| Linux (arm64) | [.AppImage](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-arm64.AppImage) · [.deb](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-arm64.deb) |
-| Windows (x64) | [.exe](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-x64.exe) |
+| Linux (x64) — **early access** | [.AppImage](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-x86_64.AppImage) · [.deb](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-amd64.deb) |
+| Linux (arm64) — **early access** | [.AppImage](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-arm64.AppImage) · [.deb](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-arm64.deb) |
+| Windows (x64) — **early access** | [.exe](https://github.com/sandbox-quantum/switch/releases/latest/download/switch-console-x64.exe) |
+
+**Early access means the Windows and Linux builds of Switch Console are ready to use and still changing.** Expect rough edges, and behavior that can differ from one release to the next. When you hit one, [open an issue](https://github.com/sandbox-quantum/switch/issues) — a report is what moves it up the list. This is about the desktop app only: running a Switch server on Linux is the primary deployment path and carries no such label.
 
 
 ### I want to deploy Switch for my team


### PR DESCRIPTION
Brings the README's download table into line with the install page in [sandbox-quantum/docs#298](https://github.com/sandbox-quantum/docs/pull/298), which labels the same two platforms early access.

[CHOO-2351](https://sandboxquantum.atlassian.net/browse/CHOO-2351)

The Windows and Linux rows carry the label, since the table is where someone picks a build, and a sentence under it says what the label means: ready to use and still changing, expect rough edges, report what you hit.

Two deliberate choices, both taken from the docs PR:

- **No comparative testing claim.** The earlier framing said Windows and Linux were less tested than macOS. Nothing sourced that, and CI runs Linux-only, so it could not be stood up. Early access is a statement about how settled a build is, not about how much it was tested.
- **The label is scoped to the desktop app.** Running a Switch server on Linux is the primary deployment path and is not early access, so the sentence says so — the table sits under a Switch Console heading, but the two are easy to conflate.

The issues link is part of the wording rather than decoration: an early access label with nowhere to report a problem asks the reader to absorb the cost silently.

Wording mirrors the docs page rather than being reinvented, so the two stay in step. Nothing else in the README changed.

[CHOO-2351]: https://sandboxquantum.atlassian.net/browse/CHOO-2351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ