### PR TITLE
perf(agent-bridge): take the sequential scan off the heartbeat path and size the DB pool for it

### DIFF
--- a/core/switch_core/config.py
+++ b/core/switch_core/config.py
@@ -72,10 +72,19 @@ class SwitchConfig(BaseSettings):
     # of being truncated or silently dropped.
     agent_media_max_bytes: int = 20 * 1024 * 1024
 
-    db_pool_size: int = 20
+    # Every authenticated agent request resolves its bearer token against the
+    # database before the handler runs, and each live agent connection beats
+    # every 2s, so the pool is sized against connection count rather than
+    # human traffic: a fleet of N connections costs roughly N/2 checkouts per
+    # second. Exceeding the pool does not shed load, it queues, and a queued
+    # heartbeat that misses HEARTBEAT_TTL_SECONDS costs the connection.
+    db_pool_size: int = 30
     db_max_overflow: int = 10
     db_pool_recycle: int = 1800
     db_pool_pre_ping: bool = True
+    # SQLAlchemy's default is 30s, long enough that pool starvation surfaces as
+    # unexplained latency rather than an error. Fail fast and loudly instead.
+    db_pool_timeout: float = 5.0
 
     # libpq-style TLS mode for the Postgres connection, forwarded to asyncpg.
     # "disable" (the default) keeps in-cluster / local-dev connections plain,

--- a/core/switch_core/db/engine.py
+++ b/core/switch_core/db/engine.py
@@ -20,6 +20,7 @@ def create_engine_from_config(
         "max_overflow": config.db_max_overflow,
         "pool_recycle": config.db_pool_recycle,
         "pool_pre_ping": config.db_pool_pre_ping,
+        "pool_timeout": config.db_pool_timeout,
         "connect_args": connect_args,
     }
     defaults.update(engine_kwargs)

--- a/core/switch_core/db/models.py
+++ b/core/switch_core/db/models.py
@@ -111,8 +111,11 @@ class Agent(Base):
     client_id: Mapped[str] = mapped_column(
         Text, ForeignKey("clients.id"), unique=True, nullable=False
     )
+    # Indexed because bearer-token auth resolves the key row and then looks the
+    # agent up by this column on every authenticated request, heartbeats
+    # included — without it that is a sequential scan per beat.
     api_key_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("api_keys.id"), nullable=False
+        Text, ForeignKey("api_keys.id"), nullable=False, index=True
     )
     owner_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id"), nullable=True

