### PR TITLE
fix(discord): create room on /invite-agent as first message

### DIFF
--- a/core/switch_core/bridges/collaboration/bridge_core.py
+++ b/core/switch_core/bridges/collaboration/bridge_core.py
@@ -590,8 +590,19 @@ class BridgeCore:
     async def _handle_inbound_command(self, cmd: InboundCommand) -> None:
         room_ids = self._channel_to_room.get(cmd.channel_id)
         if room_ids is None:
-            logger.error("No room mapping for channel %s", cmd.channel_id)
-            return
+            lock = self._channel_locks.setdefault(cmd.channel_id, asyncio.Lock())
+            async with lock:
+                room_ids = self._channel_to_room.get(cmd.channel_id)
+                if room_ids is None:
+                    room_ids = await self._create_room_for_channel(
+                        channel_id=cmd.channel_id,
+                        channel_type=cmd.channel_type,
+                        agent_name=cmd.agent_name,
+                        sender_name=cmd.sender_name,
+                        channel_name=cmd.channel_name,
+                    )
+            if room_ids is None:
+                return
         room_id, matrix_room_id = room_ids
 
         puppet = await self._ensure_user_in_matrix_room(


### PR DESCRIPTION
## Summary
- `_handle_inbound_command` in `bridge_core.py` silently dropped commands when no room mapping existed for the channel — it logged an error and returned.
- Add the same lazy room-provisioning path that `_handle_inbound_message` already uses: acquire the per-channel lock and call `_create_room_for_channel` before proceeding.
- This fixes `/invite-agent` (and `!invite-agent`) doing nothing when sent as the first interaction in a new Discord channel.

## Test plan
- [ ] Create a new Discord channel where the bot has visibility
- [ ] Run `/invite-agent` as the very first message — verify the Switch room is created and the agent is invited
- [ ] Verify existing channels with rooms still work normally
- [ ] Verify `!invite-agent` as first message also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)