### PR TITLE
feat(commands): render agents under their display name in room commands

### DIFF
--- a/core/switch_core/agent_display_name.py
+++ b/core/switch_core/agent_display_name.py
@@ -1,4 +1,4 @@
-"""Validation for an agent's human display name.
+"""Validating an agent's human display name, and writing it into a message.
 
 An agent's `name` is a machine identifier — lowercase, no spaces — because it
 is addressed, mentioned and matched on. A display name is the other half: the
@@ -6,9 +6,14 @@ label a person reads ("Switch Dev" beside "switchdev"), so uppercase, spaces
 and punctuation are exactly what it exists to allow.
 
 It is rendered into message headers on the collaboration bridges, which is what
-the rules below constrain: a newline or a control character in a header is a
-way to forge a line the platform never sent, and length has to fit the
+the validation rules constrain: a newline or a control character in a header is
+a way to forge a line the platform never sent, and length has to fit the
 narrowest consumer rather than the widest.
+
+Everything punctuation-shaped that survives validation is then the render
+helpers' problem — see `defuse_label_markup`. They live here, free of any
+bridge or database import, so the `!` command surface and the collaboration
+adapters can share one rule rather than each growing their own.
 """
 
 from typing import NoReturn
@@ -17,6 +22,8 @@ from typing import NoReturn
 # or above that. 64 is a safe intersection with room to spare, and short enough
 # that a display name stays a label rather than a sentence.
 MAX_DISPLAY_NAME_LENGTH = 64
+
+_ZERO_WIDTH_SPACE = "\u200b"
 
 
 class InvalidDisplayName(ValueError):
@@ -78,3 +85,62 @@ def normalise_display_name(value: str | None) -> str | None:
         return None
 
     return validate_display_name(value)
+
+
+def defuse_label_markup(label: str) -> str:
+    """Neutralise the markup a label can use to claim something it is not.
+
+    A display name is free text an agent's owner chooses, and it is inlined
+    into message bodies that reach chat platforms. Two constructs are near
+    universal there:
+
+    - `@…` addresses somebody. Whether the reader's platform resolves
+      `@channel`, `@here`, a person, or one of Switch's own agent handles on
+      the way out, an un-defused label gets to notify people the message was
+      never aimed at. A zero-width space after every `@` leaves the sigil
+      legible and the resolution dead.
+    - `[text](url)` renders an anchor whose destination the label chose and
+      whose visible text hides it. The zero-width space goes after the `]`,
+      breaking the `](` adjacency every Markdown dialect requires — after the
+      `[` it lands inside the visible text and the link still matches.
+
+    Defused rather than escaped, because the result has to survive as far as
+    whatever renders it: a backslash escape would have to match the dialect at
+    the far end, while a zero-width space is inert in every escaping pipeline
+    it may pass through afterwards, so it cannot compound with one.
+    """
+    return label.replace("@", "@" + _ZERO_WIDTH_SPACE).replace(
+        "]", "]" + _ZERO_WIDTH_SPACE
+    )
+
+
+def agent_label(display_name: str | None, name: str) -> str:
+    """How to write an agent where the text is pure attribution.
+
+    The display name when there is one, otherwise the identifier — defused
+    with `defuse_label_markup`, because the caller is putting it into a body
+    that nothing downstream escapes for it.
+
+    For text a reader also has to type or copy back, use
+    `agent_label_with_identifier`: this one can render a label that addresses
+    nothing.
+    """
+    return defuse_label_markup(display_name or name)
+
+
+def agent_label_with_identifier(display_name: str | None, name: str) -> str:
+    """How to write an agent where the reader both reads and copies the name.
+
+    ``Switch Dev (`switchdev`)`` — the defused display name, then the
+    identifier that actually routes, so a reader can act on the line as well as
+    read it. The identifier is in backticks because Discord and Slack resolve
+    no mention inside a code span: it stays copyable without becoming a live
+    ping of whoever happens to hold that handle on the platform.
+
+    An agent with no display name renders as the bare identifier; there is
+    nothing to disambiguate, and ``switchdev (`switchdev`)`` reads as noise.
+    """
+    if not display_name:
+        return name
+
+    return f"{defuse_label_markup(display_name)} (`{name}`)"

--- a/core/switch_core/bridges/agent/commands.py
+++ b/core/switch_core/bridges/agent/commands.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from nio import MatrixRoom
 
+from switch_core.agent_display_name import agent_label, agent_label_with_identifier
 from switch_core.aliases import (
     AliasError,
     check_alias_collisions,
@@ -445,7 +446,8 @@ async def _cmd_list_room_agents(
             agent = await client._agent_store.get(session, agent_id)
             if agent:
                 desc = f" — {agent.description}" if agent.description else ""
-                lines.append(f"- **{agent.name}**{desc}")
+                label = agent_label_with_identifier(agent.display_name, agent.name)
+                lines.append(f"- **{label}**{desc}")
 
     await _reply(client, room, event, "\n".join(lines))
 
@@ -469,11 +471,15 @@ async def _cmd_list_aliases(
         lines = ["**Aliases in this room:**"]
         for agent_id, alias in aliases.items():
             agent = await client._agent_store.get(session, agent_id)
-            name = agent.name if agent else agent_id
+            label = (
+                agent_label_with_identifier(agent.display_name, agent.name)
+                if agent
+                else agent_id
+            )
             # Render the alias WITHOUT a leading `@`: this text is posted as a
             # room message, and a live `@<alias>` would be re-parsed as a mention
             # and address the aliased agent.
-            lines.append(f"- `{alias}` → **{name}**")
+            lines.append(f"- `{alias}` → **{label}**")
 
     await _reply(client, room, event, "\n".join(lines))
 
@@ -544,7 +550,7 @@ async def _cmd_set_alias(
         client,
         room,
         event,
-        f"Alias set — address **{target.name}** as `{alias}` in this room.",
+        f"Alias set — address **{agent_label_with_identifier(target.display_name, target.name)}** as `{alias}` in this room.",
     )
 
 
@@ -639,7 +645,10 @@ async def _cmd_invite(
         room_agent_ids = await client._room_store.get_agent_ids(session, meta.room_id)
         if target.id in room_agent_ids:
             await _reply(
-                client, room, event, f"**{target.name}** is already in this room."
+                client,
+                room,
+                event,
+                f"**{agent_label_with_identifier(target.display_name, target.name)}** is already in this room.",
             )
             return
 
@@ -651,7 +660,12 @@ async def _cmd_invite(
     await cast("AdminClient", client)._room_service.add_agents_to_room(
         meta.room_id, agent_names=[target.name]
     )
-    await _reply(client, room, event, f"Added **{target.name}** to this room.")
+    await _reply(
+        client,
+        room,
+        event,
+        f"Added **{agent_label_with_identifier(target.display_name, target.name)}** to this room.",
+    )
 
 
 # Emoji + label shown per status by the !status command.
@@ -677,20 +691,22 @@ def _format_status_lines(
     runtime_states: dict[str, str],
     deeplinks: dict[str, str],
 ) -> str:
-    """Render the !status summary: one line per agent (sorted by name) with
-    its presence emoji + label, runtime state (if any), agent_type, task
-    capabilities, and a Switch Console deeplink to its session when one is known.
+    """Render the !status summary: one line per agent (sorted by the name it is
+    shown under) with its presence emoji + label, runtime state (if any),
+    agent_type, task capabilities, and a Switch Console deeplink to its session
+    when one is known.
 
     The deeplink is shown only for an agent whose session is LIVE in this room:
     the stored link is per (agent, room) and survives a room switch, so once the
     session moves away it would point at a session no longer here. Gating on
     LIVE keeps the link from going stale when an agent hops rooms."""
     lines = ["**Agent status in this room:**"]
