### PR TITLE
gitignore: add .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,7 @@ __marimo__/
 related-projects
 .claude/settings.local.json
 .claude/agents/
+.claude/worktrees/
 
 # Switch Console working-tree artifacts. Build output and scratch downloads that
 # land at the repo root; ignored so they cannot be committed by accident.


### PR DESCRIPTION
## Summary

Add `.claude/worktrees/` to `.gitignore` so that agent worktree directories are not committable.

The `.gitignore` already covers `.claude/settings.local.json` and `.claude/agents/` but not `.claude/worktrees/`, which means agent worktree directories show up as untracked files and can be accidentally committed.

## Change

One line added to `.gitignore`:

```
.claude/worktrees/
```

## Verification

- `git check-ignore -q .claude/worktrees/` → exit 0 (ignored)
- `git check-ignore -q .claude/worktrees/somefile` → exit 0 (files inside ignored)
- `git ls-files .claude` → empty (no tracked files under `.claude/`)

Fixes #332