### PR TITLE
Add a website badge and a walkthrough video to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 **The harness for building your team where humans and agents work side by side**
 
+[![Website](https://img.shields.io/badge/website-flintai.dev-FF895E)](https://www.flintai.dev/products/switch)
 [![License: Apache 2.0 + Commons Clause](https://img.shields.io/badge/license-Apache%202.0%20%2B%20Commons%20Clause-blue)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-read-FF895E)](https://docs.flintai.dev/flintai/switch/getting-started)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md)


### PR DESCRIPTION
Two commits.

[CHOO-2351](https://sandboxquantum.atlassian.net/browse/CHOO-2351)

**Website badge.** Links to https://www.flintai.dev/products/switch, first in the row and ahead of the license. Everything else there — license, docs, contributing, Discord — assumes you have already decided to use Switch; someone who has just landed and wants to know what it is had nowhere to go.

**Watch it work**, immediately before "Why Switch". An incident in Discord: someone reports checkout failing, an agent opens an incident channel, pulls the error rate and finds the deploy behind it, with a second agent doing the charting. One collapsible block per app, Discord open and Slack and Mattermost waiting, so adding the next recording is pasting one URL.

## How the video is hosted, and why it matters

The recording is a GitHub attachment, not a file in this repository. Nothing was committed.

That was worth establishing rather than assuming, because most of the obvious ways do not work. Checked against the rendered page on a branch, not from memory:

| In a README | Result |
| --- | --- |
| `<video>` tag | stripped to a link |
| Link to an `.mp4` committed here | plain link |
| `blob/…?raw=true` | plain link |
| Bare `user-attachments` URL on its own line | **plays** |

It also plays inside `<details>` and inside a centered `<div>`, which is what lets the section hold one block per app without running long.

The earlier revision of this branch committed an 11 MB `.mp4` and a poster image. Both are gone, and the branch was rewritten so the blobs are not in its history — three recordings would otherwise have put roughly 33 MB into the repository permanently, paid by everyone who clones. A comment above the section says so, so the next person reaches for an attachment instead.

## Worth a look before merging

- **The recording shows real names.** Two colleagues' first names appear in the channel, and the left rail lists the other Discord servers the recorder belongs to. Nothing sensitive to Switch, but a README is public and permanent.
- **I have not watched the video**, only sampled frames from it. The description is written from those.