--- a/core/switch_core/migrations/versions/f3b81c47d9a2_index_agents_api_key_id.py
+++ b/core/switch_core/migrations/versions/f3b81c47d9a2_index_agents_api_key_id.py
@@ -1,0 +1,25 @@
+"""index agents.api_key_id
+
+Revision ID: f3b81c47d9a2
+Revises: a2171c0de1f4
+Create Date: 2026-09-02
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3b81c47d9a2"
+down_revision: str | None = "a2171c0de1f4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_agents_api_key_id", "agents", ["api_key_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agents_api_key_id", table_name="agents")

--- a/deploy/remote/helm/switch/templates/_helpers.tpl
+++ b/deploy/remote/helm/switch/templates/_helpers.tpl
@@ -227,6 +227,12 @@ Include with `nindent 12`.
   value: {{ include "switch.postgresDatabase" . | quote }}
 - name: DB_SSL_MODE
   value: {{ .Values.postgresql.sslMode | quote }}
+- name: DB_POOL_SIZE
+  value: {{ .Values.postgresql.pool.size | quote }}
+- name: DB_MAX_OVERFLOW
+  value: {{ .Values.postgresql.pool.maxOverflow | quote }}
+- name: DB_POOL_TIMEOUT
+  value: {{ .Values.postgresql.pool.timeout | quote }}
 - name: MATRIX_SERVER
   value: "http://{{ include "switch.tuwunelHost" . }}:8008"
 - name: MATRIX_SERVER_NAME

--- a/deploy/remote/helm/switch/templates/postgresql/statefulset.yaml
+++ b/deploy/remote/helm/switch/templates/postgresql/statefulset.yaml
@@ -25,6 +25,13 @@ spec:
         - name: postgresql
           image: {{ .Values.postgresql.image }}
           imagePullPolicy: {{ .Values.postgresql.imagePullPolicy }}
+          {{- with .Values.postgresql.parameters }}
+          args:
+            {{- range $name, $value := . }}
+            - -c
+            - {{ printf "%s=%v" $name $value | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - containerPort: 5432
               protocol: TCP

--- a/deploy/remote/helm/switch/values.yaml
+++ b/deploy/remote/helm/switch/values.yaml
@@ -302,6 +302,22 @@ postgresql:
   # managed cloud databases generally require "require" or stricter.
   sslMode: disable
 
+  # switch-core's SQLAlchemy connection pool. Size this against the number of
+  # live agent connections, not human traffic: bearer-token auth hits the
+  # database on every authenticated request and each agent connection beats
+  # every 2s, so roughly N/2 checkouts per second for N connections. When the
+  # pool is exhausted requests queue rather than fail, and a heartbeat delayed
+  # past the server's TTL loses its connection — so under-sizing this shows up
+  # as fleet-wide agent disconnects, not as database errors.
+  # size + maxOverflow must stay under Postgres max_connections, remembering
+  # Mattermost and Keycloak share the same instance.
+  pool:
+    size: 30
+    maxOverflow: 10
+    # Seconds to wait for a free slot before raising. Deliberately short:
+    # SQLAlchemy's 30s default hides starvation as latency.
+    timeout: 5
+
   # Password source. By default the password is read from the chart-managed
   # Secret (secrets.postgresPassword). To source it from a pre-existing Secret
   # instead (e.g. synced by external-secrets / sealed-secrets), set
@@ -332,6 +348,18 @@ postgresql:
       memory: 256Mi
     limits:
       memory: 512Mi
+
+  # Postgres server parameters, passed as `-c name=value`. Each client
+  # connection is a backend process costing several MB of non-reclaimable
+  # memory, so raising the pool above without also raising resources.limits
+  # .memory trades a connection-pool stall for an OOMKill — size them together.
+  # effective_cache_size in particular should track the memory limit rather
+  # than being left at the Postgres default, which assumes a far larger host.
+  # Example:
+  #   parameters:
+  #     effective_cache_size: 1536MB
+  #     shared_buffers: 256MB
+  parameters: {}
 
 # ── Backups ───────────────────────────────────────────────────────────────────
 # This chart ships no backup jobs on purpose — an on-cluster backup shares the


### PR DESCRIPTION
## Why

The pilot has been reaping its entire agent fleet, repeatedly, for minutes at a time — 84 connections across 36 distinct agents closed in a single millisecond, all `reason=heartbeat lapsed`, victims with 690–812 unbroken beats behind them.

The cause is on the authenticated request path:

- `BearerAuthMiddleware` resolves the `api_keys` row and then looks the agent up by `api_key_id` (`auth.py:157-162`) on **every** authenticated request.
- Heartbeats are authenticated, and the beat handler itself does **zero** database work (`handlers.py:826-857` is pure dict/deque). So authentication is 100% of a heartbeat's I/O.
- `agents.api_key_id` was a bare `ForeignKey` with **no index** — a sequential scan per beat.

At N live connections beating every 2s that is ~N/2 pool checkouts/second. Pool exhaustion doesn't shed load, it queues, and a heartbeat queued past `HEARTBEAT_TTL_SECONDS` loses its connection. So pool pressure surfaces as *fleet-wide agent disconnects*, not as database errors — which is exactly why it went unrecognised.

It did reach outright starvation:
```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 20 overflow 10 reached,
connection timed out, timeout 30.00
```

Three independent measurements localise it to the authenticated path specifically: `/health` (no auth, no DB) stayed on-grid to within 0.6s across the whole window, the connection-sweep tick never lagged more than 426ms, and the ingress logged `context canceled` exactly 4s after each cutoff — i.e. requests arrived and were forwarded, and clients gave up.

## What this changes

- **Index `agents.api_key_id`** — `index=True` plus a migration. This is the real fix: it attacks hold time, and by Little's law required pool size is `arrival rate × hold time`.
- **Pool 20 → 30**, overflow unchanged at 10.
- **`pool_timeout` 30s → 5s.** SQLAlchemy's default is long enough that starvation reads as unexplained latency rather than an error. Fail fast and loudly.
- **Expose the pool via the chart** (`DB_POOL_SIZE` / `DB_MAX_OVERFLOW` / `DB_POOL_TIMEOUT`). `config.py` already read these from the environment; the chart just never surfaced them, so there was no supported way to tune the pool without a code change.
- **Add `postgresql.parameters`**, rendered as `-c name=value`. Each pooled connection is a backend process costing several MB of non-reclaimable memory, so raising the pool without raising `resources.limits.memory` trades a pool stall for an OOMKill — the two must be tunable together. It also makes `effective_cache_size` settable, which currently keeps a default assuming a much larger host.

## Deliberately not included

**`HEARTBEAT_TTL_SECONDS` 6.0 → 15.0.** Worth knowing that `BEAT_INTERVAL_MS` (2000) + `BEAT_REQUEST_TIMEOUT_MS` (4000) equals the TTL exactly, so a single timed-out beat is unrecoverable and the client's backoff then puts the retry 8s out — past the TTL. Of six measured latency excursions, five were under 15s and would have reaped nothing.

That's a behavioural change to the protocol rather than a capacity fix, so it's left for its own PR/decision.

## Risk

Defaults-only behaviour change is the pool numbers and `pool_timeout`. `postgresql.parameters` defaults to `{}`, so no `args` are rendered and the StatefulSet is byte-identical unless set. The migration adds one index to a 278-row table.

## Verification

- `just check`, `just typecheck` clean; **2010 tests pass** (includes `test_migration_chain.py`)
- `helm template` verified: defaults render the new env vars; overrides for `postgresql.pool.size` and `postgresql.parameters` render correctly; with `parameters` unset no `args` block appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)