### PR TITLE
fix(sidecar): reap dead tmux targets

### DIFF
--- a/console/apps/switch-console-desktop/src/sidecar/index.ts
+++ b/console/apps/switch-console-desktop/src/sidecar/index.ts
@@ -413,6 +413,20 @@ async function main(): Promise<void> {
       })
     );
     for (const t of [...liveTargets]) if (!targets.has(t)) liveTargets.delete(t);
+
+    // A dead pane is terminal for the runtime connection. Reap it now rather
+    // than leaving RoomConnection's no-target retry loop and the durable
+    // session registry alive indefinitely. The watcher guard is released so a
+    // later notification can auto-start a replacement for the room.
+    for (const { sessionId, roomId } of runtime.reapDeadSessions()) {
+      spawner?.drop(sessionId);
+      if (roomId) watcher?.clearRoom(roomId);
+      log.error('sidecar: reaped session after its tmux target died', {
+        event: 'switch_session_reaped_dead_target',
+        sessionId,
+        roomId,
+      });
+    }
   };
   const refresh = async (): Promise<void> => {
     await Promise.all([refreshLiveness(), refreshWatchEnabled(), refreshLaunchSpec()]);

--- a/console/apps/switch-console-desktop/src/sidecar/sidecar-runtime.test.ts
+++ b/console/apps/switch-console-desktop/src/sidecar/sidecar-runtime.test.ts
@@ -10,6 +10,7 @@ import {
   SidecarRuntime,
 } from './sidecar-runtime';
 import type { SidecarSessionEntry } from './sidecar-state';
+import { makeAgentTmuxSessionName } from './vm-tmux';
 
 // Use the generic parser so raw 'start'/'stop' map to status deterministically,
 // independent of any provider's custom hook parser.
@@ -378,6 +379,70 @@ describe('SidecarRuntime (multi-session)', () => {
 
     expect(created[0].conn.stop).not.toHaveBeenCalled();
     expect(runtime.connectedSessions()).toHaveLength(1);
+  });
+
+  it('reaps dead panes, stops their retrying connection, and forgets their room', async () => {
+    const created: Array<{ deps: RoomConnectionDeps; conn: ManagedConnection }> = [];
+    const factory: RoomConnectionFactory = (deps) => {
+      const conn = fakeConnection();
+      created.push({ deps, conn });
+      return conn;
+    };
+    let paneLive = true;
+    const registry = fakeRegistry();
+    const startupWatch = makeStartupWatch();
+    const runtime = new SidecarRuntime({
+      creds: { agentId: 'agent-1', apiEndpoint: 'https://switch.test', token: 'tok' },
+      deeplinkScheme: 'switchdash',
+      tmuxRun: vi.fn(),
+      isPaneLive: () => paneLive,
+      log: silentLog,
+      createConnection: factory,
+      registry,
+      startupWatch,
+    });
+    await runtime.handleHook(switchRoomHook('room-1', PTY_A));
+    startupWatch.begin({ ptyId: PTY_A, sessionId: 'session-a', providerId: 'codex' });
+    expect(startupWatch.blocksInjection(PTY_A)).toBe(true);
+    expect(registry.has('session-a')).toBe(true);
+
+    paneLive = false;
+    expect(runtime.reapDeadSessions()).toEqual([{ sessionId: 'session-a', roomId: 'room-1' }]);
+    expect(created[0].conn.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.activeTmuxTargets()).toEqual([]);
+    expect(runtime.hasLiveRoom('room-1')).toBe(false);
+    expect(registry.has('session-a')).toBe(false);
+    expect(startupWatch.blocksInjection(PTY_A)).toBe(false);
+  });
+
+  it('does not reap a live pane or another session when one pane dies', async () => {
+    const live = new Set(['session-a']);
+    const created: Array<{ deps: RoomConnectionDeps; conn: ManagedConnection }> = [];
+    const factory: RoomConnectionFactory = (deps) => {
+      const conn = fakeConnection();
+      created.push({ deps, conn });
+      return conn;
+    };
+    const runtime = new SidecarRuntime({
+      creds: { agentId: 'agent-1', apiEndpoint: 'https://switch.test', token: 'tok' },
+      deeplinkScheme: 'switchdash',
+      tmuxRun: vi.fn(),
+      isPaneLive: (target) =>
+        [...live].some((sessionId) => target === makeAgentTmuxSessionName(sessionId)),
+      log: silentLog,
+      createConnection: factory,
+      registry: fakeRegistry(),
+      startupWatch: makeStartupWatch(),
+    });
+    await runtime.handleHook(switchRoomHook('room-1', PTY_A));
+    await runtime.handleHook(switchRoomHook('room-2', PTY_B));
+
+    live.clear();
+    live.add('session-b');
+    expect(runtime.reapDeadSessions()).toEqual([{ sessionId: 'session-a', roomId: 'room-1' }]);
+    expect(created[0].conn.stop).toHaveBeenCalledTimes(1);
+    expect(created[1].conn.stop).not.toHaveBeenCalled();
+    expect(runtime.connectedSessions()).toEqual([{ sessionId: 'session-b', roomId: 'room-2' }]);
   });
 });
 

