### PR TITLE
release: agent-runtime 0.3.3 (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2469,6 +2469,19 @@ The Switch protocol client and MCP runtime
 
 ### [Unreleased]
 
+### [0.3.3] - 2026-08-27
+
+#### Fixed
+- The runtime now exits when its host does, instead of running forever. Its
+  intended shutdown path (via the transport's `onclose`) never fired for a host
+  that was killed, crashed or force-quit, and the hook listener's TCP server
+  plus the heartbeat and lease timers kept the process alive against a Switch
+  that was already gone — leaving stale processes and loopback listeners piling
+  up across sessions. Shutdown is now driven by four independent triggers —
+  stdin `end`/`close`, termination signals, a stdout/stderr write error, and a
+  parent-pid watchdog — so the process goes away whichever way its host vanishes
+  (#307).
+
 ### [0.3.2] - 2026-08-19
 
 #### Fixed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -82,7 +82,7 @@ artifacts:
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
-    version: 0.3.2
+    version: 0.3.3
     declared_in: console/packages/switch-agent-runtime/package.json
 
   sidecar:

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -22,7 +22,7 @@ export interface ContractRange {
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.0',
   'switch-console': '0.31.1',
-  'agent-runtime': '0.3.2',
+  'agent-runtime': '0.3.3',
   sidecar: '1.9.4',
   gateway: '0.21.0',
   setup: '0.21.0',

--- a/console/packages/switch-agent-runtime/package.json
+++ b/console/packages/switch-agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sandboxaq/switch-agent-runtime",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Switch agent protocol client, and the local MCP runtime built on it",
   "license": "Apache-2.0",
   "author": {

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -22,7 +22,7 @@ export interface ContractRange {
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.0',
   'switch-console': '0.31.1',
-  'agent-runtime': '0.3.2',
+  'agent-runtime': '0.3.3',
   sidecar: '1.9.4',
   gateway: '0.21.0',
   setup: '0.21.0',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -22,7 +22,7 @@ class ContractRange(NamedTuple):
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.21.0",
     "switch-console": "0.31.1",
-    "agent-runtime": "0.3.2",
+    "agent-runtime": "0.3.3",
     "sidecar": "1.9.4",
     "gateway": "0.21.0",
     "setup": "0.21.0",


### PR DESCRIPTION
Phase 1 of a two-phase runtime release — publishes **agent-runtime `0.3.2 → 0.3.3`** to npm.

## Change
- **fix(#307):** the runtime now exits when its host does instead of running forever. The `onclose`-based shutdown never fired for a killed/crashed/force-quit host, and the hook listener's TCP server + heartbeat/lease timers kept the process alive against a Switch that was already gone — leaving stale processes and loopback listeners accumulating across sessions. Shutdown is now driven by four independent triggers (stdin `end`/`close`, termination signals, a stdout/stderr write error, a parent-pid watchdog).

## Phase 1 vs Phase 2
- **This PR (Phase 1):** bump `package.json` + `artifacts.yaml` → `0.3.3`, changelog. On merge → tag `switch-agent-runtime-v0.3.3` → CI publishes to npm.
- **Deliberately NOT touched:** the connector runtime pins (claude & codex `.mcp.json`, opencode `opencode.json`, `SWITCH_AGENT_RUNTIME_PIN`), the plugin versions, and the sidecar — all stay at their current versions. A pin must never name a version npm doesn't have yet; the pin tests only check the pins agree with each other, so they stay green.
- **Phase 2 (later, on request):** re-pin all four to `0.3.3`, bump each plugin's version so it re-downloads, bump the sidecar. Until then the fix is on npm but sessions still run `0.3.2`.

`artifacts.yaml` + generated modules regenerated; `artifacts-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)