### PR TITLE
release: switch-core 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,30 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.23.0] - 2026-09-03
+
+#### Performance
+- **Matrix I/O no longer runs inside a database transaction.**
+  `add_agents_to_room`, `remove_agents_from_room` and `delete_room` each held a
+  connection-pool slot open across a fan-out of Matrix invites/kicks (up to 10s
+  per call), a major contributor to pool exhaustion under load. The three now
+  read short, commit, then do the Matrix work holding nothing — ordered so
+  Matrix membership can never exceed what the database records (a crash leaves
+  an under-privileged, repairable agent, never one silently reading a room
+  Switch has no record of) (#354).
+- **Per-client sync-cursor writes are staggered.** With one Matrix client per
+  participant (hundreds in a single process) and the throttle interval equal to
+  the sync long-poll, every client persisted its cursor in the same instant on
+  an idle instance — a periodic burst of concurrent one-row transactions that
+  starved the pool and cost heartbeats their connection. A sync that carried
+  nothing durable no longer earns a write, and the writes that remain no longer
+  align (#357).
+
+#### Changed
+- On the collaboration bridges, a turn that ends on an error now renders as the
+  stall it is — the reason is shown as why the turn stopped, not streamed as an
+  in-progress step under a spinner (#356).
+
 ### [0.22.1] - 2026-09-02
 
 #### Performance

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.22.1
+    version: 0.23.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.22.1',
+  'switch-core': '0.23.0',
   'switch-console': '0.31.3',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.22.1',
-  setup: '0.22.1',
-  'helm-chart': '0.22.1',
-  compose: '0.22.1',
+  gateway: '0.23.0',
+  setup: '0.23.0',
+  'helm-chart': '0.23.0',
+  compose: '0.23.0',
   'switch-connector': '0.9.11',
   'switch-connector-codex': '0.3.12',
   'switch-connector-opencode': '0.1.7',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.22.1',
+  'switch-core': '0.23.0',
   'switch-console': '0.31.3',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.22.1',
-  setup: '0.22.1',
-  'helm-chart': '0.22.1',
-  compose: '0.22.1',
+  gateway: '0.23.0',
+  setup: '0.23.0',
+  'helm-chart': '0.23.0',
+  compose: '0.23.0',
   'switch-connector': '0.9.11',
   'switch-connector-codex': '0.3.12',
   'switch-connector-opencode': '0.1.7',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.22.1"
+version = "0.23.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.22.1",
+    "switch-core": "0.23.0",
     "switch-console": "0.31.3",
     "agent-runtime": "0.4.1",
     "sidecar": "1.9.7",
-    "gateway": "0.22.1",
-    "setup": "0.22.1",
-    "helm-chart": "0.22.1",
-    "compose": "0.22.1",
+    "gateway": "0.23.0",
+    "setup": "0.23.0",
+    "helm-chart": "0.23.0",
+    "compose": "0.23.0",
     "switch-connector": "0.9.11",
     "switch-connector-codex": "0.3.12",
     "switch-connector-opencode": "0.1.7",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.22.1"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **switch-core 0.23.0** (minor).

- **Performance** — Matrix I/O moved out of RoomService transactions (#354); per-client sync-cursor writes staggered so they no longer burst-starve the pool (#357).
- **Changed** — collaboration bridges render a turn that ended on an error as a stall with its reason, not an in-progress step (#356).

Bumped `core/pyproject.toml` + `artifacts.yaml`, regenerated modules (`just artifacts-check` green), cut the `## switch-core` changelog. No wire/contract change. No new schema/migration.

Package-only release — no GitHub Release; the tag + changelog are the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)