### PR TITLE
fix(console): make the setup checklist's ✕ actually hide it (CHOO-2344)

### DIFF
--- a/console/apps/switch-console-desktop/src/renderer/features/onboarding/use-onboarding-checklist.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/onboarding/use-onboarding-checklist.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect } from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { switchRoomsStore } from '@renderer/features/switch-servers/switch-rooms-store';
 import { switchServersStore } from '@renderer/features/switch-servers/switch-servers-store';
-import { rpc } from '@renderer/lib/ipc';
 import { useNavigate } from '@renderer/lib/layout/navigation-provider';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { appState } from '@renderer/lib/stores/app-state';
@@ -54,7 +53,7 @@ export type OnboardingChecklist = {
  */
 export function useOnboardingChecklist(): OnboardingChecklist {
   const progress = useOnboardingProgress();
-  const { value: onboarding } = useAppSettingsKey('onboarding');
+  const { update: updateOnboardingSettings } = useAppSettingsKey('onboarding');
   const showAddServerModal = useShowModal('addServerModal');
   const showAddAgentModal = useShowModal('addAgentModal');
   const showCreateRoomModal = useShowModal('createRoomModal');
@@ -83,11 +82,14 @@ export function useOnboardingChecklist(): OnboardingChecklist {
 
   const complete = isOnboardingComplete(progress);
 
+  // Goes through the settings mutation rather than the IPC call it wraps: the
+  // checklist's visibility is read from the cached setting, and nothing
+  // broadcasts a settings change back to the renderer, so writing straight to
+  // the main process leaves the panel on screen until the next launch.
   const dismiss = useCallback(() => {
-    if (!onboarding) return;
     report('onboarding_checklist_dismissed', {});
-    void rpc.appSettings.update('onboarding', { ...onboarding, showChecklist: false });
-  }, [onboarding]);
+    updateOnboardingSettings({ showChecklist: false });
+  }, [updateOnboardingSettings]);
 
   // Completion is a condition, not an event: it becomes true during a render and
   // is true again on every later launch. Asking more than once is harmless —

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/onboarding-checklist-dismiss.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/onboarding-checklist-dismiss.test.tsx
@@ -1,0 +1,117 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Dismissing the setup checklist has to reach the checklist, not just the disk.
+ *
+ * The panel renders from the cached `onboarding` setting and nothing broadcasts
+ * a settings change back to the renderer, so a dismissal written straight over
+ * IPC persisted correctly and changed nothing on screen — the ✕ read as a dead
+ * button until the next launch (CHOO-2344).
+ */
+
+/** Stands in for the main process: `getWithMeta` reflects what `update` stored. */
+const stored = vi.hoisted(() => ({ showChecklist: true }));
+const settingsUpdate = vi.hoisted(() => vi.fn());
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: { on: vi.fn(() => () => {}), emit: vi.fn() },
+  rpc: {
+    appSettings: {
+      getWithMeta: vi.fn(() =>
+        Promise.resolve({
+          value: { ...stored },
+          defaults: { showChecklist: true },
+          overrides: {},
+        })
+      ),
+      update: settingsUpdate.mockImplementation((_key, value) => {
+        Object.assign(stored, value);
+        return Promise.resolve(undefined);
+      }),
+      reset: vi.fn(),
+      resetField: vi.fn(),
+    },
+    switchSetup: {
+      listAgentTypeAvailability: vi.fn(() => Promise.resolve([])),
+      listAgentTypeAvailabilityRemote: vi.fn(() => Promise.resolve([])),
+    },
+  },
+}));
+vi.mock('@renderer/lib/telemetry/report', () => ({ report: vi.fn() }));
+
+import { useOnboardingChecklist } from '@renderer/features/onboarding/use-onboarding-checklist';
+import { appSettingsMetaQueryKey } from '@renderer/features/settings/app-settings-client';
+import { queryClient } from '@renderer/lib/query-client';
+
+const ONBOARDING_KEY = appSettingsMetaQueryKey('onboarding');
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+  queryClient.clear();
+  settingsUpdate.mockClear();
+  stored.showChecklist = true;
+});
+
+/** Mounts the hook against the app's own query client and hands back `dismiss`. */
+async function mountChecklist() {
+  queryClient.setQueryData(ONBOARDING_KEY, {
+    value: { showChecklist: true },
+    defaults: { showChecklist: true },
+    overrides: {},
+  });
+
+  let dismiss: () => void = () => {};
+  function Probe() {
+    dismiss = useOnboardingChecklist().dismiss;
+    return null;
+  }
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () =>
+    root!.render(
+      <QueryClientProvider client={queryClient}>
+        <Probe />
+      </QueryClientProvider>
+    )
+  );
+
+  return () => dismiss();
+}
+
+describe('dismissing the setup checklist', () => {
+  it('hides the checklist for the session, not only on the next launch', async () => {
+    const dismiss = await mountChecklist();
+
+    await act(async () => {
+      dismiss();
+      await vi.waitFor(() =>
+        expect(
+          queryClient.getQueryData<{ value: { showChecklist: boolean } }>(ONBOARDING_KEY)?.value
+            .showChecklist
+        ).toBe(false)
+      );
+    });
+  });
+
+  it('persists the dismissal', async () => {
+    const dismiss = await mountChecklist();
+
+    await act(async () => {
+      dismiss();
+      await vi.waitFor(() =>
+        expect(settingsUpdate).toHaveBeenCalledWith('onboarding', { showChecklist: false })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Symptom

The ✕ on the sidebar's **Setting up Switch** checklist does nothing. The checklist stays on screen.

## Cause

The dismiss handler wrote the setting with a raw `rpc.appSettings.update(...)` rather than the settings mutation that wraps it. The checklist's visibility is read from the react-query-cached `onboarding` setting, and nothing broadcasts a settings change back to the renderer — so the value persisted to disk while the cache went on saying `showChecklist: true`. The button worked; you just couldn't tell until the next launch.

The Settings → General toggle for the same setting was already going through the mutation, which is why that one worked.

## Fix

Route the dismissal through `useAppSettingsKey('onboarding').update`, which writes the cache optimistically, invalidates on settle, and rolls back on failure. Both dismiss buttons (sidebar panel and welcome card) share this handler, so both are fixed.

Also drops the `if (!onboarding) return` guard — a silent no-op when the setting had not loaded. The mutation merges from the cache itself, so the value is no longer needed here.

## Test

The existing checklist tests mount the presentational component with a stub `onDismiss`, so they asserted the button calls its prop and never touched the wiring. Added `onboarding-checklist-dismiss.test.tsx`, which mounts the hook against the app's query client and asserts the cached setting flips — verified failing against the old call and passing with the fix.

Console suite: 3239 tests green (323 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)