### PR TITLE
release: console 0.31.1 + connectors claude 0.9.9 / codex 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,6 +1072,12 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.31.1] - 2026-08-26
+
+#### Fixed
+- The setup checklist's ✕ now actually dismisses it. The button did nothing, so
+  a checklist a user had finished with stayed on screen.
+
 ### [0.31.0] - 2026-08-25
 #### Added
 - Creating an agent, starting a session and adding a server now report whether
@@ -2655,6 +2661,13 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
+### [0.9.9] - 2026-08-26
+#### Fixed
+- The `configure` skill's standalone feature list no longer claims the **task
+  protocol** works — it was removed from the connector skills, so an agent
+  reading the old list could try something unavailable. Plugin version bumped so
+  installs re-download.
+
 ### [0.9.8] - 2026-08-24
 #### Changed
 - The `configure` skill's generated connect command now names the agent it was
@@ -2864,6 +2877,14 @@ manifest history.
 `connectors/codex-plugin/`. Version lives in `.codex-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.3.10] - 2026-08-26
+#### Fixed
+- The `configure` skill's standalone feature list no longer claims the **task
+  protocol** works — it was removed from the connector skills, so an agent
+  reading the old list could try something unavailable. Also corrects a
+  `mcp_servers` → `mcpServers` reference. Plugin version bumped so installs
+  re-download.
 
 ### [0.3.9] - 2026-08-24
 #### Changed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.31.0
+    version: 0.31.1
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.8
+    version: 0.9.9
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.9
+    version: 0.3.10
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,15 +21,15 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.0',
-  'switch-console': '0.31.0',
+  'switch-console': '0.31.1',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
   gateway: '0.21.0',
   setup: '0.21.0',
   'helm-chart': '0.21.0',
   compose: '0.21.0',
-  'switch-connector': '0.9.8',
-  'switch-connector-codex': '0.3.9',
+  'switch-connector': '0.9.9',
+  'switch-connector-codex': '0.3.10',
   'switch-connector-opencode': '0.1.5',
 } as const satisfies Record<string, string>;
 

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,15 +21,15 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.0',
-  'switch-console': '0.31.0',
+  'switch-console': '0.31.1',
   'agent-runtime': '0.3.2',
   sidecar: '1.9.4',
   gateway: '0.21.0',
   setup: '0.21.0',
   'helm-chart': '0.21.0',
   compose: '0.21.0',
-  'switch-connector': '0.9.8',
-  'switch-connector-codex': '0.3.9',
+  'switch-connector': '0.9.9',
+  'switch-connector-codex': '0.3.10',
   'switch-connector-opencode': '0.1.5',
 } as const satisfies Record<string, string>;
 

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,15 +21,15 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.21.0",
-    "switch-console": "0.31.0",
+    "switch-console": "0.31.1",
     "agent-runtime": "0.3.2",
     "sidecar": "1.9.4",
     "gateway": "0.21.0",
     "setup": "0.21.0",
     "helm-chart": "0.21.0",
     "compose": "0.21.0",
-    "switch-connector": "0.9.8",
-    "switch-connector-codex": "0.3.9",
+    "switch-connector": "0.9.9",
+    "switch-connector-codex": "0.3.10",
     "switch-connector-opencode": "0.1.5",
 }
 


### PR DESCRIPTION
Small batch cut from the Switch Releases room, covering everything on main since core `0.21.0` / console `0.31.0`.

## switch-console `0.31.0 → 0.31.1` (patch)
- **fix(#304):** the setup checklist's ✕ now actually dismisses it

## Connector plugins (patch — re-download for the #302 `configure`-skill correction)
- switch-connector `0.9.8 → 0.9.9`, switch-connector-codex `0.3.9 → 0.3.10`
- The standalone feature list no longer claims the **task protocol** works (removed in CHOO-1418); codex skill also fixes an `mcp_servers` → `mcpServers` reference. **opencode `0.1.5` untouched.**

## Not released / unchanged
- **switch-core** — the doc-sync PR (#295) only touched a Teams README + a test under `core/`; no shipping code, so no core release and the bundle pin stays at `0.21.0`.
- agent-runtime (`0.3.2`), sidecar (`1.9.4`) — no changes.

## Registry / contracts
- `artifacts.yaml` + generated modules regenerated; `artifacts-check` passes.
- No contract changes (`1/1`). Authored all `[Unreleased]` entries.

On merge: tag `switch-console-v0.31.1` (macOS build gated on approval). No switch-core tag this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)