### PR TITLE
release: switch-core 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.21.1] - 2026-09-01
+
+#### Fixed
+- Slack: normalize typed command mentions so commands addressed with a typed
+  `@agent` are recognized (#316).
+- Slack: resolve agent mentions that crossed a workspace boundary (#327).
+
 ### [0.21.0] - 2026-08-25
 
 #### Added

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.21.0
+    version: 0.21.1
     declared_in: core/pyproject.toml
     published_as: switch-core
 

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.21.0',
+  'switch-core': '0.21.1',
   'switch-console': '0.31.2',
   'agent-runtime': '0.3.3',
   sidecar: '1.9.5',
-  gateway: '0.21.0',
-  setup: '0.21.0',
-  'helm-chart': '0.21.0',
-  compose: '0.21.0',
+  gateway: '0.21.1',
+  setup: '0.21.1',
+  'helm-chart': '0.21.1',
+  compose: '0.21.1',
   'switch-connector': '0.9.10',
   'switch-connector-codex': '0.3.11',
   'switch-connector-opencode': '0.1.6',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.21.0',
+  'switch-core': '0.21.1',
   'switch-console': '0.31.2',
   'agent-runtime': '0.3.3',
   sidecar: '1.9.5',
-  gateway: '0.21.0',
-  setup: '0.21.0',
-  'helm-chart': '0.21.0',
-  compose: '0.21.0',
+  gateway: '0.21.1',
+  setup: '0.21.1',
+  'helm-chart': '0.21.1',
+  compose: '0.21.1',
   'switch-connector': '0.9.10',
   'switch-connector-codex': '0.3.11',
   'switch-connector-opencode': '0.1.6',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.21.0"
+version = "0.21.1"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.21.0",
+    "switch-core": "0.21.1",
     "switch-console": "0.31.2",
     "agent-runtime": "0.3.3",
     "sidecar": "1.9.5",
-    "gateway": "0.21.0",
-    "setup": "0.21.0",
-    "helm-chart": "0.21.0",
-    "compose": "0.21.0",
+    "gateway": "0.21.1",
+    "setup": "0.21.1",
+    "helm-chart": "0.21.1",
+    "compose": "0.21.1",
     "switch-connector": "0.9.10",
     "switch-connector-codex": "0.3.11",
     "switch-connector-opencode": "0.1.6",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **switch-core 0.21.1**.

## What's Changed
- Slack: normalize typed command mentions (#316)
- Slack: resolve agent mentions that crossed a workspace boundary (#327)

Bumps `core/pyproject.toml` + `artifacts.yaml` (0.21.0 → 0.21.1), regenerates the artifact modules, cuts the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)