### PR TITLE
release: agent-runtime 0.3.4 (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2494,6 +2494,14 @@ The Switch protocol client and MCP runtime
 
 ### [Unreleased]
 
+### [0.3.4] - 2026-09-01
+
+#### Added
+- Reap orphaned agent runtimes at boot: `reapOrphanedRuntimes` is now part of
+  the package's public surface so the runtime and Switch Console share one
+  definition of an abandoned runtime, and a session started on a dead host is
+  cleaned up on the next start (#309).
+
 ### [0.3.3] - 2026-08-27
 
 #### Fixed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -82,7 +82,7 @@ artifacts:
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
-    version: 0.3.3
+    version: 0.3.4
     declared_in: console/packages/switch-agent-runtime/package.json
 
   sidecar:

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -22,7 +22,7 @@ export interface ContractRange {
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.1',
   'switch-console': '0.31.2',
-  'agent-runtime': '0.3.3',
+  'agent-runtime': '0.3.4',
   sidecar: '1.9.5',
   gateway: '0.21.1',
   setup: '0.21.1',

--- a/console/packages/switch-agent-runtime/package.json
+++ b/console/packages/switch-agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sandboxaq/switch-agent-runtime",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Switch agent protocol client, and the local MCP runtime built on it",
   "license": "Apache-2.0",
   "author": {

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -22,7 +22,7 @@ export interface ContractRange {
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.1',
   'switch-console': '0.31.2',
-  'agent-runtime': '0.3.3',
+  'agent-runtime': '0.3.4',
   sidecar: '1.9.5',
   gateway: '0.21.1',
   setup: '0.21.1',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -22,7 +22,7 @@ class ContractRange(NamedTuple):
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.21.1",
     "switch-console": "0.31.2",
-    "agent-runtime": "0.3.3",
+    "agent-runtime": "0.3.4",
     "sidecar": "1.9.5",
     "gateway": "0.21.1",
     "setup": "0.21.1",


### PR DESCRIPTION
Phase 1 of the runtime cascade: publish **agent-runtime 0.3.4**.

## What's Changed
- Reap orphaned agent runtimes at boot — `reapOrphanedRuntimes` promoted to the package's public surface, shared by the runtime and Switch Console (#309)

Bumps `packages/switch-agent-runtime/package.json` + `artifacts.yaml` (0.3.3 → 0.3.4), regenerates modules, cuts the CHANGELOG. Connector pins move in **phase 2**, after the `switch-agent-runtime-v0.3.4` tag publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)