--- a/console/apps/switch-console-desktop/src/sidecar/sidecar-runtime.ts
+++ b/console/apps/switch-console-desktop/src/sidecar/sidecar-runtime.ts
@@ -76,6 +76,7 @@ export interface SessionRegistry {
 
 interface SessionConnection {
   connection: ManagedConnection;
+  ptyId: string | null;
   /** Null while the session holds no room — the server has not named one yet,
    * or it named one and then took it away. `connectRoom` branches on this. */
   roomId: string | null;
@@ -262,6 +263,16 @@ export class SidecarRuntime {
     startCursor?: number
   ): string {
     const tmuxTarget = makeAgentTmuxSessionName(sessionId);
+    // A connection can be opened from persisted or test data before the
+    // provider has been validated. Only a known provider can have a startup
+    // watch; preserve the connection path for unknown values instead of
+    // making liveness cleanup introduce a new validation failure.
+    let ptyId: string | null = null;
+    try {
+      ptyId = makePtyId(asPtyProviderId(providerId), sessionId);
+    } catch {
+      // The provider-specific injector remains the authority for that input.
+    }
     // Derived, not random: the session's pane outlives this process and keeps
     // stamping the id it was launched with, so a restarted sidecar has to
     // recompute that id rather than mint one the agent will never hear about.
@@ -283,7 +294,7 @@ export class SidecarRuntime {
         this.deps.tmuxRun,
         () =>
           this.deps.isPaneLive(tmuxTarget) &&
-          !this.deps.startupWatch.blocksInjection(makePtyId(asPtyProviderId(providerId), sessionId))
+          (ptyId === null || !this.deps.startupWatch.blocksInjection(ptyId))
       ),
       injector: new PluginPromptInjector(providerId),
       control: resolveSessionControl(providerId),
@@ -315,7 +326,7 @@ export class SidecarRuntime {
       },
       log: this.deps.log,
     });
-    this.sessions.set(sessionId, { connection, roomId, lostRoom: false, tmuxTarget });
+    this.sessions.set(sessionId, { connection, ptyId, roomId, lostRoom: false, tmuxTarget });
     if (roomId) this.deps.registry.record({ sessionId, roomId, providerId, tmuxTarget });
     // The other end of the watcher's hand-off. If a spawned session comes up
     // without the message that triggered it, this says whether a cursor was
@@ -377,9 +388,29 @@ export class SidecarRuntime {
     const session = this.sessions.get(sessionId);
     if (!session) return;
     session.connection.stop();
+    if (session.ptyId) this.deps.startupWatch.end(session.ptyId);
     this.sessions.delete(sessionId);
     this.deps.registry.forget(sessionId);
     this.deps.log.debug('SidecarRuntime: session stopped', { sessionId });
+  }
+
+  /**
+   * Reap connections whose tmux pane disappeared since the last liveness poll.
+   *
+   * A dead pane must not remain in this map: RoomConnection would otherwise
+   * keep its no-target retry timer alive forever, and the durable registry plus
+   * watcher would continue to say that the room has a session. Return the
+   * rooms before stopSession forgets the connection so the entrypoint can
+   * release its corresponding spawn guard as well.
+   */
+  reapDeadSessions(): Array<{ sessionId: string; roomId: string | null }> {
+    const dead: Array<{ sessionId: string; roomId: string | null }> = [];
+    for (const [sessionId, session] of this.sessions) {
+      if (this.deps.isPaneLive(session.tmuxTarget)) continue;
+      dead.push({ sessionId, roomId: session.roomId });
+      this.stopSession(sessionId);
+    }
+    return dead;
   }
 
   /** Agent tmux targets the runtime is currently injecting into (for pane-liveness polling). */
@@ -421,7 +452,10 @@ export class SidecarRuntime {
   }
 
   stop(): void {
-    for (const session of this.sessions.values()) session.connection.stop();
+    for (const session of this.sessions.values()) {
+      session.connection.stop();
+      if (session.ptyId) this.deps.startupWatch.end(session.ptyId);
+    }
     this.sessions.clear();
   }
 }


### PR DESCRIPTION
Fixes #321

The sidecar liveness poll now reaps runtime sessions as soon as their tmux target disappears. Reaping uses the existing stopSession lifecycle, which stops the RoomConnection no-target retry loop, clears startup-watch state, removes the durable registry entry, and releases the spawner and notification-watcher room guards so a later notification can auto-start a replacement.

Added regression coverage for dead-pane cleanup and for preserving unrelated live sessions.

Validation:
- pnpm run build:sidecar
- pnpm vitest run --project node src/sidecar/sidecar-runtime.test.ts src/main/core/switch-rooms/room-connection.test.ts (86 passed)
- pnpm exec tsgo --noEmit
- changed-file oxfmt and oxlint
- Full node/main-db run is environment-blocked by incomplete Electron/better-sqlite3 installation and existing Windows/POSIX assumptions (2444 passed, 53 failed, 56 suites blocked).