### PR TITLE
release: runtime cascade phase 2 — pin agent-runtime 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2624,6 +2624,11 @@ by Switch Console rather than published on its own.
 
 ### [Unreleased]
 
+### [1.9.6] - 2026-09-01
+
+#### Changed
+- Rebuilt on agent-runtime 0.3.4, which reaps orphaned agent runtimes at boot.
+
 ### [1.9.5]
 
 #### Changed
@@ -2714,6 +2719,11 @@ compatibility signal. History for those is in the git log.
 `.claude-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.9.11] - 2026-09-01
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.4` (was `0.3.3`) — picks up reaping
+  of orphaned agent runtimes at boot.
 
 ### [0.9.10] - 2026-08-27
 #### Changed
@@ -2938,6 +2948,11 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.3.12] - 2026-09-01
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.4` (was `0.3.3`) — picks up reaping
+  of orphaned agent runtimes at boot.
+
 ### [0.3.11] - 2026-08-27
 #### Changed
 - Pin `@sandboxaq/switch-agent-runtime@0.3.3` (was `0.3.2`) — picks up the
@@ -3115,6 +3130,11 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.7] - 2026-09-01
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.3.4` (was `0.3.3`) — picks up reaping
+  of orphaned agent runtimes at boot.
 
 ### [0.1.6] - 2026-08-27
 #### Changed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -90,7 +90,7 @@ artifacts:
       The remote runtime Switch Console deploys to an agent host. Deployed rather
       than published, so nothing else declares its version — this file is its
       only source and the constant is generated from it.
-    version: 1.9.5
+    version: 1.9.6
 
   # ── Published under the switch-core release ────────────────────────────────
   # No version of their own: `helm package` and the image build stamp them with
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.10
+    version: 0.9.11
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.11
+    version: 0.3.12
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.6
+    version: 0.1.7
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/.mcp.json
+++ b/connectors/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.3"]
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.4"]
     }
   }
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/codex-plugin/.mcp.json
+++ b/connectors/codex-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.3"],
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.4"],
       "env_vars": [
         "SWITCH_API_ENDPOINT",
         "SWITCH_API_TOKEN",

--- a/connectors/opencode-plugin/opencode.json
+++ b/connectors/opencode-plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "switch": {
       "type": "local",
-      "command": ["npx", "-y", "@sandboxaq/switch-agent-runtime@0.3.3"],
+      "command": ["npx", "-y", "@sandboxaq/switch-agent-runtime@0.3.4"],
       "enabled": true,
       "timeout": 60000
     }

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/packages/plugins/src/distribution.ts
+++ b/console/packages/plugins/src/distribution.ts
@@ -27,4 +27,4 @@ export const SWITCH_MARKETPLACE_SOURCE = 'sandbox-quantum/switch';
  * has got to, which during a release is a version npm does not have yet. A
  * pin has to lag it deliberately, and the lag is the point.
  */
-export const SWITCH_AGENT_RUNTIME_PIN = '@sandboxaq/switch-agent-runtime@0.3.3';
+export const SWITCH_AGENT_RUNTIME_PIN = '@sandboxaq/switch-agent-runtime@0.3.4';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -23,14 +23,14 @@ export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.1',
   'switch-console': '0.31.2',
   'agent-runtime': '0.3.4',
-  sidecar: '1.9.5',
+  sidecar: '1.9.6',
   gateway: '0.21.1',
   setup: '0.21.1',
   'helm-chart': '0.21.1',
   compose: '0.21.1',
-  'switch-connector': '0.9.10',
-  'switch-connector-codex': '0.3.11',
-  'switch-connector-opencode': '0.1.6',
+  'switch-connector': '0.9.11',
+  'switch-connector-codex': '0.3.12',
+  'switch-connector-opencode': '0.1.7',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -23,14 +23,14 @@ export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.1',
   'switch-console': '0.31.2',
   'agent-runtime': '0.3.4',
-  sidecar: '1.9.5',
+  sidecar: '1.9.6',
   gateway: '0.21.1',
   setup: '0.21.1',
   'helm-chart': '0.21.1',
   compose: '0.21.1',
-  'switch-connector': '0.9.10',
-  'switch-connector-codex': '0.3.11',
-  'switch-connector-opencode': '0.1.6',
+  'switch-connector': '0.9.11',
+  'switch-connector-codex': '0.3.12',
+  'switch-connector-opencode': '0.1.7',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -23,14 +23,14 @@ ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.21.1",
     "switch-console": "0.31.2",
     "agent-runtime": "0.3.4",
-    "sidecar": "1.9.5",
+    "sidecar": "1.9.6",
     "gateway": "0.21.1",
     "setup": "0.21.1",
     "helm-chart": "0.21.1",
     "compose": "0.21.1",
-    "switch-connector": "0.9.10",
-    "switch-connector-codex": "0.3.11",
-    "switch-connector-opencode": "0.1.6",
+    "switch-connector": "0.9.11",
+    "switch-connector-codex": "0.3.12",
+    "switch-connector-opencode": "0.1.7",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {


### PR DESCRIPTION
Phase 2 of the runtime cascade. `switch-agent-runtime-v0.3.4` is published to npm, so the pins move to it now.

## What's Changed
- Pin `@sandboxaq/switch-agent-runtime@0.3.4` in `distribution.ts` and the three connector MCP configs (Claude Code, Codex, OpenCode)
- switch-connector (Claude Code) 0.9.10 → 0.9.11
- switch-connector-codex 0.3.11 → 0.3.12
- switch-connector-opencode 0.1.6 → 0.1.7
- sidecar 1.9.5 → 1.9.6

`artifacts.yaml` bumped + modules regenerated + CHANGELOG cut for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)