### PR TITLE
feat(bridges): render agents under their display name on Mattermost

### DIFF
--- a/console/apps/switch-console-desktop/src/main/core/managed-switch-server/resources/standalone-docker-compose.pinned.yml
+++ b/console/apps/switch-console-desktop/src/main/core/managed-switch-server/resources/standalone-docker-compose.pinned.yml
@@ -139,6 +139,7 @@ services:
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
       MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
       MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
+      MM_TEAMSETTINGS_TEAMMATENAMEDISPLAY: "full_name"
       # Neither plugin is usable in a bundled Switch deployment: Copilot has no
       # configured provider and throws a 404 looking up its bot on every page
       # load, and Calls ships a WebRTC service nothing here can reach.

--- a/core/switch_core/bridges/collaboration/mattermost/adapter.py
+++ b/core/switch_core/bridges/collaboration/mattermost/adapter.py
@@ -55,6 +55,11 @@ _JOINABLE_MM_CHANNEL_TYPES = frozenset({"O", "P"})
 # Emoji marking the message an agent is currently working on.
 _WORKING_REACTION = "eyes"
 
+# The values of `TeamSettings.TeammateNameDisplay` under which Mattermost puts
+# a bot's display name in the post header. Under any other value — including
+# the server default, "username" — the display name is stored and never shown.
+_NAME_DISPLAY_SHOWS_LABEL = frozenset({"full_name", "nickname_full_name"})
+
 
 class MattermostConnectionConfig(BridgeConnectionConfig):
     url: str
@@ -126,6 +131,14 @@ class MattermostAdapter(CollaborationAdapter):
 
         # channel id -> channel name (URL slug), for building channel deeplinks.
         self._channel_name_cache: dict[str, str] = {}
+
+        # The server's `TeamSettings.TeammateNameDisplay`, read once per run:
+        # it decides whether a bot's display name is rendered anywhere, and
+        # under the default ("username") it never is. None once a read has been
+        # attempted and could not answer.
+        self._name_display_setting: str | None = None
+        self._name_display_read = False
+        self._name_display_warned = False
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
 
@@ -970,9 +983,25 @@ class MattermostAdapter(CollaborationAdapter):
 
         loop = self._main_loop
 
+        # The username is the routing handle — the mention, the member-list key
+        # and the key this adapter adopts a bot back by — so it stays the
+        # identifier. Only the bot's own display name carries the label.
+        label = (await self.agent_rendering(agent_name)).field_label
+        if label != agent_name:
+            self._warn_once_if_display_names_are_hidden()
+
         existing = await self._find_existing_bot(agent_name)
         if existing:
             bot_id: str = str(existing["user_id"])
+            if existing.get("display_name") != label:
+                try:
+                    self._mm_api("put", f"/bots/{bot_id}", {"display_name": label})
+                except Exception as e:
+                    logger.exception(
+                        "Failed to update the display name of Mattermost bot %s: %s",
+                        agent_name,
+                        e,
+                    )
         else:
             try:
                 bot = self._mm_api(
@@ -980,7 +1009,7 @@ class MattermostAdapter(CollaborationAdapter):
                     "/bots",
                     {
                         "username": agent_name,
-                        "display_name": agent_name,
+                        "display_name": label,
                         "description": f"Switch agent: {agent_description}",
                     },
                 )
@@ -1209,6 +1238,53 @@ class MattermostAdapter(CollaborationAdapter):
             if bot_name:
                 agent_names.append(bot_name)
         return agent_names
+
+    def _read_name_display_setting(self) -> str | None:
+        """`TeamSettings.TeammateNameDisplay`, read at most once per run.
+
+        None when the read could not answer — the server config is readable
+        only by a system admin, and an agent's bot is worth having either
+        way, so the caller reports the blind spot instead of failing on it."""
+        if self._name_display_read:
+            return self._name_display_setting
+        self._name_display_read = True
+        try:
+            config = self._mm_api("get", "/config")
+            setting = (config.get("TeamSettings") or {}).get("TeammateNameDisplay")
+        except Exception as e:
+            logger.warning(
+                "Could not read the Mattermost server config (%s), so whether "
+                "agent display names are rendered on this server is unknown",
+                e,
+            )
+            return None
+        if not isinstance(setting, str):
+            logger.warning(
+                "The Mattermost server config carries no "
+                "TeamSettings.TeammateNameDisplay, so whether agent display "
+                "names are rendered on this server is unknown"
+            )
+            return None
+        self._name_display_setting = setting
+        return setting
+
+    def _warn_once_if_display_names_are_hidden(self) -> None:
+        """Say so when this server will store an agent's display name and show
+        nobody. Mattermost renders a bot under its username unless the server
+        is told otherwise, so a display name Switch sets can be invisible with
+        nothing about the write itself failing."""
+        if self._name_display_warned:
+            return
+        setting = self._read_name_display_setting()
+        if setting is None or setting in _NAME_DISPLAY_SHOWS_LABEL:
+            return
+        self._name_display_warned = True
+        logger.warning(
+            "Mattermost TeamSettings.TeammateNameDisplay is '%s', so agent "
+            "display names will not appear in the post header on this server — "
+            "set it to 'full_name' or 'nickname_full_name' to render them",
+            setting,
+        )
 
     # ── Bot icons ────────────────────────────────────────────────────────────
 

