### PR TITLE
release: switch-core 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,11 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.22.0] - 2026-09-02
+
 #### Added
+- Agents can carry an optional human display name, stored on the agent and
+  surfaced over the agent protocol (agent detail) and the gateway (#326).
 - **User-defined external reference types.** Reference types are no longer a
   closed set of four. Any signed-in user can define one — slug, display name,
   agent-facing instructions, value hint and a read/write visibility pair,
@@ -81,6 +85,15 @@ version of their own to them without also giving them a release of their own.
   401 without one. It was the last unauthenticated route on the references
   router; the set it returns is per-caller now, so it cannot be answered
   anonymously.
+
+#### Fixed
+- Discord: create the room on the first command, not only on the first message
+  (#341).
+- Deeplinks: replaced the handoff page with a branded two-state design (#339).
+
+#### Performance
+- Agent bridge: take the sequential scan off the heartbeat path and size the DB
+  pool for it, backed by a new index on `agents.api_key_id` (#344).
 
 ### [0.21.1] - 2026-09-01
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.21.1
+    version: 0.22.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.21.1',
+  'switch-core': '0.22.0',
   'switch-console': '0.31.3',
   'agent-runtime': '0.3.4',
   sidecar: '1.9.6',
-  gateway: '0.21.1',
-  setup: '0.21.1',
-  'helm-chart': '0.21.1',
-  compose: '0.21.1',
+  gateway: '0.22.0',
+  setup: '0.22.0',
+  'helm-chart': '0.22.0',
+  compose: '0.22.0',
   'switch-connector': '0.9.11',
   'switch-connector-codex': '0.3.12',
   'switch-connector-opencode': '0.1.7',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.21.1',
+  'switch-core': '0.22.0',
   'switch-console': '0.31.3',
   'agent-runtime': '0.3.4',
   sidecar: '1.9.6',
-  gateway: '0.21.1',
-  setup: '0.21.1',
-  'helm-chart': '0.21.1',
-  compose: '0.21.1',
+  gateway: '0.22.0',
+  setup: '0.22.0',
+  'helm-chart': '0.22.0',
+  compose: '0.22.0',
   'switch-connector': '0.9.11',
   'switch-connector-codex': '0.3.12',
   'switch-connector-opencode': '0.1.7',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.21.1"
+version = "0.22.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.21.1",
+    "switch-core": "0.22.0",
     "switch-console": "0.31.3",
     "agent-runtime": "0.3.4",
     "sidecar": "1.9.6",
-    "gateway": "0.21.1",
-    "setup": "0.21.1",
-    "helm-chart": "0.21.1",
-    "compose": "0.21.1",
+    "gateway": "0.22.0",
+    "setup": "0.22.0",
+    "helm-chart": "0.22.0",
+    "compose": "0.22.0",
     "switch-connector": "0.9.11",
     "switch-connector-codex": "0.3.12",
     "switch-connector-opencode": "0.1.7",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.21.1"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **switch-core 0.22.0**.

## What's Changed
- **Added:** user-defined external reference types (agent protocol + gateway UI); `list_all_references` for instance-wide reference discovery; optional agent human display name (#326)
- **Changed:** a reference value must now carry at least one URL (previously an absent `urls` silently stored empty — now 400); `GET /references/reference-types` now requires a session
- **Fixed:** Discord room created on first command (#341); branded two-state deeplink handoff page (#339)
- **Performance:** heartbeat path no longer does a sequential scan; new index on `agents.api_key_id` + DB pool sizing (#344)

Bumps `core/pyproject.toml` + `artifacts.yaml` (0.21.1 → 0.22.0), regenerates modules, cuts the CHANGELOG. Contracts unchanged (additive wire only). Includes a DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)