### PR TITLE
release: switch-console 0.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1079,6 +1079,17 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.31.3] - 2026-09-01
+
+#### Added
+- The disabled "Add agent" button now explains why on hover, splitting the
+  not-ready tooltip into distinct checking and blocked messages (#314).
+
+#### Changed
+- Bundles agent-runtime 0.3.4 (reaps orphaned agent runtimes at boot) and the
+  updated connectors (Claude Code 0.9.11, Codex 0.3.12, OpenCode 0.1.7) and
+  sidecar 1.9.6.
+
 ### [0.31.2] - 2026-08-27
 
 #### Added

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.31.2
+    version: 0.31.3
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.1',
-  'switch-console': '0.31.2',
+  'switch-console': '0.31.3',
   'agent-runtime': '0.3.4',
   sidecar: '1.9.6',
   gateway: '0.21.1',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,7 +21,7 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.21.1',
-  'switch-console': '0.31.2',
+  'switch-console': '0.31.3',
   'agent-runtime': '0.3.4',
   sidecar: '1.9.6',
   gateway: '0.21.1',

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,7 +21,7 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.21.1",
-    "switch-console": "0.31.2",
+    "switch-console": "0.31.3",
     "agent-runtime": "0.3.4",
     "sidecar": "1.9.6",
     "gateway": "0.21.1",


### PR DESCRIPTION
Cuts **Switch Console 0.31.3**.

## What's Changed
- The disabled "Add agent" button now explains why on hover (#314)
- Bundles agent-runtime 0.3.4, connectors (Claude Code 0.9.11, Codex 0.3.12, OpenCode 0.1.7) and sidecar 1.9.6

Bumps `package.json` + `artifacts.yaml` (0.31.2 → 0.31.3), regenerates modules, cuts the CHANGELOG. `pins.switch-core` left at 0.21.0 deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)