### PR TITLE
release: switch-console 0.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,6 +1072,24 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.31.2] - 2026-08-27
+
+#### Added
+- Orphaned agent runtimes are reaped at boot: a runtime whose host has gone —
+  left behind because a user updated the app but never revisited the connector —
+  is cleared on startup, using the same "is this runtime abandoned?" predicate
+  the runtime itself uses, so a live session is never touched (#309).
+- A one-shot catch-up brings already-installed Switch connectors up to date once,
+  so an install that never revisits Settings → Agents stops drifting several
+  runtime versions behind. It runs once, latches, and leaves the Update button
+  as the normal path; it never installs a connector that isn't already there
+  (#309).
+
+#### Changed
+- The bundled sidecar (`1.9.5`) and the OpenCode connector (`0.1.6`) this build
+  writes now run agent-runtime `0.3.3`, which exits with its host instead of
+  leaving stale processes behind.
+
 ### [0.31.1] - 2026-08-26
 
 #### Fixed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.31.1
+    version: 0.31.2
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.0',
-  'switch-console': '0.31.1',
+  'switch-console': '0.31.2',
   'agent-runtime': '0.3.3',
   sidecar: '1.9.5',
   gateway: '0.21.0',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.0',
-  'switch-console': '0.31.1',
+  'switch-console': '0.31.2',
   'agent-runtime': '0.3.3',
   sidecar: '1.9.5',
   gateway: '0.21.0',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,7 +21,7 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.21.0",
-    "switch-console": "0.31.1",
+    "switch-console": "0.31.2",
     "agent-runtime": "0.3.3",
     "sidecar": "1.9.5",
     "gateway": "0.21.0",


### PR DESCRIPTION
Console release cut from the Switch Releases room.

## switch-console `0.31.1 → 0.31.2` (patch, per request)
Contains #309:
- **Reap orphaned agent runtimes at boot** — a runtime whose host is gone (left behind when the app updated but the connector didn't) is cleared on startup, using the runtime's own "is this abandoned?" predicate so a live session is never touched.
- **One-shot connector catch-up** — brings already-installed connectors up to date once, then latches; never installs a connector that isn't already there.

## Also ships (Phase 2, already on main, was waiting for a console release)
- Bundled **sidecar `1.9.5`** and **OpenCode connector `0.1.6`** now run **agent-runtime `0.3.3`** (exits with its host instead of leaving stale processes behind).

## Notes
- Bundle pin / `COMPATIBLE_SWITCH_VERSION` stays at core `0.21.0` (no core release).
- **Runtime version drift** from #309 (runtime source changed, `package.json` still `0.3.3` = what's on npm) is deliberately left for the next runtime release — no user-facing runtime behaviour changed.
- `artifacts.yaml` + generated modules regenerated; `artifacts-check` passes.

On merge: tag `switch-console-v0.31.2` (macOS build gated on approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)