-    for agent in sorted(agents, key=lambda a: a.name):
+    for agent in sorted(agents, key=lambda a: (a.display_name or a.name).lower()):
         status = statuses.get(agent.id, AgentStatus.NO_SESSION)
         emoji, label = _STATUS_DISPLAY.get(status, ("", status.value))
         runtime = _RUNTIME_STATE_DISPLAY.get(runtime_states.get(agent.id, ""))
-        head = f"{emoji} **{agent.name}** — {label}"
+        name = agent_label_with_identifier(agent.display_name, agent.name)
+        head = f"{emoji} **{name}** — {label}"
         if runtime is not None:
             head += f" · {runtime}"
         parts = [head, agent.agent_type]
@@ -774,7 +790,7 @@ async def _cmd_roles(
         for holder_id in {h for ids in holders.values() for h in ids}:
             holder = await client._agent_store.get(session, holder_id)
             if holder is not None:
-                holder_names[holder_id] = holder.name
+                holder_names[holder_id] = agent_label(holder.display_name, holder.name)
 
     lines = ["**Roles in this room:**"]
     for role in roles:
@@ -818,7 +834,9 @@ async def _cmd_list_documents(
             if d.created_by_agent_id:
                 agent = await client._agent_store.get(session, d.created_by_agent_id)
                 if agent:
-                    creator = f" — created by {agent.name}"
+                    creator = (
+                        f" — created by {agent_label(agent.display_name, agent.name)}"
+                    )
             desc = f" — {d.description}" if d.description else ""
             if client._frontend_base_url is None:
                 name_md = f"**{d.name}**"
@@ -912,7 +930,8 @@ async def _cmd_list_all_agents(
     lines = ["**Available agents:**"]
     for agent in agents:
         desc = f" — {agent.description}" if agent.description else ""
-        lines.append(f"- **{agent.name}**{desc}")
+        label = agent_label_with_identifier(agent.display_name, agent.name)
+        lines.append(f"- **{label}**{desc}")
     await _reply(client, room, event, "\n".join(lines))
 
 
@@ -993,11 +1012,14 @@ async def _cmd_agents_greet(
     event: CommandEvent,
     is_direct: bool,
 ) -> None:
-    name = client.agent.name
+    agent = await client._fresh_agent()
     if is_direct:
-        await _reply(client, room, event, f"Hi! I'm {name} — how can I help?")
+        label = agent_label(agent.display_name, agent.name)
+        await _reply(client, room, event, f"Hi! I'm {label} — how can I help?")
     else:
-        greeting = random.choice(AGENT_GREETINGS).format(name=name)
+        # `@{name}` here is a live mention handle the reader tags back, so it
+        # stays the identifier whatever the agent is displayed as.
+        greeting = random.choice(AGENT_GREETINGS).format(name=agent.name)
         await _reply(client, room, event, greeting)
 
 

--- a/core/switch_core/bridges/collaboration/adapter.py
+++ b/core/switch_core/bridges/collaboration/adapter.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from typing import ClassVar
 
+from switch_core.agent_display_name import defuse_label_markup
 from switch_core.agent_icon import default_icon_url
 from switch_core.bridges.collaboration.models import (
     BridgeInstallLink,
@@ -22,8 +23,6 @@ from switch_core.bridges.collaboration.models import (
 )
 
 logger = logging.getLogger(__name__)
-
-_ZERO_WIDTH_SPACE = "\u200b"
 
 
 def format_elapsed(seconds: float) -> str:
@@ -917,9 +916,7 @@ class CollaborationAdapter(ABC):
         unbalance the run around it. That is cosmetic, and the line held here
         is that forged markup is closed while broken formatting is not worth
         an escape that would show up in every ordinary name."""
-        return label.replace("@", "@" + _ZERO_WIDTH_SPACE).replace(
-            "]", "]" + _ZERO_WIDTH_SPACE
-        )
+        return defuse_label_markup(label)
 
     async def agent_rendering(self, agent_name: str) -> AgentRendering:
         """Everything a send needs to present an agent, from ONE lookup.

--- a/core/switch_core/clients/admin_client.py
+++ b/core/switch_core/clients/admin_client.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from nio import MatrixRoom, RoomMessage, RoomMessageText
 
+from switch_core.agent_display_name import agent_label_with_identifier
 from switch_core.bridges.agent.commands import dispatch_admin_command
 from switch_core.bridges.agent.protocol.connections import ConnectionRegistry
 from switch_core.clients.admin_messages import (
@@ -201,10 +202,12 @@ class AdminClient(ClientBase[ClientConfig]):
                 agent = await self._agent_store.get_by_name_insensitive(session, token)
                 if agent is None or agent.id in member_ids:
                     continue
-                absent.append(agent.name)
+                absent.append(
+                    agent_label_with_identifier(agent.display_name, agent.name)
+                )
         if not absent:
             return
-        names = ", ".join(f"**{name}**" for name in absent)
+        names = ", ".join(f"**{label}**" for label in absent)
         verb = "isn't" if len(absent) == 1 else "aren't"
         pronoun = "it" if len(absent) == 1 else "them"
         handle = self._sender_handle(event)

--- a/core/tests/switch_core/bridges/agent/test_commands_aliases.py
+++ b/core/tests/switch_core/bridges/agent/test_commands_aliases.py
@@ -78,9 +78,15 @@ def _event(args: str) -> SimpleNamespace:
     return SimpleNamespace(command="set-alias", args=args, thread_id=None)
 
 
+def _agent(
+    agent_id: str, name: str, display_name: str | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(id=agent_id, name=name, display_name=display_name)
+
+
 _AGENTS = {
-    "a1": SimpleNamespace(id="a1", name="claude-code.alice"),
-    "a2": SimpleNamespace(id="a2", name="moderator"),
+    "a1": _agent("a1", "claude-code.alice"),
+    "a2": _agent("a2", "moderator"),
 }
 
 
@@ -118,6 +124,85 @@ class TestListAliasesCommand:
         await _cmd_list_aliases(client, _Room(room_id="!m:x"), _event(""), False)
         assert "boss" in posted[0]
         assert _MENTION.search(posted[0]) is None
+
+
+class TestAliasCommandsRenderDisplayNames:
+    async def test_set_alias_names_the_agent_and_keeps_its_identifier(self) -> None:
+        agents = {"a1": _agent("a1", "switchdev", "Switch Dev")}
+        client, posted = _build_client(agents=agents, aliases={}, role_names=[])
+        await _cmd_set_alias(
+            client, _Room(room_id="!m:x"), _event("@switchdev @boss"), False
+        )
+        assert "Switch Dev (`switchdev`)" in posted[0]
+
+    async def test_set_alias_without_a_display_name_names_it_once(self) -> None:
+        client, posted = _build_client(agents=_AGENTS, aliases={}, role_names=[])
+        await _cmd_set_alias(
+            client, _Room(room_id="!m:x"), _event("@claude-code.alice @boss"), False
+        )
+        assert "**claude-code.alice**" in posted[0]
+        assert "(`claude-code.alice`)" not in posted[0]
+
+    async def test_set_alias_display_name_cannot_ping_the_channel(self) -> None:
+        agents = {"a1": _agent("a1", "switchdev", "@everyone")}
+        client, posted = _build_client(agents=agents, aliases={}, role_names=[])
+        await _cmd_set_alias(
+            client, _Room(room_id="!m:x"), _event("@switchdev @boss"), False
+        )
+        assert _MENTION.search(posted[0]) is None
+        assert "switchdev" in posted[0]
+
+    async def test_set_alias_display_name_cannot_forge_a_link(self) -> None:
+        agents = {"a1": _agent("a1", "switchdev", "[here](https://example.invalid)")}
+        client, posted = _build_client(agents=agents, aliases={}, role_names=[])
+        await _cmd_set_alias(
+            client, _Room(room_id="!m:x"), _event("@switchdev @boss"), False
+        )
+        assert "](https://example.invalid)" not in posted[0]
+
+    async def test_set_alias_echoes_a_mistyped_token_verbatim(self) -> None:
+        # The user typed the identifier, so the "no such agent" line has to
+        # quote what they typed — not some other agent's display name.
+        agents = {"a1": _agent("a1", "switchdev", "Switch Dev")}
+        client, posted = _build_client(agents=agents, aliases={}, role_names=[])
+        await _cmd_set_alias(
+            client, _Room(room_id="!m:x"), _event("@switchdevv @boss"), False
+        )
+        assert "No agent named `switchdevv`" in posted[0]
+        assert "Switch Dev" not in posted[0]
+
+    async def test_list_aliases_names_the_agent_and_keeps_its_identifier(self) -> None:
+        agents = {"a1": _agent("a1", "switchdev", "Switch Dev")}
+        client, posted = _build_client(
+            agents=agents, aliases={"a1": "boss"}, role_names=[]
+        )
+        await _cmd_list_aliases(client, _Room(room_id="!m:x"), _event(""), False)
+        # The alias itself stays bare and typeable; the agent gets its label.
+        assert "- `boss` → **Switch Dev (`switchdev`)**" in posted[0]
+
+    async def test_list_aliases_without_a_display_name_names_it_once(self) -> None:
+        client, posted = _build_client(
+            agents=_AGENTS, aliases={"a1": "boss"}, role_names=[]
+        )
+        await _cmd_list_aliases(client, _Room(room_id="!m:x"), _event(""), False)
+        assert "- `boss` → **claude-code.alice**" in posted[0]
+
+    async def test_list_aliases_display_name_cannot_ping_the_channel(self) -> None:
+        agents = {"a1": _agent("a1", "switchdev", "@everyone")}
+        client, posted = _build_client(
+            agents=agents, aliases={"a1": "boss"}, role_names=[]
+        )
+        await _cmd_list_aliases(client, _Room(room_id="!m:x"), _event(""), False)
+        assert _MENTION.search(posted[0]) is None
+        assert "switchdev" in posted[0]
+
+    async def test_list_aliases_display_name_cannot_forge_a_link(self) -> None:
+        agents = {"a1": _agent("a1", "switchdev", "[here](https://example.invalid)")}
+        client, posted = _build_client(
+            agents=agents, aliases={"a1": "boss"}, role_names=[]
+        )
+        await _cmd_list_aliases(client, _Room(room_id="!m:x"), _event(""), False)
+        assert "](https://example.invalid)" not in posted[0]
 
 
 class TestAliasCommandRegistration:

--- a/core/tests/switch_core/bridges/agent/test_commands_display_names.py
+++ b/core/tests/switch_core/bridges/agent/test_commands_display_names.py
@@ -1,0 +1,307 @@
+"""The `!` command surface renders agents under their display name.
+
+An agent's `name` routes; its `display_name` is what a person reads. These
+commands print both, one or the other, depending on whether the reader has to
+type the name back — and every one of them has to defuse the label first. A
+command reply is built here and handed straight to the bridge, which escapes
+nothing on the way out but *does* turn a plain `@handle` into a real mention,
+so a display name of `@everyone` would otherwise become a mass ping.
+"""
+
+from __future__ import annotations
+
+import re
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+from switch_core.bridges.agent.commands import (
+    _cmd_agents_greet,
+    _cmd_list_all_agents,
+    _cmd_list_documents,
+    _cmd_list_room_agents,
+    _cmd_roles,
+)
+
+# Matches a live `@<handle>` mention token (same char class Switch re-parses).
+_MENTION = re.compile(r"@[A-Za-z0-9._-]+")
+
+_FORGED_LINK = "[here](https://example.invalid)"
+
+
+class _Room(SimpleNamespace):
+    pass
+
+
+def _agent(
+    agent_id: str,
+    name: str,
+    display_name: str | None = None,
+    description: str = "",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=agent_id, name=name, display_name=display_name, description=description
+    )
+
+
+def _document(doc_id: str, name: str, created_by: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=doc_id,
+        name=name,
+        description="",
+        room_id="room-1",
+        created_by_agent_id=created_by,
+    )
+
+
+def _role(role_id: str, name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=role_id, name=name, exclusive=True)
+
+
+def _event(command: str) -> SimpleNamespace:
+    return SimpleNamespace(command=command, args="", thread_id=None)
+
+
+def _build_client(
+    *,
+    agents: dict[str, Any] | None = None,
+    roles: list[Any] | None = None,
+    holders: dict[str, list[str]] | None = None,
+    documents: list[Any] | None = None,
+    this_agent: Any = None,
+) -> tuple[SimpleNamespace, list[str]]:
+    """A fake host client capturing every reply body it posts."""
+    posted: list[str] = []
+    by_id = dict(agents or {})
+
+    @asynccontextmanager
+    async def _session_factory():  # type: ignore[no-untyped-def]
+        yield SimpleNamespace()
+
+    async def _resolve_room_meta(_room_id: str) -> SimpleNamespace:
+        return SimpleNamespace(room_id="room-1", name="Feature room")
+
+    async def _reply_command(_room_id, body, **_kw):  # type: ignore[no-untyped-def]
+        posted.append(body)
+
+    async def _get_agent_ids(_session, _room_id):  # type: ignore[no-untyped-def]
+        return list(by_id)
+
+    async def _agent_get(_session, agent_id):  # type: ignore[no-untyped-def]
+        return by_id.get(agent_id)
+
+    async def _get_all(_session):  # type: ignore[no-untyped-def]
+        return list(by_id.values())
+
+    async def _list_roles(_session, _room_id):  # type: ignore[no-untyped-def]
+        return list(roles or [])
+
+    async def _live_holders_for_room(_session, _room_id, _live_ids):  # type: ignore[no-untyped-def]
+        return dict(holders or {})
+
+    async def _list_for_room(_session, _room_id):  # type: ignore[no-untyped-def]
+        return list(documents or [])
+
+    async def _fresh_agent():  # type: ignore[no-untyped-def]
+        return this_agent
+
+    client = SimpleNamespace(
+        agent=this_agent,
+        _fresh_agent=_fresh_agent,
+        session_factory=_session_factory,
+        _resolve_room_meta=_resolve_room_meta,
+        reply_command=_reply_command,
+        _frontend_base_url=None,
+        _room_store=SimpleNamespace(get_agent_ids=_get_agent_ids),
+        _agent_store=SimpleNamespace(get=_agent_get, get_all=_get_all),
+        _room_role_store=SimpleNamespace(
+            list_roles=_list_roles, live_holders_for_room=_live_holders_for_room
+        ),
+        _document_store=SimpleNamespace(list_for_room=_list_for_room),
+        _connections=SimpleNamespace(live_agent_ids=lambda: set()),
+    )
+    return client, posted
+
+
+class TestListRoomAgents:
+    async def test_display_name_precedes_the_identifier(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", "Switch Dev", "Builds Switch")}
+        )
+        await _cmd_list_room_agents(client, _Room(room_id="!m:x"), _event("x"), False)
+        assert "- **Switch Dev (`switchdev`)** — Builds Switch" in posted[0]
+
+    async def test_no_display_name_names_the_identifier_once(self) -> None:
+        client, posted = _build_client(agents={"a1": _agent("a1", "switchdev")})
+        await _cmd_list_room_agents(client, _Room(room_id="!m:x"), _event("x"), False)
+        assert "- **switchdev**" in posted[0]
+        assert "(`switchdev`)" not in posted[0]
+
+    async def test_display_name_cannot_ping_the_channel(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", "@everyone")}
+        )
+        await _cmd_list_room_agents(client, _Room(room_id="!m:x"), _event("x"), False)
+        assert _MENTION.search(posted[0]) is None
+        assert "switchdev" in posted[0]
+
+    async def test_display_name_cannot_forge_a_link(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", _FORGED_LINK)}
+        )
+        await _cmd_list_room_agents(client, _Room(room_id="!m:x"), _event("x"), False)
+        assert "](https://example.invalid)" not in posted[0]
+
+
+class TestListAllAgents:
+    async def test_display_name_precedes_the_identifier(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", "Switch Dev", "Builds Switch")}
+        )
+        await _cmd_list_all_agents(client, _Room(room_id="!m:x"), _event("x"), False)
+        assert "- **Switch Dev (`switchdev`)** — Builds Switch" in posted[0]
+
+    async def test_no_display_name_names_the_identifier_once(self) -> None:
+        client, posted = _build_client(agents={"a1": _agent("a1", "switchdev")})
+        await _cmd_list_all_agents(client, _Room(room_id="!m:x"), _event("x"), False)
+        assert "- **switchdev**" in posted[0]
+        assert "(`switchdev`)" not in posted[0]
+
+    async def test_display_name_cannot_ping_the_channel(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", "@everyone")}
+        )
+        await _cmd_list_all_agents(client, _Room(room_id="!m:x"), _event("x"), False)
+        assert _MENTION.search(posted[0]) is None
+        assert "switchdev" in posted[0]
+
+    async def test_display_name_cannot_forge_a_link(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", _FORGED_LINK)}
+        )
+        await _cmd_list_all_agents(client, _Room(room_id="!m:x"), _event("x"), False)
+        assert "](https://example.invalid)" not in posted[0]
+
+
+class TestRoles:
+    async def test_holder_is_named_by_its_display_name_alone(self) -> None:
+        # Pure attribution: there is nothing here for the reader to type, so
+        # the identifier does not need to ride along.
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", "Switch Dev")},
+            roles=[_role("r1", "reviewer")],
+            holders={"r1": ["a1"]},
+        )
+        await _cmd_roles(client, _Room(room_id="!m:x"), _event("roles"), False)
+        assert (
+            "- **reviewer** _(exclusive)_ — 🟢 held by Switch Dev"
+            == posted[0].splitlines()[1]
+        )
+
+    async def test_holder_without_a_display_name_falls_back(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev")},
+            roles=[_role("r1", "reviewer")],
+            holders={"r1": ["a1"]},
+        )
+        await _cmd_roles(client, _Room(room_id="!m:x"), _event("roles"), False)
+        assert "held by switchdev" in posted[0]
+
+    async def test_holder_display_name_cannot_ping_the_channel(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", "@everyone")},
+            roles=[_role("r1", "reviewer")],
+            holders={"r1": ["a1"]},
+        )
+        await _cmd_roles(client, _Room(room_id="!m:x"), _event("roles"), False)
+        assert _MENTION.search(posted[0]) is None
+
+    async def test_holder_display_name_cannot_forge_a_link(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", _FORGED_LINK)},
+            roles=[_role("r1", "reviewer")],
+            holders={"r1": ["a1"]},
+        )
+        await _cmd_roles(client, _Room(room_id="!m:x"), _event("roles"), False)
+        assert "](https://example.invalid)" not in posted[0]
+
+
+class TestListDocuments:
+    async def test_creator_is_named_by_its_display_name_alone(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", "Switch Dev")},
+            documents=[_document("d1", "Runbook", "a1")],
+        )
+        await _cmd_list_documents(client, _Room(room_id="!m:x"), _event("docs"), False)
+        assert "created by Switch Dev" in posted[0]
+        assert "(`switchdev`)" not in posted[0]
+
+    async def test_creator_without_a_display_name_falls_back(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev")},
+            documents=[_document("d1", "Runbook", "a1")],
+        )
+        await _cmd_list_documents(client, _Room(room_id="!m:x"), _event("docs"), False)
+        assert "created by switchdev" in posted[0]
+
+    async def test_creator_display_name_cannot_ping_the_channel(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", "@everyone")},
+            documents=[_document("d1", "Runbook", "a1")],
+        )
+        await _cmd_list_documents(client, _Room(room_id="!m:x"), _event("docs"), False)
+        assert _MENTION.search(posted[0]) is None
+
+    async def test_creator_display_name_cannot_forge_a_link(self) -> None:
+        client, posted = _build_client(
+            agents={"a1": _agent("a1", "switchdev", _FORGED_LINK)},
+            documents=[_document("d1", "Runbook", "a1")],
+        )
+        await _cmd_list_documents(client, _Room(room_id="!m:x"), _event("docs"), False)
+        assert "](https://example.invalid)" not in posted[0]
+
+
+class TestAgentsGreet:
+    async def test_direct_greeting_uses_the_display_name(self) -> None:
+        client, posted = _build_client(
+            this_agent=_agent("a1", "switchdev", "Switch Dev")
+        )
+        await _cmd_agents_greet(client, _Room(room_id="!m:x"), _event("greet"), True)
+        assert posted[0] == "Hi! I'm Switch Dev — how can I help?"
+
+    async def test_direct_greeting_falls_back_to_the_identifier(self) -> None:
+        client, posted = _build_client(this_agent=_agent("a1", "switchdev"))
+        await _cmd_agents_greet(client, _Room(room_id="!m:x"), _event("greet"), True)
+        assert posted[0] == "Hi! I'm switchdev — how can I help?"
+
+    async def test_direct_greeting_display_name_cannot_ping_the_channel(self) -> None:
+        client, posted = _build_client(
+            this_agent=_agent("a1", "switchdev", "@everyone")
+        )
+        await _cmd_agents_greet(client, _Room(room_id="!m:x"), _event("greet"), True)
+        assert _MENTION.search(posted[0]) is None
+
+    async def test_direct_greeting_display_name_cannot_forge_a_link(self) -> None:
+        client, posted = _build_client(
+            this_agent=_agent("a1", "switchdev", _FORGED_LINK)
+        )
+        await _cmd_agents_greet(client, _Room(room_id="!m:x"), _event("greet"), True)
+        assert "](https://example.invalid)" not in posted[0]
+
+    async def test_room_greeting_keeps_the_live_mention_handle(self) -> None:
+        # The room greeting exists to teach the reader what to tag, so it stays
+        # the routing identifier however the agent is displayed.
+        client, posted = _build_client(
+            this_agent=_agent("a1", "switchdev", "Switch Dev")
+        )
+        await _cmd_agents_greet(client, _Room(room_id="!m:x"), _event("greet"), False)
+        assert "@switchdev" in posted[0]
+        assert "Switch Dev" not in posted[0]
+
+    async def test_greeting_reads_the_agent_fresh(self) -> None:
+        # `client.agent` is a boot-time snapshot; a display name edited in the
+        # gateway has to show up without restarting the client.
+        client, posted = _build_client(this_agent=_agent("a1", "switchdev"))
+        client.agent = _agent("a1", "switchdev", "Stale Name")
+        await _cmd_agents_greet(client, _Room(room_id="!m:x"), _event("greet"), True)
+        assert posted[0] == "Hi! I'm switchdev — how can I help?"

--- a/core/tests/switch_core/bridges/agent/test_commands_invite.py
+++ b/core/tests/switch_core/bridges/agent/test_commands_invite.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import re
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any
 
 from switch_core.bridges.agent.commands import COMMANDS_BY_NAME, _cmd_invite
+
+# Matches a live `@<handle>` mention token (same char class Switch re-parses).
+_MENTION = re.compile(r"@[A-Za-z0-9._-]+")
 
 
 class _Room(SimpleNamespace):
@@ -56,7 +60,13 @@ def _event(args: str) -> SimpleNamespace:
     return SimpleNamespace(command="invite-agent", args=args, thread_id=None)
 
 
-_ALICE = SimpleNamespace(id="a1", name="claude-code.alice")
+def _agent(
+    agent_id: str, name: str, display_name: str | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(id=agent_id, name=name, display_name=display_name)
+
+
+_ALICE = _agent("a1", "claude-code.alice")
 
 
 class TestInviteCommand:
@@ -94,6 +104,62 @@ class TestInviteCommand:
         await _cmd_invite(client, _Room(room_id="!m:x"), _event(""), False)
         assert added == []
         assert "Usage" in posted[0]
+
+
+class TestInviteCommandDisplayNames:
+    async def test_added_notice_names_the_agent_and_keeps_its_identifier(self) -> None:
+        agent = _agent("a1", "switchdev", "Switch Dev")
+        client, posted, added = _build_client(
+            registry={"switchdev": agent}, room_agent_ids=[]
+        )
+        await _cmd_invite(client, _Room(room_id="!m:x"), _event("@switchdev"), False)
+        # Routing still goes by the identifier, whatever it is displayed as.
+        assert added == [("room-1", ["switchdev"])]
+        assert "Added **Switch Dev (`switchdev`)** to this room." == posted[0]
+
+    async def test_already_present_notice_names_the_agent(self) -> None:
+        agent = _agent("a1", "switchdev", "Switch Dev")
+        client, posted, _added = _build_client(
+            registry={"switchdev": agent}, room_agent_ids=["a1"]
+        )
+        await _cmd_invite(client, _Room(room_id="!m:x"), _event("@switchdev"), False)
+        assert "**Switch Dev (`switchdev`)** is already in this room." == posted[0]
+
+    async def test_no_display_name_names_the_identifier_once(self) -> None:
+        client, posted, _added = _build_client(
+            registry={"claude-code.alice": _ALICE}, room_agent_ids=[]
+        )
+        await _cmd_invite(
+            client, _Room(room_id="!m:x"), _event("@claude-code.alice"), False
+        )
+        assert "Added **claude-code.alice** to this room." == posted[0]
+        assert "(`claude-code.alice`)" not in posted[0]
+
+    async def test_display_name_cannot_ping_the_channel(self) -> None:
+        agent = _agent("a1", "switchdev", "@everyone")
+        client, posted, _added = _build_client(
+            registry={"switchdev": agent}, room_agent_ids=[]
+        )
+        await _cmd_invite(client, _Room(room_id="!m:x"), _event("@switchdev"), False)
+        assert _MENTION.search(posted[0]) is None
+        assert "switchdev" in posted[0]
+
+    async def test_display_name_cannot_forge_a_link(self) -> None:
+        agent = _agent("a1", "switchdev", "[here](https://example.invalid)")
+        client, posted, _added = _build_client(
+            registry={"switchdev": agent}, room_agent_ids=["a1"]
+        )
+        await _cmd_invite(client, _Room(room_id="!m:x"), _event("@switchdev"), False)
+        assert "](https://example.invalid)" not in posted[0]
+
+    async def test_unknown_token_is_echoed_verbatim(self) -> None:
+        agent = _agent("a1", "switchdev", "Switch Dev")
+        client, posted, _added = _build_client(
+            registry={"switchdev": agent}, room_agent_ids=[]
+        )
+        await _cmd_invite(client, _Room(room_id="!m:x"), _event("@switchdevv"), False)
+        assert "No agent named `switchdevv`" in posted[0]
+        assert "Switch Dev" not in posted[0]
 
 
 class TestInviteCommandRegistration:

--- a/core/tests/switch_core/bridges/agent/test_commands_status.py
+++ b/core/tests/switch_core/bridges/agent/test_commands_status.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 
 from switch_core.bridges.agent.commands import (
@@ -8,18 +9,23 @@ from switch_core.bridges.agent.commands import (
 )
 from switch_core.bridges.agent.protocol.types import AgentStatus
 
+# Matches a live `@<handle>` mention token (same char class Switch re-parses).
+_MENTION = re.compile(r"@[A-Za-z0-9._-]+")
+
 
 def _agent(
     agent_id: str,
     name: str,
     agent_type: str,
     *,
+    display_name: str | None = None,
     can_delegate: bool = False,
     can_accept: bool = False,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         id=agent_id,
         name=name,
+        display_name=display_name,
         agent_type=agent_type,
         integration_profile={
             "task_protocol": {
@@ -130,6 +136,59 @@ class TestFormatStatusLines:
             {"a": "switchdash://session?server=s&agent=a&room=r"},
         )
         assert "Switch Console" not in out
+
+
+class TestFormatStatusLinesDisplayNames:
+    def test_display_name_precedes_the_identifier_in_backticks(self) -> None:
+        agents = [_agent("a", "switchdev", "always_on", display_name="Switch Dev")]
+        out = _format_status_lines(agents, {"a": AgentStatus.LIVE}, {}, {})
+        assert "**Switch Dev (`switchdev`)** — live" in out
+
+    def test_no_display_name_renders_the_identifier_once(self) -> None:
+        agents = [_agent("a", "switchdev", "always_on")]
+        out = _format_status_lines(agents, {"a": AgentStatus.LIVE}, {}, {})
+        assert "**switchdev** — live" in out
+        assert "(`switchdev`)" not in out
+
+    def test_a_display_name_cannot_ping_the_channel(self) -> None:
+        agents = [_agent("a", "switchdev", "always_on", display_name="@everyone")]
+        out = _format_status_lines(agents, {"a": AgentStatus.LIVE}, {}, {})
+        assert _MENTION.search(out) is None
+        assert "switchdev" in out
+
+    def test_a_display_name_cannot_forge_a_link(self) -> None:
+        agents = [
+            _agent(
+                "a",
+                "switchdev",
+                "always_on",
+                display_name="[click here](https://example.invalid)",
+            )
+        ]
+        out = _format_status_lines(agents, {"a": AgentStatus.LIVE}, {}, {})
+        assert "](https://example.invalid)" not in out
+
+    def test_order_follows_the_displayed_label(self) -> None:
+        # Sorted by identifier this reads zeta, alpha; the reader sees the
+        # display names, so those are what the order has to follow.
+        agents = [
+            _agent("z", "zeta", "always_on", display_name="Alpha Bot"),
+            _agent("a", "alpha", "always_on", display_name="Zeta Bot"),
+        ]
+        statuses = {"z": AgentStatus.LIVE, "a": AgentStatus.LIVE}
+        lines = _format_status_lines(agents, statuses, {}, {}).splitlines()
+        assert "Alpha Bot" in lines[1]
+        assert "Zeta Bot" in lines[2]
+
+    def test_order_mixes_displayed_and_bare_identifiers(self) -> None:
+        agents = [
+            _agent("w", "worker", "always_on"),
+            _agent("b", "zeta", "always_on", display_name="Bravo Bot"),
+        ]
+        statuses = {"w": AgentStatus.LIVE, "b": AgentStatus.LIVE}
+        lines = _format_status_lines(agents, statuses, {}, {}).splitlines()
+        assert "Bravo Bot" in lines[1]
+        assert "worker" in lines[2]
 
 
 class TestStatusCommandRegistration:

--- a/core/tests/switch_core/clients/test_admin_client.py
+++ b/core/tests/switch_core/clients/test_admin_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
@@ -7,6 +8,9 @@ from switch_core.bridges.agent.commands import dispatch_admin_command
 from switch_core.clients.admin_client import AdminClient
 from switch_core.clients.admin_messages import ADMIN_MARKER, AdminMessageType
 from switch_core.events import CommandEvent
+
+# Matches a live `@<handle>` mention token (same char class Switch re-parses).
+_MENTION = re.compile(r"@[A-Za-z0-9._-]+")
 
 
 def _no_connections() -> SimpleNamespace:
@@ -177,7 +181,11 @@ class TestAdminUnreachableRoleWarning:
 
 class TestAdminAbsentAgentWarning:
     async def test_warns_when_agent_absent(self) -> None:
-        agents = {"web-searcher": SimpleNamespace(id="a-web", name="web-searcher")}
+        agents = {
+            "web-searcher": SimpleNamespace(
+                id="a-web", name="web-searcher", display_name=None
+            )
+        }
         client, sent = _admin_client(agents_by_name=agents)
         event = _event("@web-searcher can you look this up?")
         await AdminClient._warn_absent_agents(client, _room(), event, "room-1", None)
@@ -187,7 +195,11 @@ class TestAdminAbsentAgentWarning:
         assert _marker_type(sent[0]) == AdminMessageType.ABSENT_AGENT.value
 
     async def test_warning_tags_the_asker(self) -> None:
-        agents = {"web-searcher": SimpleNamespace(id="a-web", name="web-searcher")}
+        agents = {
+            "web-searcher": SimpleNamespace(
+                id="a-web", name="web-searcher", display_name=None
+            )
+        }
         client, sent = _admin_client(agents_by_name=agents)
         event = _event("@web-searcher ping", sender_name="carol")
         await AdminClient._warn_absent_agents(client, _room(), event, "room-1", None)
@@ -195,7 +207,11 @@ class TestAdminAbsentAgentWarning:
         assert sent[0]["mentions"] == ["@carol:switch.local"]
 
     async def test_warning_threads_under_trigger(self) -> None:
-        agents = {"web-searcher": SimpleNamespace(id="a-web", name="web-searcher")}
+        agents = {
+            "web-searcher": SimpleNamespace(
+                id="a-web", name="web-searcher", display_name=None
+            )
+        }
         client, sent = _admin_client(agents_by_name=agents)
         event = _event("@web-searcher ping")
         await AdminClient._warn_absent_agents(
@@ -204,7 +220,11 @@ class TestAdminAbsentAgentWarning:
         assert sent[0]["thread_root_id"] == "thread-42"
 
     async def test_no_warning_when_agent_is_member(self) -> None:
-        agents = {"web-searcher": SimpleNamespace(id="a-web", name="web-searcher")}
+        agents = {
+            "web-searcher": SimpleNamespace(
+                id="a-web", name="web-searcher", display_name=None
+            )
+        }
         client, sent = _admin_client(members={"a-web"}, agents_by_name=agents)
         event = _event("@web-searcher status?")
         await AdminClient._warn_absent_agents(client, _room(), event, "room-1", None)
@@ -218,7 +238,11 @@ class TestAdminAbsentAgentWarning:
         assert sent == []
 
     async def test_prefix_name_not_falsely_warned(self) -> None:
-        agents = {"cc-bug-fixing": SimpleNamespace(id="a-ccbf", name="cc-bug-fixing")}
+        agents = {
+            "cc-bug-fixing": SimpleNamespace(
+                id="a-ccbf", name="cc-bug-fixing", display_name=None
+            )
+        }
         client, sent = _admin_client(agents_by_name=agents)
         event = _event("@cc-bug-fixing-2 please run")
         await AdminClient._warn_absent_agents(client, _room(), event, "room-1", None)
@@ -234,8 +258,12 @@ class TestAdminAbsentAgentWarning:
 
     async def test_combines_multiple_absent_agents(self) -> None:
         agents = {
-            "web-searcher": SimpleNamespace(id="a-web", name="web-searcher"),
-            "doc-expert": SimpleNamespace(id="a-doc", name="doc-expert"),
+            "web-searcher": SimpleNamespace(
+                id="a-web", name="web-searcher", display_name=None
+            ),
+            "doc-expert": SimpleNamespace(
+                id="a-doc", name="doc-expert", display_name=None
+            ),
         }
         client, sent = _admin_client(agents_by_name=agents)
         event = _event("@web-searcher @doc-expert can you pair up?")
@@ -244,6 +272,56 @@ class TestAdminAbsentAgentWarning:
         assert "web-searcher" in sent[0]["body"]
         assert "doc-expert" in sent[0]["body"]
         assert "aren't in this room" in sent[0]["body"]
+
+    async def test_warning_names_the_agent_and_keeps_its_identifier(self) -> None:
+        # The reader just mistyped a mention, so the identifier they have to
+        # retype has to stay on the line beside the label.
+        agents = {
+            "switchdev": SimpleNamespace(
+                id="a-sd", name="switchdev", display_name="Switch Dev"
+            )
+        }
+        client, sent = _admin_client(agents_by_name=agents)
+        event = _event("@switchdev can you look this up?")
+        await AdminClient._warn_absent_agents(client, _room(), event, "room-1", None)
+        assert "**Switch Dev (`switchdev`)**" in sent[0]["body"]
+
+    async def test_warning_without_a_display_name_names_it_once(self) -> None:
+        agents = {
+            "switchdev": SimpleNamespace(id="a-sd", name="switchdev", display_name=None)
+        }
+        client, sent = _admin_client(agents_by_name=agents)
+        event = _event("@switchdev ping")
+        await AdminClient._warn_absent_agents(client, _room(), event, "room-1", None)
+        assert "**switchdev**" in sent[0]["body"]
+        assert "(`switchdev`)" not in sent[0]["body"]
+
+    async def test_warning_display_name_cannot_ping_the_channel(self) -> None:
+        agents = {
+            "switchdev": SimpleNamespace(
+                id="a-sd", name="switchdev", display_name="@everyone"
+            )
+        }
+        client, sent = _admin_client(agents_by_name=agents)
+        event = _event("@switchdev ping", sender_name="carol")
+        await AdminClient._warn_absent_agents(client, _room(), event, "room-1", None)
+        body = sent[0]["body"]
+        # The one live mention left is the asker the notice is addressed to.
+        assert _MENTION.findall(body) == ["@carol"]
+        assert "switchdev" in body
+
+    async def test_warning_display_name_cannot_forge_a_link(self) -> None:
+        agents = {
+            "switchdev": SimpleNamespace(
+                id="a-sd",
+                name="switchdev",
+                display_name="[here](https://example.invalid)",
+            )
+        }
+        client, sent = _admin_client(agents_by_name=agents)
+        event = _event("@switchdev ping")
+        await AdminClient._warn_absent_agents(client, _room(), event, "room-1", None)
+        assert "](https://example.invalid)" not in sent[0]["body"]
 
 
 def _cmd_event(command: str, args: str = "") -> CommandEvent:


### PR DESCRIPTION
Stacked on #338. Review that one first; this diff is only the last commit.

## What

The `!` command surface was the last place still naming every agent by its
routing identifier. A room that shows "Switch Dev" in every bridged message
dropped back to "switchdev" the moment anyone ran `!list-agents`.

Which name a command prints is decided by one question — **does the reader
have to type it back?**

| Surface | Prints | Why |
|---|---|---|
| `!list-agents`, `!list-all-agents`, `!invite-agent`, `!alias`, status replies | ``Switch Dev (`switchdev`)`` | the identifier is the thing you type next |
| `!roles` holders, `!list-documents` creators | `Switch Dev` | nobody addresses a document's author |
| room greeting | `@switchdev` | it is a live mention token and has to stay one |

Listings sort on the label, so the order matches what is on screen rather than
a hidden identifier.

## The security half

A display name is text a user typed, and these replies are handed to the
bridge, which escapes nothing on the way out but **does** rewrite a plain
`@handle` into a real mention. A display name of `@everyone` would have been a
mass ping — latent before this feature existed, armed by it.

Every command therefore defuses the label first. The zero-width-space
treatment the platform adapters already applied moves down into
`agent_display_name` so the command layer shares that one implementation
instead of growing a second copy:

```
stored : '@everyone'
posted : '- **@​everyone (`switchdev`)**'
```

Invisible to a reader, inert to the mention parser.

## Verification

2237 pass (+47), ruff and mypy clean. Beyond the suite I mutation-tested the
six load-bearing claims — every one of them fails the suite when broken:

- defusal reduced to identity → **41 failures** (the bridge suite goes with it,
  which is what proves the extraction is genuinely shared rather than a copy)
- `agent_label` / `agent_label_with_identifier` skipping defusal → 6 / 14
- an agent with no display name rendering ``switchdev (`switchdev`)`` → 12
- sort key reverting to the identifier → 2
- a **routing** site switched to the display name → 1

That last one is the one worth keeping: it is the check that stops a later
edit from "consistently" applying the display name to the greeting and
silently breaking the mention it hands out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)