### PR TITLE
release: switch-console 0.32.0 (+ sidecar, connectors, pins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1180,6 +1180,37 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.32.0] - 2026-09-03
+
+#### Added
+- **A session that dies on an API error now says so.** A Claude Code turn that
+  fails on expired credentials, quota or a provider outage fires `StopFailure`,
+  which nothing listened for — the channel just went quiet and the operator had
+  to open the TUI to find out why. It now maps onto the `error` status and
+  carries the reason through, so the deeplink ping names what broke instead of a
+  bare "needs your input" (#356).
+
+#### Changed
+- **Sidecar upgrades are taken under live sessions now, except a major.** A
+  sidecar whose build differed from the client's used to be left alone whenever
+  it owned a session and upgraded only once idle, so a busy host could sit on a
+  stale sidecar indefinitely. The upgrade (a few seconds of room injection) is
+  now taken while sessions run; a major bump still waits for idle (#356).
+- Registering an agent with a name that isn't accepted now offers a valid slug
+  instead of rejecting it, and shows the rejected-name message as an error
+  banner (#325).
+- Bundles agent-runtime 0.4.1 (deleted-room / heartbeat backoff fixes), sidecar
+  1.9.7 (reaps dead tmux targets), and the updated connectors (Claude Code
+  0.9.12, Codex 0.3.13, OpenCode 0.1.8).
+- **Local-server mode now bundles switch-core 0.23.0** (was 0.21.0) — the pinned
+  images and standalone compose it pulls move up to the current release.
+
+#### Fixed
+- An errored turn no longer reads as a fresh request for input: the stalled
+  prompt that follows a failure is suppressed so it doesn't bury the reason, and
+  on the Slack card the reason is marked as a stall rather than streamed under a
+  spinner as if it were progress (#356).
+
 ### [0.31.3] - 2026-09-01
 
 #### Added
@@ -2754,6 +2785,16 @@ by Switch Console rather than published on its own.
 
 ### [Unreleased]
 
+### [1.9.7] - 2026-09-03
+
+#### Fixed
+- Reap dead tmux targets so a pane whose tmux session has gone is not treated as
+  a live one (#336).
+
+#### Changed
+- Rebuilt on agent-runtime 0.4.1 (a deleted room no longer wedges the whole
+  connection, and the heartbeat backs off when the connection is rejected).
+
 ### [1.9.6] - 2026-09-01
 
 #### Changed
@@ -2849,6 +2890,14 @@ compatibility signal. History for those is in the git log.
 `.claude-plugin/plugin.json`.
 
 ### [Unreleased]
+
+### [0.9.12] - 2026-09-03
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.4.1` (was `0.3.4`) — a deleted room no
+  longer wedges the whole connection, and the heartbeat backs off when the
+  connection is rejected. Plugin version bumps so installs re-download.
+- Skill updated: documents user-defined external reference types and
+  `list_all_references` for discovering references across the instance.
 
 ### [0.9.11] - 2026-09-01
 #### Changed
@@ -3078,6 +3127,14 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.3.13] - 2026-09-03
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.4.1` (was `0.3.4`) — a deleted room no
+  longer wedges the whole connection, and the heartbeat backs off when the
+  connection is rejected. Plugin version bumps so installs re-download.
+- Skills updated: document user-defined external reference types and
+  `list_all_references` for discovering references across the instance.
+
 ### [0.3.12] - 2026-09-01
 #### Changed
 - Pin `@sandboxaq/switch-agent-runtime@0.3.4` (was `0.3.3`) — picks up reaping
@@ -3260,6 +3317,15 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.8] - 2026-09-03
+#### Changed
+- Pin `@sandboxaq/switch-agent-runtime@0.4.1` (was `0.3.4`) — a deleted room no
+  longer wedges the whole connection, and the heartbeat backs off when the
+  connection is rejected. (Delivered at the next Switch Console update, which
+  rewrites the embedded connector.)
+- Skill updated: documents user-defined external reference types and
+  `list_all_references` for discovering references across the instance.
 
 ### [0.1.7] - 2026-09-01
 #### Changed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.31.3
+    version: 0.32.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.21.0
+      switch-core: 0.23.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.11
+    version: 0.9.12
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.12
+    version: 0.3.13
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.7
+    version: 0.1.8
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/claude-code-plugin/.mcp.json
+++ b/connectors/claude-code-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.4"]
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.4.1"]
     }
   }
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/codex-plugin/.mcp.json
+++ b/connectors/codex-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "switch": {
       "command": "npx",
-      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.3.4"],
+      "args": ["-y", "@sandboxaq/switch-agent-runtime@0.4.1"],
       "env_vars": [
         "SWITCH_API_ENDPOINT",
         "SWITCH_API_TOKEN",

--- a/connectors/opencode-plugin/opencode.json
+++ b/connectors/opencode-plugin/opencode.json
@@ -3,7 +3,7 @@
   "mcp": {
     "switch": {
       "type": "local",
-      "command": ["npx", "-y", "@sandboxaq/switch-agent-runtime@0.3.4"],
+      "command": ["npx", "-y", "@sandboxaq/switch-agent-runtime@0.4.1"],
       "enabled": true,
       "timeout": 60000
     }

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.31.3",
+  "version": "0.32.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.21.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.23.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.21.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.23.0';

--- a/console/packages/plugins/src/distribution.ts
+++ b/console/packages/plugins/src/distribution.ts
@@ -27,4 +27,4 @@ export const SWITCH_MARKETPLACE_SOURCE = 'sandbox-quantum/switch';
  * has got to, which during a release is a version npm does not have yet. A
  * pin has to lag it deliberately, and the lag is the point.
  */
-export const SWITCH_AGENT_RUNTIME_PIN = '@sandboxaq/switch-agent-runtime@0.3.4';
+export const SWITCH_AGENT_RUNTIME_PIN = '@sandboxaq/switch-agent-runtime@0.4.1';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,16 +21,16 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.23.0',
-  'switch-console': '0.31.3',
+  'switch-console': '0.32.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
   gateway: '0.23.0',
   setup: '0.23.0',
   'helm-chart': '0.23.0',
   compose: '0.23.0',
-  'switch-connector': '0.9.11',
-  'switch-connector-codex': '0.3.12',
-  'switch-connector-opencode': '0.1.7',
+  'switch-connector': '0.9.12',
+  'switch-connector-codex': '0.3.13',
+  'switch-connector-opencode': '0.1.8',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,16 +21,16 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.23.0',
-  'switch-console': '0.31.3',
+  'switch-console': '0.32.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
   gateway: '0.23.0',
   setup: '0.23.0',
   'helm-chart': '0.23.0',
   compose: '0.23.0',
-  'switch-connector': '0.9.11',
-  'switch-connector-codex': '0.3.12',
-  'switch-connector-opencode': '0.1.7',
+  'switch-connector': '0.9.12',
+  'switch-connector-codex': '0.3.13',
+  'switch-connector-opencode': '0.1.8',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,16 +21,16 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.23.0",
-    "switch-console": "0.31.3",
+    "switch-console": "0.32.0",
     "agent-runtime": "0.4.1",
     "sidecar": "1.9.7",
     "gateway": "0.23.0",
     "setup": "0.23.0",
     "helm-chart": "0.23.0",
     "compose": "0.23.0",
-    "switch-connector": "0.9.11",
-    "switch-connector-codex": "0.3.12",
-    "switch-connector-opencode": "0.1.7",
+    "switch-connector": "0.9.12",
+    "switch-connector-codex": "0.3.13",
+    "switch-connector-opencode": "0.1.8",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {


### PR DESCRIPTION
Cuts **Switch Console 0.32.0** and the artifacts that ship with it.

**Switch Console 0.32.0** (minor)
- Surface a session's API errors with its deeplink; take sidecar upgrades under live sessions (except a major); slug-instead-of-reject registration UX; errored-turn fixes (#356, #325, #336).

**Cascade off agent-runtime 0.4.1**
- **sidecar 1.9.7** — reaps dead tmux targets, rebuilt on runtime 0.4.1 (ships inside Console; changelog only).
- **Connector plugins** re-pinned to runtime **0.4.1** and version-bumped so installs re-download: claude `0.9.12`, codex `0.3.13`, opencode `0.1.8` (incl. `distribution.ts` `SWITCH_AGENT_RUNTIME_PIN` for the app-written opencode connector).

**Bundled core pin moved 0.21.0 → 0.23.0**
- `artifacts.yaml` `switch-console.pins.switch-core` + `COMPATIBLE_SWITCH_VERSION` in `app-identity.ts` / `app-identity.canary.ts`; bundled standalone compose re-synced (already current). Local-server mode now pulls the current core release.

All versions mirrored in `artifacts.yaml` and regenerated (`just artifacts-check` green).

**Depends on:** agent-runtime `switch-agent-runtime-v0.4.1` (#358) published first, and switch-core `0.23.0` (#359) tagged first (the pin points at it). I'll rebase this on main after those merge, then tag `switch-console-v0.32.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)