### PR TITLE
fix(slack): normalize typed command mentions

### DIFF
--- a/core/switch_core/bridges/collaboration/slack/adapter.py
+++ b/core/switch_core/bridges/collaboration/slack/adapter.py
@@ -2009,7 +2009,7 @@ class SlackAdapter(CollaborationAdapter):
         if stripped.startswith("!") and self._on_command:
             parts = stripped.split(None, 1)
             command = parts[0].lstrip("!")
-            args = parts[1].strip() if len(parts) > 1 else ""
+            args = self.translate_inbound(parts[1].strip()) if len(parts) > 1 else ""
             await self._on_command(
                 InboundCommand(
                     channel_id=channel_id,
@@ -2072,9 +2072,9 @@ class SlackAdapter(CollaborationAdapter):
         user = await self._resolve_user_name(user_id)
         channel_name = str(payload.get("channel_name", "")) or None
 
-        # Slack encodes any @mentions in the slash text as `<@U…>`; normalise
-        # them to `@name` so the command dispatcher's targeting (first @token →
-        # target agent/role) resolves the same way it does for a typed command.
+        # Slack encodes @mentions in command arguments as `<@U…>`; normalise
+        # them to `@name` so the command dispatcher's first `@` token resolves
+        # to the target agent or role.
         args = self.translate_inbound(text)
 
         try:

--- a/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
+++ b/core/tests/switch_core/bridges/collaboration/test_slack_adapter.py
@@ -1028,6 +1028,30 @@ def _capture_commands(adapter: SlackAdapter) -> list[InboundCommand]:
     return captured
 
 
+def test_typed_command_translates_slack_mention() -> None:
+    adapter = _adapter()
+    adapter._user_cache["U1"] = SlackUser(name="jane", display_name="Jane")
+    adapter._user_cache["U999"] = SlackUser(name="worker", display_name="Worker")
+    adapter._channel_name_cache["C123"] = "general"
+    commands = _capture_commands(adapter)
+
+    _run(
+        adapter._handle_message_event(
+            {
+                "channel": "C123",
+                "ts": "100.1",
+                "user": "U1",
+                "text": "!invite-agent <@U999>",
+                "channel_type": "channel",
+            }
+        )
+    )
+
+    assert len(commands) == 1
+    assert commands[0].command == "invite-agent"
+    assert commands[0].args == "@worker"
+
+
 def test_slash_command_maps_to_in_room_command() -> None:
     adapter = _adapter()
     fake = _FakeSlashWebClient()


### PR DESCRIPTION
### Context

Fixes #315 

Slack encodes an autocomplete-selected mention as `<@U123>`, even though it displays the mention as `@username` in the client.

The Slack slash-command path normalizes this encoding with `translate_inbound`, but the typed `!command` path previously passed its arguments to the command dispatcher unchanged. As a result, commands such as `!invite-agent` could silently fail when their target was selected from Slack’s autocomplete popup.

### Description

Normalize typed Slack `!command` arguments using `translate_inbound` before dispatching them.

This converts Slack-encoded mentions such as `<@U123>` into the `@username` format expected by the command dispatcher. The stale slash-command comment was also updated to describe the shared normalization behavior accurately.

The related adapters were checked in the same pass:

- Discord already normalizes typed-command mentions and has regression coverage.
- Mattermost sends mentions as literal `@username`, so no normalization change is required.

### Steps to review

- `core/switch_core/bridges/collaboration/slack/adapter.py` — confirm typed command arguments pass through `translate_inbound`.
- `core/tests/switch_core/bridges/collaboration/test_slack_adapter.py` — regression test sends `!invite-agent <@U999>` and verifies the dispatcher receives `@worker`.
- Confirm the slash-command path continues using the same inbound translation.

Tests:

- `just check` — passed
- `just typecheck` — passed
- `just test` — 2011 passed, 5 deselected
- Live Slack test — an autocomplete-selected mention in `!invite-agent @username` successfully added the corresponding Switch agent