### PR TITLE
release: switch-core 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,32 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.22.1] - 2026-09-02
+
+#### Performance
+- **Agent Bridge no longer holds a database connection while doing other
+  work.** Under load the connection pool could be exhausted by slots checked
+  out and left idle in transaction, which surfaced as `QueuePool limit ...
+  connection timed out` and, because heartbeats share the same pool, as
+  fleet-wide agent loss. Three fixes: a request never takes a second pool
+  checkout while holding one (targeted messages to owner-only agents were the
+  common trigger); the message path collapses six checkouts to one on an
+  internal room and two on a bridged one; and authentication is taken off the
+  heartbeat path via a single outer join plus a narrow in-process cache of
+  resolved credentials (#351).
+
+#### Added
+- New operator settings for the above: `AGENT_AUTH_CACHE_TTL_SECONDS` and
+  `AGENT_AUTH_CACHE_MAX_ENTRIES` tune the credential cache (set the TTL to `0`
+  to disable it), and the opt-in `DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT`
+  (default off) turns a leaked idle-in-transaction slot into a loud error. All
+  three are exposed as Helm chart values (#351).
+
+#### Fixed
+- Rejoin the two Alembic migration heads left by the parallel 0.22.0 merges, so
+  `alembic upgrade head` is unambiguous again — deploys from main were failing
+  on the two heads (#351).
+
 ### [0.22.0] - 2026-09-02
 
 #### Added

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.22.0
+    version: 0.22.1
     declared_in: core/pyproject.toml
     published_as: switch-core
 

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.22.0',
+  'switch-core': '0.22.1',
   'switch-console': '0.31.3',
   'agent-runtime': '0.3.4',
   sidecar: '1.9.6',
-  gateway: '0.22.0',
-  setup: '0.22.0',
-  'helm-chart': '0.22.0',
-  compose: '0.22.0',
+  gateway: '0.22.1',
+  setup: '0.22.1',
+  'helm-chart': '0.22.1',
+  compose: '0.22.1',
   'switch-connector': '0.9.11',
   'switch-connector-codex': '0.3.12',
   'switch-connector-opencode': '0.1.7',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.22.0',
+  'switch-core': '0.22.1',
   'switch-console': '0.31.3',
   'agent-runtime': '0.3.4',
   sidecar: '1.9.6',
-  gateway: '0.22.0',
-  setup: '0.22.0',
-  'helm-chart': '0.22.0',
-  compose: '0.22.0',
+  gateway: '0.22.1',
+  setup: '0.22.1',
+  'helm-chart': '0.22.1',
+  compose: '0.22.1',
   'switch-connector': '0.9.11',
   'switch-connector-codex': '0.3.12',
   'switch-connector-opencode': '0.1.7',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.22.0"
+version = "0.22.1"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.22.0",
+    "switch-core": "0.22.1",
     "switch-console": "0.31.3",
     "agent-runtime": "0.3.4",
     "sidecar": "1.9.6",
-    "gateway": "0.22.0",
-    "setup": "0.22.0",
-    "helm-chart": "0.22.0",
-    "compose": "0.22.0",
+    "gateway": "0.22.1",
+    "setup": "0.22.1",
+    "helm-chart": "0.22.1",
+    "compose": "0.22.1",
     "switch-connector": "0.9.11",
     "switch-connector-codex": "0.3.12",
     "switch-connector-opencode": "0.1.7",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **switch-core 0.22.1** (patch).

Contents — #351 (agent-bridge connection-pool pressure fix):
- **Performance** — never take a second pool checkout while holding one; collapse the message path from 6 checkouts to 1/2; take Postgres off the heartbeat path via a single outer join + a narrow in-process credential cache.
- **Added** — operator knobs `AGENT_AUTH_CACHE_TTL_SECONDS`, `AGENT_AUTH_CACHE_MAX_ENTRIES`, opt-in `DB_IDLE_IN_TRANSACTION_SESSION_TIMEOUT` (default off), all exposed as Helm values.
- **Fixed** — rejoin the two Alembic migration heads left by the parallel 0.22.0 merges.

Bumped `core/pyproject.toml` + `artifacts.yaml`, regenerated the version modules (`just artifacts-check` green), cut the `## switch-core` changelog section. No wire/contract change. Migration: a merge revision (no new schema).

Package-only release — no GitHub Release will be created; the tag + changelog are the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)