### PR TITLE
release: runtime cascade — pin agent-runtime 0.3.3 (phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2591,6 +2591,14 @@ by Switch Console rather than published on its own.
 
 ### [Unreleased]
 
+### [1.9.5]
+
+#### Changed
+- Runs agent-runtime `0.3.3`, which now exits when its host does instead of
+  leaving stale runtime processes and loopback listeners behind (#307). The
+  client↔sidecar wire (ready line, endpoints, on-disk layout) is unchanged, so
+  the major stays `1`.
+
 ### [1.9.4]
 
 #### Fixed
@@ -2673,6 +2681,12 @@ compatibility signal. History for those is in the git log.
 `.claude-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.9.10] - 2026-08-27
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.3` (was `0.3.2`) — picks up the
+  runtime's host-exit fix (#307), which stops stale runtime processes and
+  loopback listeners piling up. Plugin version bumps so installs re-download.
 
 ### [0.9.9] - 2026-08-26
 #### Fixed
@@ -2891,6 +2905,12 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.3.11] - 2026-08-27
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.3` (was `0.3.2`) — picks up the
+  runtime's host-exit fix (#307), which stops stale runtime processes and
+  loopback listeners piling up. Plugin version bumps so installs re-download.
+
 ### [0.3.10] - 2026-08-26
 #### Fixed
 - The `configure` skill's standalone feature list no longer claims the **task
@@ -3062,6 +3082,12 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.6] - 2026-08-27
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.3` (was `0.3.2`) — picks up the
+  runtime's host-exit fix (#307). Reaches users with the next Switch Console
+  release, which writes this connector.
 
 ### [0.1.5] - 2026-08-22
 #### Fixed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -90,7 +90,7 @@ artifacts:
       The remote runtime Switch Console deploys to an agent host. Deployed rather
       than published, so nothing else declares its version — this file is its
       only source and the constant is generated from it.
-    version: 1.9.4
+    version: 1.9.5
 
   # ── Published under the switch-core release ────────────────────────────────
   # No version of their own: `helm package` and the image build stamp them with
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.9
+    version: 0.9.10
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.10
+    version: 0.3.11
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.5
+    version: 0.1.6
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/.mcp.json
+++ b/connectors/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.2"]
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.3"]
     }
   }
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/codex-plugin/.mcp.json
+++ b/connectors/codex-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.2"],
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.3"],
       "env_vars": [
         "SWITCH_API_ENDPOINT",
         "SWITCH_API_TOKEN",

--- a/connectors/opencode-plugin/opencode.json
+++ b/connectors/opencode-plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "switch": {
       "type": "local",
-      "command": ["npx", "-y", "@sandboxaq/switch-agent-runtime@0.3.2"],
+      "command": ["npx", "-y", "@sandboxaq/switch-agent-runtime@0.3.3"],
       "enabled": true,
       "timeout": 60000
     }

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/packages/plugins/src/distribution.ts
+++ b/console/packages/plugins/src/distribution.ts
@@ -27,4 +27,4 @@ export const SWITCH_MARKETPLACE_SOURCE = 'sandbox-quantum/switch';
  * has got to, which during a release is a version npm does not have yet. A
  * pin has to lag it deliberately, and the lag is the point.
  */
-export const SWITCH_AGENT_RUNTIME_PIN = '@sandboxaq/switch-agent-runtime@0.3.2';
+export const SWITCH_AGENT_RUNTIME_PIN = '@sandboxaq/switch-agent-runtime@0.3.3';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -23,14 +23,14 @@ export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.0',
   'switch-console': '0.31.1',
   'agent-runtime': '0.3.3',
-  sidecar: '1.9.4',
+  sidecar: '1.9.5',
   gateway: '0.21.0',
   setup: '0.21.0',
   'helm-chart': '0.21.0',
   compose: '0.21.0',
-  'switch-connector': '0.9.9',
-  'switch-connector-codex': '0.3.10',
-  'switch-connector-opencode': '0.1.5',
+  'switch-connector': '0.9.10',
+  'switch-connector-codex': '0.3.11',
+  'switch-connector-opencode': '0.1.6',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -23,14 +23,14 @@ export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.0',
   'switch-console': '0.31.1',
   'agent-runtime': '0.3.3',
-  sidecar: '1.9.4',
+  sidecar: '1.9.5',
   gateway: '0.21.0',
   setup: '0.21.0',
   'helm-chart': '0.21.0',
   compose: '0.21.0',
-  'switch-connector': '0.9.9',
-  'switch-connector-codex': '0.3.10',
-  'switch-connector-opencode': '0.1.5',
+  'switch-connector': '0.9.10',
+  'switch-connector-codex': '0.3.11',
+  'switch-connector-opencode': '0.1.6',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -23,14 +23,14 @@ ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.21.0",
     "switch-console": "0.31.1",
     "agent-runtime": "0.3.3",
-    "sidecar": "1.9.4",
+    "sidecar": "1.9.5",
     "gateway": "0.21.0",
     "setup": "0.21.0",
     "helm-chart": "0.21.0",
     "compose": "0.21.0",
-    "switch-connector": "0.9.9",
-    "switch-connector-codex": "0.3.10",
-    "switch-connector-opencode": "0.1.5",
+    "switch-connector": "0.9.10",
+    "switch-connector-codex": "0.3.11",
+    "switch-connector-opencode": "0.1.6",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {


### PR DESCRIPTION
Phase 2 of the agent-runtime `0.3.3` release. `0.3.3` is live on npm (Phase 1, #308); this moves every consumer onto it so the host-exit fix (#307) actually reaches sessions.

## Runtime pin `0.3.2 → 0.3.3` (all four places)
- `connectors/claude-code-plugin/.mcp.json`
- `connectors/codex-plugin/.mcp.json`
- `connectors/opencode-plugin/opencode.json`
- `SWITCH_AGENT_RUNTIME_PIN` in `console/packages/plugins/src/distribution.ts` (the embedded OpenCode MCP config derives from this constant, so it follows — `connector-assets.test.ts` stays green)

## Consumer version bumps (so the new pin ships)
- switch-connector `0.9.9 → 0.9.10`, switch-connector-codex `0.3.10 → 0.3.11`, switch-connector-opencode `0.1.5 → 0.1.6`
- sidecar `1.9.4 → 1.9.5` (runs the new runtime; **major stays 1**, client↔sidecar wire unchanged)

## How it reaches users
- **claude & codex** — on the next marketplace **Update** (their plugin version changed).
- **opencode & sidecar** — ride the **next Switch Console release** (opencode is written by the app; the sidecar is deployed by it).

`artifacts.yaml` + generated modules regenerated; `artifacts-check` passes; the runtime pins agree with each other so `runtime-pin.test.ts` / `connector-assets.test.ts` stay green. No new tags — this is a merge-to-main change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)