### PR TITLE
feat(console): let a new agent be given a display name

### DIFF
--- a/console/apps/switch-console-desktop/src/main/core/agents/add-agent.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/agents/add-agent.test.ts
@@ -100,6 +100,7 @@ function params(overrides: Record<string, unknown> = {}) {
     providerId: 'codex' as const,
     serverId: 'srv-1',
     description: 'Codex running in repo',
+    displayName: null,
     iconUrl: null,
     autoSession: false,
     autoApprove: false,

--- a/console/apps/switch-console-desktop/src/main/core/agents/add-agent.ts
+++ b/console/apps/switch-console-desktop/src/main/core/agents/add-agent.ts
@@ -43,6 +43,9 @@ export type AddAgentParams = {
   /** The registered Switch server to mint the identity on. */
   serverId: string;
   description: string;
+  /** The human label chat platforms render the agent under. Null means it is
+   * shown under `name` instead — `name` stays the routing key either way. */
+  displayName: string | null;
   /** The icon picked in the create form. Null means the form offered no
    * choice, and the agent is registered with the avatar its name generates. */
   iconUrl: string | null;
@@ -182,6 +185,7 @@ async function runAddAgent(params: AddAgentParams): Promise<AddAgentResult> {
   const registered = await registerAgentIdentity(server, {
     name: params.name,
     description: params.description,
+    displayName: params.displayName,
     repoDir: params.dir,
     autoSession: params.autoSession,
     agentType: knownAgentTypeForProvider(params.providerId),

--- a/console/apps/switch-console-desktop/src/main/core/agents/onboard-location-agents.ts
+++ b/console/apps/switch-console-desktop/src/main/core/agents/onboard-location-agents.ts
@@ -135,6 +135,8 @@ async function resolveIdentity(
     // Nobody is at a form to choose one, so it starts with the avatar its name
     // generates — the same picture it would be shown with anyway.
     iconUrl: agentAvatarUrlForName(name),
+    // The definition file carries no human label, so there is none to adopt.
+    displayName: null,
   });
   if (registered.kind !== 'created') {
     const message = 'message' in registered ? registered.message : '';

--- a/console/apps/switch-console-desktop/src/main/core/agents/register-agent-identity.ts
+++ b/console/apps/switch-console-desktop/src/main/core/agents/register-agent-identity.ts
@@ -15,6 +15,10 @@ export type RegisterAgentInput = {
   /** The icon chosen in the create form, or null for none. Required so a new
    * create flow has to say which it means. */
   iconUrl: string | null;
+  /** The human label the agent is rendered under on chat platforms, or null to
+   * be shown under `name`. Required for the same reason as `iconUrl`: a flow
+   * that has a label to pass must not lose it by omission. */
+  displayName: string | null;
 };
 
 /**
@@ -41,6 +45,7 @@ export async function registerAgentIdentity(
       description: input.description,
       agentType: input.agentType,
       iconUrl: input.iconUrl,
+      displayName: input.displayName,
       options: {
         channels_enabled: true,
         repo_dir: input.repoDir,
@@ -53,7 +58,7 @@ export async function registerAgentIdentity(
       if (cause.kind === 'unauthorized') return { kind: 'unauthenticated' };
       if (cause.kind === 'http' && cause.status === 409) return { kind: 'name-conflict' };
       if (cause.kind === 'http' && cause.status === 400) {
-        return { kind: 'invalid-name', message: cause.message };
+        return { kind: 'invalid-name', message: cause.detail ?? cause.message };
       }
       return { kind: 'error', message: cause.message };
     }

--- a/console/apps/switch-console-desktop/src/main/core/switch-servers/backfill-agent-icons.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/switch-servers/backfill-agent-icons.test.ts
@@ -43,6 +43,7 @@ function agent(overrides: Partial<RemoteAgentSummary>): RemoteAgentSummary {
     knownAgentType: 'claude-code',
     addressingPolicy: null,
     iconUrl: null,
+    displayName: null,
     createdAt: '2026-01-01T00:00:00Z',
     ...overrides,
   };

--- a/console/apps/switch-console-desktop/src/main/core/switch-servers/controller.ts
+++ b/console/apps/switch-console-desktop/src/main/core/switch-servers/controller.ts
@@ -769,6 +769,8 @@ export const switchServersController = createRPCController({
       repoDir: params.dir,
       autoSession: params.autoSession,
       iconUrl: agentAvatarUrlForName(params.name),
+      // This flow asks for a name and nothing else, so there is no label to send.
+      displayName: null,
       // Provisioning writes `.claude/settings.local.json` — this is the Claude
       // Code path by construction, not a fallback.
       agentType: knownAgentTypeForProvider('claude'),
@@ -825,6 +827,8 @@ export const switchServersController = createRPCController({
       repoDir: params.remoteRepoDir,
       autoSession: params.autoSession,
       iconUrl: agentAvatarUrlForName(params.name),
+      // As locally: a name is all this flow collects.
+      displayName: null,
       // Remote provisioning likewise writes `.claude/settings.local.json`.
       agentType: knownAgentTypeForProvider('claude'),
     });

--- a/console/apps/switch-console-desktop/src/main/core/switch-servers/gateway-client.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/switch-servers/gateway-client.test.ts
@@ -505,6 +505,7 @@ describe('registerKnownAgent', () => {
       agentType: 'codex',
       options: { channels_enabled: true, repo_dir: '/repo' },
       iconUrl: null,
+      displayName: null,
     });
 
     expect(registered).toEqual({ id: 'sw-1', apiKey: 'tok-123' });
@@ -515,7 +516,28 @@ describe('registerKnownAgent', () => {
       description: 'Codex running in repo',
       options: { channels_enabled: true, repo_dir: '/repo' },
       icon_url: null,
+      display_name: null,
       overwrite: false,
+    });
+  });
+
+  it('sends the human display name alongside the identifier', async () => {
+    // The two are different strings on purpose: `name` routes, `display_name`
+    // is what a chat platform renders. Dropping the label here would leave the
+    // create form's field with nowhere to land.
+    await registerKnownAgent(SERVER, {
+      name: 'switch-dev',
+      description: 'Codex running in repo',
+      agentType: 'codex',
+      options: { channels_enabled: true, repo_dir: '/repo' },
+      iconUrl: null,
+      displayName: 'Switch Dev',
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, { body: string }];
+    expect(JSON.parse(init.body)).toMatchObject({
+      name: 'switch-dev',
+      display_name: 'Switch Dev',
     });
   });
 });

--- a/console/apps/switch-console-desktop/src/main/core/switch-servers/gateway-client.ts
+++ b/console/apps/switch-console-desktop/src/main/core/switch-servers/gateway-client.ts
@@ -317,6 +317,11 @@ export async function registerKnownAgent(
      * one. Required rather than optional so a create flow states which it
      * means instead of dropping the user's choice by forgetting the field. */
     iconUrl: string | null;
+    /** The label chat platforms render the agent under, or null to leave it
+     * unset and be shown under `name`. Required rather than optional for the
+     * same reason as `iconUrl`: the create form holds a label the user typed,
+     * and an omitted field would drop it without saying so. */
+    displayName: string | null;
   }
 ): Promise<RegisteredAgent> {
   const res = await gatewayFetch(server, '/agents/register', {
@@ -328,6 +333,7 @@ export async function registerKnownAgent(
       description: params.description,
       options: params.options,
       icon_url: params.iconUrl,
+      display_name: params.displayName,
       overwrite: false,
     },
   });
@@ -348,6 +354,7 @@ type AgentSummaryJson = {
   known_agent_type: string | null;
   addressing_policy?: AddressingPolicy | null;
   icon_url?: string | null;
+  display_name?: string | null;
   created_at: string;
 };
 
@@ -365,6 +372,7 @@ function toRemoteAgentSummary(json: AgentSummaryJson): RemoteAgentSummary {
     knownAgentType: json.known_agent_type,
     addressingPolicy: json.addressing_policy ?? null,
     iconUrl: json.icon_url ?? null,
+    displayName: json.display_name ?? null,
     createdAt: json.created_at,
   };
 }

--- a/console/apps/switch-console-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/locations/components/add-agent-modal/add-agent-modal.tsx
@@ -295,7 +295,7 @@ export const AddAgentModal = observer(function AddAgentModal({
     }
     if (result.kind === 'invalid-name') {
       toast({
-        title: 'That agent name cannot be used',
+        title: 'Switch rejected these agent details',
         description: result.message,
         variant: 'destructive',
       });
@@ -325,6 +325,7 @@ export const AddAgentModal = observer(function AddAgentModal({
         providerId: pickState.providerId,
         serverId: pickState.serverId,
         description: form.description.trim(),
+        displayName: form.displayName.trim() || null,
         instructions: form.instructions,
         iconUrl: form.iconUrl,
         autoSession: form.autoSession,

--- a/console/apps/switch-console-desktop/src/renderer/features/locations/components/add-agent-modal/configure-agent-panel.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/locations/components/add-agent-modal/configure-agent-panel.tsx
@@ -234,6 +234,7 @@ export const AgentSettingsSection = observer(function AgentSettingsSection({
  */
 export function AgentIdentityFields({ form }: { form: ConfigureAgentFormState }) {
   const nameId = useId();
+  const displayNameId = useId();
   const descriptionId = useId();
   const instructionsId = useId();
   const nameRef = useRef<HTMLInputElement>(null);
@@ -284,7 +285,7 @@ export function AgentIdentityFields({ form }: { form: ConfigureAgentFormState })
                   // button; without moving focus first it falls to the body and
                   // the tab order restarts.
                   onClick={() => {
-                    form.setAgentName(form.suggestedName);
+                    form.acceptSuggestedName();
                     nameRef.current?.focus();
                   }}
                 >
@@ -307,6 +308,22 @@ export function AgentIdentityFields({ form }: { form: ConfigureAgentFormState })
             agent it is.
           </span>
         )}
+      </Field>
+
+      <Field>
+        <FieldLabel htmlFor={displayNameId}>
+          Display name <span className="text-foreground-muted">(optional)</span>
+        </FieldLabel>
+        <Input
+          id={displayNameId}
+          placeholder={form.agentName.length > 0 ? form.agentName : 'How to show this agent'}
+          value={form.displayName}
+          onChange={(e) => form.setDisplayName(e.target.value)}
+        />
+        <span className="text-xs text-foreground-muted">
+          The name this agent is shown under on Slack, Discord and other chat platforms. Leave it
+          empty and it shows up under its identifier.
+        </span>
       </Field>
 
       <Field>

--- a/console/apps/switch-console-desktop/src/renderer/features/locations/components/add-agent-modal/modes.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/locations/components/add-agent-modal/modes.ts
@@ -41,6 +41,10 @@ export type PickModeState = ReturnType<typeof usePickMode>;
  */
 export function useConfigureAgentForm() {
   const [agentName, setAgentName] = useState('');
+  // The label chat platforms render the agent under. Optional: an agent with
+  // none is shown under its identifier.
+  const [displayName, setDisplayNameRaw] = useState('');
+  const [displayNameTouched, setDisplayNameTouched] = useState(false);
   const [description, setDescription] = useState('');
   // What the agent is for, in its own words (CHOO-2228). Optional: an agent
   // with none runs on its provider's defaults, and the description stands in
@@ -67,6 +71,11 @@ export function useConfigureAgentForm() {
     setAutoApproveTouched(true);
   }, []);
 
+  const setDisplayName = useCallback((value: string) => {
+    setDisplayNameRaw(value);
+    setDisplayNameTouched(true);
+  }, []);
+
   /**
    * What the run location implies, for as long as the user has not answered
    * themselves: an agent on a host is put there to run unattended, and a
@@ -89,12 +98,28 @@ export function useConfigureAgentForm() {
   const suggestedName = nameIsRejected ? slugifyAgentNamePart(agentName) : '';
   const isValid = nameIsValid && description.trim().length > 0;
 
+  /**
+   * Take the offered slug as the name, keeping the text it was slugged from as
+   * the display name. "Switch Dev" is both the label someone wants and the
+   * thing the charset rejects, so the slug must not be all that survives it.
+   * A display name the user wrote themselves is an answer, not a guess, and
+   * stands.
+   */
+  const acceptSuggestedName = useCallback(() => {
+    if (suggestedName === '') return;
+    if (!displayNameTouched) setDisplayNameRaw(agentName);
+    setAgentName(suggestedName);
+  }, [agentName, displayNameTouched, suggestedName]);
+
   return {
     agentName,
     setAgentName,
     nameIsValid,
     nameIsRejected,
     suggestedName,
+    acceptSuggestedName,
+    displayName,
+    setDisplayName,
     description,
     setDescription,
     instructions,

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/new-agent-display-name.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/new-agent-display-name.test.tsx
@@ -1,0 +1,211 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: { on: vi.fn() },
+  rpc: {
+    switchServers: {
+      listRemoteRooms: () => Promise.resolve([]),
+      listRemoteRoomGroups: () => Promise.resolve([]),
+      listRemoteExternalUsers: () => Promise.resolve([]),
+      listRemoteAgents: () => Promise.resolve([]),
+      listRemoteBridges: () => Promise.resolve([]),
+      listMyIdentities: () => Promise.resolve([]),
+    },
+  },
+}));
+/**
+ * What accepting the offered slug does to the text it was slugged from.
+ *
+ * The create form asks for one name and gets two things out of it: the
+ * identifier rooms route by, and the label a chat platform renders. Typing
+ * "Switch Dev" and accepting `switch-dev` used to overwrite the field, so the
+ * label the user had already written was gone before they could be asked for it.
+ */
+import { AgentIdentityFields } from '@renderer/features/locations/components/add-agent-modal/configure-agent-panel';
+import {
+  type ConfigureAgentFormState,
+  useConfigureAgentForm,
+} from '@renderer/features/locations/components/add-agent-modal/modes';
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+/** Mount the real hook and hand the caller its live state to drive. */
+async function mountForm(): Promise<() => ConfigureAgentFormState> {
+  let latest: ConfigureAgentFormState | null = null;
+  function Probe() {
+    latest = useConfigureAgentForm();
+    return null;
+  }
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  await act(async () =>
+    root!.render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    )
+  );
+  return () => {
+    if (latest === null) throw new Error('the form never rendered');
+    return latest;
+  };
+}
+
+describe('the display name on a new agent', () => {
+  it('starts empty', async () => {
+    const form = await mountForm();
+    expect(form().displayName).toBe('');
+  });
+
+  it('keeps the typed text as the display name when the slug is accepted', async () => {
+    const form = await mountForm();
+
+    await act(async () => form().setAgentName('Switch Dev'));
+    expect(form().suggestedName).toBe('switch-dev');
+
+    await act(async () => form().acceptSuggestedName());
+
+    expect(form().agentName).toBe('switch-dev');
+    expect(form().displayName).toBe('Switch Dev');
+  });
+
+  it('leaves a display name the user typed themselves alone', async () => {
+    const form = await mountForm();
+
+    await act(async () => form().setDisplayName('The Dev'));
+    await act(async () => form().setAgentName('Switch Dev'));
+    await act(async () => form().acceptSuggestedName());
+
+    expect(form().agentName).toBe('switch-dev');
+    expect(form().displayName).toBe('The Dev');
+  });
+
+  it('treats a display name the user cleared as an answer, not an absence', async () => {
+    // Emptying the field is a decision — "show this agent under its
+    // identifier" — so the slug must not read it as "never asked" and refill
+    // it. A falsy check on the value alone passes every other test here and
+    // fails this one.
+    const form = await mountForm();
+
+    await act(async () => form().setDisplayName('The Dev'));
+    await act(async () => form().setDisplayName(''));
+    await act(async () => form().setAgentName('Switch Dev'));
+    await act(async () => form().acceptSuggestedName());
+
+    expect(form().agentName).toBe('switch-dev');
+    expect(form().displayName).toBe('');
+  });
+
+  it('does nothing when there is no suggestion to accept', async () => {
+    const form = await mountForm();
+
+    await act(async () => form().setAgentName('switch-dev'));
+    expect(form().suggestedName).toBe('');
+
+    await act(async () => form().acceptSuggestedName());
+
+    expect(form().agentName).toBe('switch-dev');
+    expect(form().displayName).toBe('');
+  });
+});
+
+let domContainer: HTMLDivElement | null = null;
+let domRoot: Root | null = null;
+let domForm: ReturnType<typeof useConfigureAgentForm> | null = null;
+
+afterEach(async () => {
+  if (domRoot) await act(async () => domRoot!.unmount());
+  domContainer?.remove();
+  domContainer = null;
+  domRoot = null;
+  domForm = null;
+});
+
+function Fields() {
+  domForm = useConfigureAgentForm();
+  return <AgentIdentityFields form={domForm} />;
+}
+
+async function renderFields(): Promise<HTMLDivElement> {
+  domContainer = document.createElement('div');
+  document.body.appendChild(domContainer);
+  domRoot = createRoot(domContainer);
+  await act(async () => domRoot!.render(<Fields />));
+  return domContainer;
+}
+
+async function typeName(el: HTMLElement, value: string) {
+  const field = el.querySelector<HTMLInputElement>('input[placeholder="Name this agent"]');
+  expect(field, 'no Name input').not.toBeNull();
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+  await act(async () => {
+    setter.call(field!, value);
+    field!.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+async function typeDisplayName(el: HTMLElement, value: string) {
+  const label = [...el.querySelectorAll('label')].find((l) =>
+    /^Display name/.test(l.textContent ?? '')
+  );
+  expect(label, 'no Display name label').not.toBeUndefined();
+  const field = el.querySelector<HTMLInputElement>(`#${label!.htmlFor}`);
+  expect(field, 'no Display name input').not.toBeNull();
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+  await act(async () => {
+    setter.call(field!, value);
+    field!.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function suggestionButton(el: HTMLElement): HTMLButtonElement | undefined {
+  return [...el.querySelectorAll<HTMLButtonElement>('button')].find((b) =>
+    /^Use\b/.test(b.textContent?.trim() ?? '')
+  );
+}
+
+describe('the display name field in the DOM', () => {
+  it('renders an input labelled Display name', async () => {
+    const el = await renderFields();
+
+    const label = [...el.querySelectorAll('label')].find((l) =>
+      /^Display name/.test(l.textContent ?? '')
+    );
+    expect(label, 'no Display name label').not.toBeUndefined();
+    const field = el.querySelector<HTMLInputElement>(`#${label!.htmlFor}`);
+    expect(field, 'no Display name input').not.toBeNull();
+  });
+
+  it('updates form.displayName when typed into', async () => {
+    const el = await renderFields();
+
+    await typeDisplayName(el, 'The Dev');
+
+    expect(domForm?.displayName).toBe('The Dev');
+  });
+
+  it('shows the name in the Display name input after accepting the slug', async () => {
+    const el = await renderFields();
+    await typeName(el, 'Switch Dev');
+    await act(async () => suggestionButton(el)!.click());
+
+    const label = [...el.querySelectorAll('label')].find((l) =>
+      /^Display name/.test(l.textContent ?? '')
+    );
+    const field = el.querySelector<HTMLInputElement>(`#${label!.htmlFor}`);
+    expect(field?.value).toBe('Switch Dev');
+  });
+});

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/new-agent-name-suggestion.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/new-agent-name-suggestion.test.tsx
@@ -93,6 +93,7 @@ describe('a rejected agent name', () => {
 
     expect(form?.agentName).toBe('switch-dev');
     expect(form?.nameIsValid).toBe(true);
+    expect(form?.displayName).toBe('Switch Dev');
     expect(el.textContent).not.toContain(REJECTION);
     expect(suggestionButton(el)).toBeUndefined();
   });

--- a/console/apps/switch-console-desktop/src/renderer/tests/browser/palette-agent-icon.test.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/tests/browser/palette-agent-icon.test.tsx
@@ -62,6 +62,7 @@ function remoteAgent(iconUrl: string | null): RemoteAgentSummary {
     knownAgentType: 'claude-code',
     addressingPolicy: null,
     iconUrl,
+    displayName: null,
     createdAt: '2026-01-01T00:00:00.000Z',
   };
 }

--- a/console/apps/switch-console-desktop/src/shared/core/switch-servers/switch-servers.ts
+++ b/console/apps/switch-console-desktop/src/shared/core/switch-servers/switch-servers.ts
@@ -194,6 +194,10 @@ export type RemoteAgentSummary = {
    * name-derived avatar instead, so the fallback can change without every
    * agent needing rewriting. */
   iconUrl: string | null;
+  /** The human label chat platforms render the agent under, or null when it has
+   * none and is shown under `name`. Presentation only — `name` remains the key
+   * rooms, sessions and lookups are routed by. */
+  displayName: string | null;
   createdAt: string;
 };
 


### PR DESCRIPTION
Fourth and last piece of the display-name work: the setting itself. The
column landed in #326 and the bridges learned to render it in #330 and
#338 — until now nothing in the product could actually *set* it.

## What changes

The new-agent form gets an optional **Display name** field beside Name,
plumbed through the gateway client exactly the way `icon_url` already is:
nullable, presentation-only, never consulted for routing. `agents.name`
stays the lowercase identifier that rooms, sessions and the command
palette key off; `display_name` is only ever shown.

Two behaviours worth calling out, both covered by tests:

- **Accepting the slug offer keeps what you typed.** Type `Switch Dev`
  into Name, the charset rejects it, you click *Use switch-dev* — the
  identifier becomes `switch-dev` and `Switch Dev` moves into Display
  name. It is a perfectly good human name, just not a valid identifier,
  so it should not be thrown away.
- **A display name you wrote yourself is left alone** — including one you
  deliberately cleared. Emptying the field is the answer "show this agent
  under its identifier", not an absence to be filled in. This is the
  `autoApproveTouched` idiom already used elsewhere in the form; a falsy
  check on the value alone passes every other test and fails that one.

Also passes the gateway's own error `detail` through to the rejection
banner. `GatewayError.message` is prefixed with the raw status line,
which its own doc comment says "reads as noise in a form" — `detail` is
the sentence the server actually wrote.

## Base

This targets `main`, not #338. It is Console TypeScript and its real
prerequisites — the `display_name` column (#326) and the slug-suggestion
form (#325) — are both already merged. It shares no files with the bridge
PRs, so stacking it on them would only couple its CI to theirs.

## Verification

Format, lint and typecheck clean. Browser 178/178, node 2999/3000 (the
one failure is a pre-existing `/var` vs `/private/var` macOS path test in
`session-spawner.test.ts`, untouched here and green on Linux CI),
`connector-assets` 10/10.

The form was also recorded end-to-end driving the real
`AgentIdentityFields` component and `useConfigureAgentForm` hook, with
Playwright reading the resulting input values back off the page:
`switch-dev` / `Switch Dev`, then `switch-dev` / `Release Captain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)