--- a/core/tests/switch_core/bridges/collaboration/test_bridge_agent_display_names.py
+++ b/core/tests/switch_core/bridges/collaboration/test_bridge_agent_display_names.py
@@ -1737,8 +1737,10 @@ MATTERMOST_CHANNEL = "mm-channel-1"
 def _mattermost_adapter(
     bridge: BridgeCore | None,
 ) -> tuple[MattermostAdapter, list[str]]:
-    """Mattermost reaches the label through the inherited operator ping alone,
-    so the capture is of `send_message` rather than of a platform client."""
+    """Mattermost carries the label in two places: the inherited operator ping,
+    covered here, and the per-agent bot's own `display_name`, covered by the
+    identity tests below. This capture is of `send_message` rather than of a
+    platform client because the ping never reaches one."""
     adapter = MattermostAdapter(
         config=MattermostConnectionConfig(
             url="http://mattermost.invalid",
@@ -1857,3 +1859,286 @@ def test_mattermost_still_delivers_the_owner_ping() -> None:
     )
 
     assert sent[-1].startswith("@opslead ")
+
+
+# ── Mattermost bot identities ────────────────────────────────────────────────
+#
+# Mattermost is the one platform that gives an agent an account of its own. Its
+# `username` is the routing handle — the mention, the channel member-list key,
+# the key an existing bot is adopted back by — and is also constrained to 3-22
+# lowercase alphanumerics, so it stays the identifier. The bot's separate
+# `display_name` field is the presentation half, and the only place the label
+# may land.
+
+
+class _MattermostAdmin:
+    """The slice of a Mattermost `Driver` the identity path reaches.
+
+    Every `_mm_api` call goes through `client.make_request`, so the fake
+    answers at that level and records the calls verbatim — the assertions are
+    about the exact bodies Switch sends to `/bots`."""
+
+    def __init__(self, bots: list[dict[str, Any]], name_display: str | None) -> None:
+        self._bots = bots
+        self._name_display = name_display
+        self.requests: list[tuple[str, str, dict[str, Any] | None]] = []
+        self.client = SimpleNamespace(make_request=self._make_request)
+        self.teams = SimpleNamespace(add_user_to_team=lambda team_id, body: None)
+
+    def _make_request(
+        self, method: str, endpoint: str, options: dict[str, Any] | None = None
+    ) -> Any:
+        self.requests.append((method, endpoint, options))
+        payload = self._respond(method, endpoint, options)
+        return SimpleNamespace(json=lambda: payload)
+
+    def _respond(
+        self, method: str, endpoint: str, options: dict[str, Any] | None
+    ) -> Any:
+        if method == "get" and endpoint == "/config":
+            if self._name_display is None:
+                raise RuntimeError("config is readable by system admins only")
+            return {"TeamSettings": {"TeammateNameDisplay": self._name_display}}
+        if method == "get" and endpoint.startswith("/bots?"):
+            return self._bots
+        if method == "post" and endpoint == "/bots":
+            assert options is not None
+            return {"user_id": f"bot-{options['username']}"}
+        if method == "put" and endpoint.startswith("/bots/"):
+            return {}
+        if method == "post" and endpoint.endswith("/tokens"):
+            return {"token": "placeholder-bot-token"}
+        raise AssertionError(f"unexpected Mattermost call: {method} {endpoint}")
+
+    def bodies(self, method: str, endpoint: str) -> list[dict[str, Any] | None]:
+        return [
+            options for m, e, options in self.requests if m == method and e == endpoint
+        ]
+
+
+class _MattermostBot:
+    """A per-agent bot driver. It logs in and then parks in its websocket, as
+    the real one does — the identity path starts that thread as a daemon and
+    never joins it."""
+
+    def login(self) -> None:
+        return None
+
+    async def init_websocket(self, handler: Any) -> None:
+        await asyncio.Event().wait()
+
+
+def _mattermost_identity_adapter(
+    bridge: BridgeCore, bots: list[dict[str, Any]], name_display: str | None
+) -> tuple[MattermostAdapter, _MattermostAdmin]:
+    """An adapter wired for `create_agent_identity`: a fake admin driver, and
+    stubs for the icon upload (its own concern, covered elsewhere) and the bot
+    driver factory. `name_display` of None makes the config read fail, which is
+    what a non-admin bridge account sees."""
+    adapter = MattermostAdapter(
+        config=MattermostConnectionConfig(
+            url="http://mattermost.invalid",
+            admin_user="admin",
+            admin_password="pw",
+            team_name="team",
+        )
+    )
+    admin = _MattermostAdmin(bots, name_display)
+    adapter._admin_driver = admin  # type: ignore[assignment]
+    adapter._team_id = "team-1"
+    adapter.set_agent_presentation_resolver(bridge._agent_presentation)
+
+    async def set_bot_icon(bot_id: str, agent_name: str) -> None:
+        return None
+
+    adapter._set_bot_icon = set_bot_icon  # type: ignore[method-assign]
+    adapter._create_driver = lambda **kwargs: _MattermostBot()  # type: ignore[assignment,method-assign,return-value]
+    return adapter, admin
+
+
+def _create_mattermost_identity(adapter: MattermostAdapter, *agent_names: str) -> None:
+    async def _go() -> None:
+        adapter._main_loop = asyncio.get_running_loop()
+        for name in agent_names:
+            await adapter.create_agent_identity(name, "a Switch agent")
+
+    _run(_go())
+
+
+def test_mattermost_creates_the_bot_under_the_display_name() -> None:
+    bridge = _bridge(_agent("switchdev", "Switch Dev"))
+    adapter, admin = _mattermost_identity_adapter(bridge, [], "full_name")
+
+    _create_mattermost_identity(adapter, "switchdev")
+
+    assert admin.bodies("post", "/bots") == [
+        {
+            "username": "switchdev",
+            "display_name": "Switch Dev",
+            "description": "Switch agent: a Switch agent",
+        }
+    ]
+
+
+def test_a_mattermost_bot_username_is_never_the_display_name() -> None:
+    """The hazard the whole split exists for: a username is the routing handle
+    and is also constrained to lowercase alphanumerics, so a label like this
+    one would not even be a legal username."""
+    bridge = _bridge(_agent("switchdev", "Switch Dev (EMEA)"))
+    adapter, admin = _mattermost_identity_adapter(bridge, [], "full_name")
+
+    _create_mattermost_identity(adapter, "switchdev")
+
+    body = admin.bodies("post", "/bots")[0]
+    assert body is not None
+    assert body["username"] == "switchdev"
+    assert adapter._agent_bots["switchdev"]["username"] == "switchdev"
+    assert adapter._bot_id_to_username == {"bot-switchdev": "switchdev"}
+
+
+def test_a_mattermost_bot_display_name_is_not_escaped_for_message_text() -> None:
+    """`display_name` is a name field Mattermost renders on its own, so it
+    takes the label verbatim. Sending the body form instead would bake the
+    zero-width spaces that defuse markup into the stored name — invisible in a
+    diff, and permanent on the account."""
+    bridge = _bridge(_agent("switchdev", "Switch @ Dev [EMEA]"))
+    adapter, admin = _mattermost_identity_adapter(bridge, [], "full_name")
+
+    _create_mattermost_identity(adapter, "switchdev")
+
+    body = admin.bodies("post", "/bots")[0]
+    assert body is not None
+    assert body["display_name"] == "Switch @ Dev [EMEA]"
+    assert "​" not in body["display_name"]
+
+
+def test_a_mattermost_bot_falls_back_to_the_identifier() -> None:
+    bridge = _bridge(_agent("switchdev", None))
+    adapter, admin = _mattermost_identity_adapter(bridge, [], "full_name")
+
+    _create_mattermost_identity(adapter, "switchdev")
+
+    body = admin.bodies("post", "/bots")[0]
+    assert body is not None
+    assert body["display_name"] == "switchdev"
+
+
+def test_adopting_a_mattermost_bot_repairs_a_stale_display_name() -> None:
+    """The icon is re-applied on the adopt path as well as the create path, so
+    a renamed agent whose bot already exists must not be the one thing that
+    keeps its old name forever."""
+    existing = {
+        "user_id": "bot-switchdev",
+        "username": "switchdev",
+        "display_name": "Switch Dev",
+    }
+    bridge = _bridge(_agent("switchdev", "Switch Developer"))
+    adapter, admin = _mattermost_identity_adapter(bridge, [existing], "full_name")
+
+    _create_mattermost_identity(adapter, "switchdev")
+
+    assert admin.bodies("put", "/bots/bot-switchdev") == [
+        {"display_name": "Switch Developer"}
+    ]
+    assert admin.bodies("post", "/bots") == []
+
+
+def test_adopting_a_mattermost_bot_leaves_a_current_display_name_alone() -> None:
+    existing = {
+        "user_id": "bot-switchdev",
+        "username": "switchdev",
+        "display_name": "Switch Dev",
+    }
+    bridge = _bridge(_agent("switchdev", "Switch Dev"))
+    adapter, admin = _mattermost_identity_adapter(bridge, [existing], "full_name")
+
+    _create_mattermost_identity(adapter, "switchdev")
+
+    assert [m for m, _e, _o in admin.requests if m == "put"] == []
+
+
+def _name_display_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelname == "WARNING" and "TeammateNameDisplay" in r.getMessage()
+    ]
+
+
+def test_mattermost_warns_when_the_server_will_not_render_display_names(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`TeammateNameDisplay` defaults to "username", under which the display
+    name is stored and never seen. Setting it silently would be the degrade
+    that looks fine."""
+    bridge = _bridge(_agent("switchdev", "Switch Dev"))
+    adapter, _admin = _mattermost_identity_adapter(bridge, [], "username")
+
+    with caplog.at_level("WARNING"):
+        _create_mattermost_identity(adapter, "switchdev")
+
+    assert len(_name_display_warnings(caplog)) == 1
+    assert "will not appear in the post header" in _name_display_warnings(caplog)[0]
+
+
+def test_mattermost_does_not_warn_when_the_server_renders_display_names(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bridge = _bridge(_agent("switchdev", "Switch Dev"))
+    adapter, _admin = _mattermost_identity_adapter(bridge, [], "full_name")
+
+    with caplog.at_level("WARNING"):
+        _create_mattermost_identity(adapter, "switchdev")
+
+    assert _name_display_warnings(caplog) == []
+
+
+def test_mattermost_does_not_warn_when_no_agent_has_a_display_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Nothing to render, nothing to warn about — and no reason to ask the
+    server about a setting that changes nothing here."""
+    bridge = _bridge(_agent("switchdev", None))
+    adapter, admin = _mattermost_identity_adapter(bridge, [], "username")
+
+    with caplog.at_level("WARNING"):
+        _create_mattermost_identity(adapter, "switchdev")
+
+    assert _name_display_warnings(caplog) == []
+    assert [e for _m, e, _o in admin.requests if e == "/config"] == []
+
+
+def test_mattermost_reads_the_name_display_setting_once_per_run(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bridge = _bridge(_agent("switchdev", "Switch Dev"), _agent("opsbot", "Ops Bot"))
+    adapter, admin = _mattermost_identity_adapter(bridge, [], "username")
+
+    with caplog.at_level("WARNING"):
+        _create_mattermost_identity(adapter, "switchdev", "opsbot")
+
+    assert [e for _m, e, _o in admin.requests if e == "/config"] == ["/config"]
+    assert len(_name_display_warnings(caplog)) == 1
+
+
+def test_a_mattermost_bot_is_created_even_when_the_setting_cannot_be_read(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The server config is readable by a system admin only. Not knowing is
+    said out loud, and is not a reason to leave the agent without a bot."""
+    bridge = _bridge(_agent("switchdev", "Switch Dev"))
+    adapter, admin = _mattermost_identity_adapter(bridge, [], None)
+
+    with caplog.at_level("WARNING"):
+        _create_mattermost_identity(adapter, "switchdev")
+
+    body = admin.bodies("post", "/bots")[0]
+    assert body is not None
+    assert body["display_name"] == "Switch Dev"
+    assert "switchdev" in adapter._agent_bots
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelname == "WARNING" and "server config" in r.getMessage()
+    ]
+    assert len(warnings) == 1

--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
       MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
       MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
+      MM_TEAMSETTINGS_TEAMMATENAMEDISPLAY: "full_name"
       # Both of these exist for Switch Console's embedded room view (CHOO-1674):
       # the onboarding checklist opens a modal over a dimmed page inside the
       # pane, and Mattermost only turns known schemes into links, so without

--- a/deploy/local/standalone-docker-compose.yml
+++ b/deploy/local/standalone-docker-compose.yml
@@ -132,6 +132,7 @@ services:
       MM_SERVICESETTINGS_ENABLEBOTACCOUNTCREATION: "true"
       MM_SERVICESETTINGS_ENABLEUSERACCESSTOKENS: "true"
       MM_TEAMSETTINGS_ENABLEOPENSERVER: "true"
+      MM_TEAMSETTINGS_TEAMMATENAMEDISPLAY: "full_name"
       # Neither plugin is usable in a bundled Switch deployment: Copilot has no
       # configured provider and throws a 404 looking up its bot on every page
       # load, and Calls ships a WebRTC service nothing here can reach.

--- a/deploy/remote/helm/switch/templates/mattermost/deployment.yaml
+++ b/deploy/remote/helm/switch/templates/mattermost/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: "true"
             - name: MM_TEAMSETTINGS_ENABLEOPENSERVER
               value: "true"
+            - name: MM_TEAMSETTINGS_TEAMMATENAMEDISPLAY
+              value: "full_name"
             # For Switch Console's embedded room view (CHOO-1674): suppress the
             # onboarding modal, and linkify the `switchdash://` deeplinks
             # agents post. Kept in step with the standalone compose.


### PR DESCRIPTION
Stacked on #338. Two commits: the bridge change, then the deploy default.

## Why Mattermost needed its own PR

Every other platform lets a single bot post under a different name per
message. Mattermost doesn't — it gives **each agent its own bot account**, and
that account's username *is* the routing handle: the mention, the member-list
key, and how Switch re-adopts the bot after a restart. Usernames are also
3-22 chars, lowercase, no spaces, so "Switch Dev" cannot be one.

So the label goes on the bot's `display_name` and the username stays the
identifier, untouched.

Two things fall out of that:

- **Adoption was already broken.** When Switch re-adopts an existing bot it
  re-applies the icon but never touched the display name. Renaming an agent
  left the old label on the account forever. The adopt path now patches it
  when stale.
- **The name is a name field, not message text.** It takes the label
  verbatim, *not* the zero-width-defused body form. Sending the escaped form
  would bake invisible characters permanently into a stored account name —
  invisible in a diff, and there for good.

## The deploy commit

Mattermost renders a bot under its username unless `TeammateNameDisplay` says
otherwise, and the default says username. Without the second commit, Switch
writes "Switch Dev", the write succeeds, nothing errors, and every human still
reads `switchdev` — the silent-degradation case this repo explicitly forbids.

The bridge warns when it detects that (once, and only when a label would
actually be hidden). The deploy commit makes it *work* wherever Switch owns
the server: local compose, standalone compose, Helm chart, plus the pinned
copy Switch Console bundles — re-synced with the repo's own
`sync-standalone-compose.mjs`, whose `--check` mode gates CI and would have
failed the first three on their own.

**Reviewer note, deliberate trade-off:** `TeammateNameDisplay` is server-wide,
so human members of these deployments render under their full names too. And
because Mattermost freezes any setting supplied via env var, this becomes
fixed in the System Console rather than admin-editable. Both are consequences
worth accepting for the feature to do anything at all, but they are product
choices, not implementation details.

## Verification

Core: 2201 pass, ruff and mypy clean, compose drift check green.

I ran a controlled experiment against a real Mattermost 11.9.0 rather than
trusting the docs — same server, same bot, same post, only the setting
changed:

| `TeammateNameDisplay` | post header |
|---|---|
| `full_name` (this PR) | **Switch Dev** |
| `username` (stock) | **switchdev** |

The stored account record was identical in both — `username: "switchdev"`,
`first_name: "Switch Dev"`. That contrast is the entire argument for the
deploy commit.

I also mutation-tested the bridge commit. The one the suite initially missed:
swapping the verbatim label for the escaped body form passed all 1086 tests,
so I added `test_a_mattermost_bot_display_name_is_not_escaped_for_message_text`
to close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)