### PR TITLE
Revert "docs: separate an agent's routing identifier from its display name"

### DIFF
--- a/connectors/claude-code-plugin/skills/configure/SKILL.md
+++ b/connectors/claude-code-plugin/skills/configure/SKILL.md
@@ -253,8 +253,7 @@ in one command, then reference it by name in the next.
 Switch validates the name against `^[a-z0-9][a-z0-9._-]*$` — lowercase letters,
 digits, dots, hyphens, underscores; must start with a letter or digit. **No
 spaces, no `@`, no uppercase.** The name is used in Matrix room handles and
-`@mention` syntax; an agent's human-readable display name is a separate
-optional field, so this one only has to route.
+`@mention` syntax.
 
 Suggest a default that **identifies the user**, not just the repo. Agent names
 are visible to everyone in the rooms the agent joins. If two developers both

--- a/connectors/claude-code-plugin/skills/switch/SKILL.md
+++ b/connectors/claude-code-plugin/skills/switch/SKILL.md
@@ -352,13 +352,6 @@ none of it is needed to take part in a conversation.
   sets the agent's parent (validated against self-parenting and cycles);
   `clear_parent=true` detaches it to top-level.
 
-**Address by `name`, not `display_name`.** `list_agents` and
-`get_agent_detail` return both. `name` is the machine identifier and the only
-one that routes: `target_names`, mentions and room aliases all take it.
-`display_name` is a free-form human label for showing an agent to a person, and
-is null when the agent has none — fall back to `name`. A `target_names` entry
-carrying a display name addresses no one.
-
 ### Creating rooms
 
 - **`list_bridges`** — the collaboration bridges configured on this instance:

--- a/connectors/codex-plugin/skills/configure/SKILL.md
+++ b/connectors/codex-plugin/skills/configure/SKILL.md
@@ -181,8 +181,7 @@ it, never write it to any file.
 Switch validates the name against `^[a-z0-9][a-z0-9._-]*$` — lowercase letters,
 digits, dots, hyphens, underscores; must start with a letter or digit. **No
 spaces, no `@`, no uppercase.** The name is used in Matrix room handles and
-`@mention` syntax; an agent's human-readable display name is a separate
-optional field, so this one only has to route.
+`@mention` syntax.
 
 Suggest a default that **identifies the user**, not just the repo. Agent names
 are visible to everyone in the rooms the agent joins. If two developers both

--- a/connectors/codex-plugin/skills/switch/SKILL.md
+++ b/connectors/codex-plugin/skills/switch/SKILL.md
@@ -350,13 +350,6 @@ none of it is needed to take part in a conversation.
   sets the agent's parent (validated against self-parenting and cycles);
   `clear_parent=true` detaches it to top-level.
 
-**Address by `name`, not `display_name`.** `list_agents` and
-`get_agent_detail` return both. `name` is the machine identifier and the only
-one that routes: `target_names`, mentions and room aliases all take it.
-`display_name` is a free-form human label for showing an agent to a person, and
-is null when the agent has none — fall back to `name`. A `target_names` entry
-carrying a display name addresses no one.
-
 ### Creating rooms
 
 - **`list_bridges`** — the collaboration bridges configured on this instance:

--- a/connectors/opencode-plugin/skills/switch/SKILL.md
+++ b/connectors/opencode-plugin/skills/switch/SKILL.md
@@ -358,13 +358,6 @@ none of it is needed to take part in a conversation.
   sets the agent's parent (validated against self-parenting and cycles);
   `clear_parent=true` detaches it to top-level.
 
-**Address by `name`, not `display_name`.** `list_agents` and
-`get_agent_detail` return both. `name` is the machine identifier and the only
-one that routes: `target_names`, mentions and room aliases all take it.
-`display_name` is a free-form human label for showing an agent to a person, and
-is null when the agent has none — fall back to `name`. A `target_names` entry
-carrying a display name addresses no one.
-
 ### Creating rooms
 
 - **`list_bridges`** — the collaboration bridges configured on this instance:

--- a/console/packages/plugins/src/agents/impl/opencode/skill-file.ts
+++ b/console/packages/plugins/src/agents/impl/opencode/skill-file.ts
@@ -366,13 +366,6 @@ none of it is needed to take part in a conversation.
   sets the agent's parent (validated against self-parenting and cycles);
   \`clear_parent=true\` detaches it to top-level.
 
-**Address by \`name\`, not \`display_name\`.** \`list_agents\` and
-\`get_agent_detail\` return both. \`name\` is the machine identifier and the only
-one that routes: \`target_names\`, mentions and room aliases all take it.
-\`display_name\` is a free-form human label for showing an agent to a person, and
-is null when the agent has none — fall back to \`name\`. A \`target_names\` entry
-carrying a display name addresses no one.
-
 ### Creating rooms
 
 - **\`list_bridges\`** — the collaboration bridges configured on this instance:

--- a/core/switch_core/bridges/agent/operations/definitions.py
+++ b/core/switch_core/bridges/agent/operations/definitions.py
@@ -1557,8 +1557,6 @@ async def list_agents(
         known_agent_options}.
         `icon_url` is null when the agent has no icon set. `display_name` is
         null when the agent has no display name set; fall back to `name`.
-        Address agents by `name`: `display_name` is a human label that routes
-        nothing, and `name_contains` matches `name` alone.
         Use `get_agent_detail` for the full detail of one agent.
     """
     agent_id = get_agent_id()
@@ -1587,7 +1585,6 @@ async def get_agent_detail(agent_id: str) -> dict[str, Any]:
         rooms, sessions, children}.
         `icon_url` is null when the agent has no icon set. `display_name` is
         null when the agent has no display name set; fall back to `name`.
-        Address agents by `name`; `display_name` routes nothing.
     """
     caller_id = get_agent_id()
     protocol = get_protocol()

--- a/docs/old/ARCHITECTURE.md
+++ b/docs/old/ARCHITECTURE.md
@@ -118,11 +118,8 @@ The relational schema is defined in
 
 - **User** — a human principal; `role == "admin"` is a global authorization
   bypass. **ExternalUser** maps a platform identity (Slack/etc.) to a puppet.
-- **Agent** — a registered AI agent, owned by a User. Its `name` is a lowercase
-  identifier and the routing key everything addresses it by (mentions, Matrix
-  handle, per-platform handles), while the optional `display_name` is
-  presentation only and falls back to `name`. An agent inherits exactly its
-  owner's permissions. **AgentSession** / **AgentRuntimeState** track a live
+- **Agent** — a registered AI agent, owned by a User. An agent inherits exactly
+  its owner's permissions. **AgentSession** / **AgentRuntimeState** track a live
   session and its surfaced state (working / needs-input).
 - **ApiKey** — a hashed credential, of type `"agent"` or `"registration"`.
 - **Client** / **ClientRoom** — the Matrix client backing each participant and

--- a/docs/old/bridges/DISCORD_SETUP.md
+++ b/docs/old/bridges/DISCORD_SETUP.md
@@ -2,11 +2,9 @@
 
 Connects a Discord server (**guild**) to Switch. A **single bot application**
 backs every Switch agent; per-agent presentation is done with **per-channel
-webhooks** (Discord webhooks accept a per-message username and avatar), the
-username carrying the agent's display name or its identifier when it has none.
-Inbound events arrive over an outbound **Gateway WebSocket** scoped to the
-configured guild, so **no public ingress is required**; outbound goes through
-the REST API.
+webhooks** (Discord webhooks accept a per-message username and avatar). Inbound
+events arrive over an outbound **Gateway WebSocket** scoped to the configured
+guild, so **no public ingress is required**; outbound goes through the REST API.
 
 Rooms are provisioned **lazily**: Discord has no "app invited to channel" signal
 (the bot sees every channel its permissions allow), so a channel's Switch room is
@@ -89,11 +87,10 @@ the first bridged message.
 An agent is not a Discord member — one bot serves all of them, differentiated
 per message by a webhook override — so by default nothing Discord knows about
 carries an agent's name and typing `@` never offers one. With this on, each
-agent gets a **mentionable role named exactly after its identifier** — the
-lowercase name, not the agent's display name — so `@flint-tracker` completes in
-the composer and arrives as a real pill. The role is empty and carries no
-permissions: mentioning it notifies nobody, and Switch resolves the mention back
-to the agent's name on the way in.
+agent gets a **mentionable role named exactly after it**, so `@flint-tracker`
+completes in the composer and arrives as a real pill. The role is empty and
+carries no permissions: mentioning it notifies nobody, and Switch resolves the
+mention back to the agent's name on the way in.
 
 Roles are provisioned for every existing agent when the bridge starts, and for
 each new agent as it registers. Two limits are worth knowing before you turn it
@@ -103,13 +100,12 @@ on:
   one warning naming it, and the bridge stops trying — agents stay addressable
   by typing their name.
 - **A role carries no metadata**, so there is nowhere to record that a role
-  belongs to Switch. An agent's role is therefore the one whose name matches the
-  agent's **identifier** exactly — never its display name, so a role made under
-  a display name belongs to no agent and autocompletes nothing. Two
-  consequences: a role you created by hand for an agent is adopted rather than
-  duplicated (which is how to use this on a server where the bot may not manage
-  roles), and when an agent is deleted its role is only deleted if **nobody
-  holds it** — one with members is left in place, and the bridge says so.
+  belongs to Switch. An agent's role is therefore the one whose name matches it
+  **exactly**. Two consequences: a role you created by hand for an agent is
+  adopted rather than duplicated (which is how to use this on a server where
+  the bot may not manage roles), and when an agent is deleted its role is only
+  deleted if **nobody holds it** — one with members is left in place, and the
+  bridge says so.
 
 Renaming an agent leaves its old role behind; delete it by hand.
 

--- a/docs/old/bridges/MATTERMOST_SETUP.md
+++ b/docs/old/bridges/MATTERMOST_SETUP.md
@@ -21,15 +21,6 @@ required**.
 2. Have (or create) the **admin** user the bridge will authenticate as, and the
    **team** (its URL name / slug) that channels will be created under.
 3. Make sure the admin can create channels and manage members on that team.
-4. Set **Teammate Name Display** to *Show first and last name* (System Console →
-   Site Configuration → Users and Teams → Teammate Name Display, or
-   `TeamSettings.TeammateNameDisplay` = `full_name`; `nickname_full_name` works
-   too). Mattermost's default is `username`, under which every account is
-   rendered by its username and an agent's display name is stored but never
-   shown. The setting is **server-wide** — it changes how human members' names
-   render as well, so it is a decision for the server, not for Switch. Switch's
-   own Mattermost deployments (the local and standalone compose stacks and the
-   Helm chart) set it; a server you bring yourself does not.
 
 ## 2. Onboard the bridge in Switch
 
@@ -74,15 +65,7 @@ don't onboard Mattermost by hand — it's already there after setup. Log in at
 ## Notes
 
 - **Identity.** Each agent gets its own Mattermost bot account, so agent messages
-  appear as distinct users (not a single relayed bot). The bot's **username** is
-  the agent's identifier — the handle a mention resolves, and the key the bridge
-  finds an existing bot back by — and the bot account's own display-name field
-  carries the agent's display name, falling back to the identifier. A bot whose
-  display name has drifted from the agent's is corrected when the bridge adopts
-  it. Whether Mattermost shows any of it is the **Teammate Name Display** server
-  setting from [step 1](#1-prepare-the-mattermost-server); the bridge logs one
-  warning when it writes an agent display name on a server whose setting would
-  hide it.
+  appear as distinct users (not a single relayed bot).
 - **DMs.** Switch-initiated DM rooms are user-initiated on Mattermost — a user
   starts the DM with the agent's bot and Switch picks it up.
 - **Deeplinks.** Set `GATEWAY_PUBLIC_URL` on switch-core for clickable "Open in
@@ -107,10 +90,9 @@ Three signals, in order of how long they last. Nothing here needs configuring.
   progress signal.
 
 **What Mattermost cannot do.** There is no equivalent of Slack's native AI
-progress card — the live panel that streams what an agent is doing under the
-agent's own name and icon. The one thing in Mattermost that looks like it, the
-"thinking" UI in Mattermost's own
-[Agents plugin](https://github.com/mattermost/mattermost-plugin-agents),
+progress card — the live panel that streams what an agent is doing under its own
+name. The one thing in Mattermost that looks like it, the "thinking" UI in
+Mattermost's own [Agents plugin](https://github.com/mattermost/mattermost-plugin-agents),
 is not a platform feature: progress travels over a plugin-private websocket
 event and is drawn by a webapp bundle that plugin registers. Neither half is
 reachable from a bot token or the REST API, and ephemeral posts cannot be edited

--- a/docs/old/bridges/README.md
+++ b/docs/old/bridges/README.md
@@ -4,9 +4,8 @@ A **collaboration bridge** is a two-way relay between an external chat platform
 (Slack, Mattermost, Microsoft Teams, Discord, Telegram) and Switch's internal Matrix
 rooms. Humans talk in their normal chat client; Switch agents see those messages
 as room events and reply back into the same channel. Each external channel maps
-to a Switch room, and each Switch agent is presented in the channel under the
-agent's own display name and avatar, as far as the platform's identity model
-allows.
+to a Switch room, and each Switch agent is presented in the channel under its own
+name and avatar.
 
 This directory documents how to set up each bridge. Read this page first for the
 shared onboarding model, then the per-platform guide:
@@ -17,7 +16,7 @@ shared onboarding model, then the per-platform guide:
 | Mattermost | [`MATTERMOST_SETUP.md`](MATTERMOST_SETUP.md) | one bot account per agent | WebSocket (outbound) | not required |
 | Microsoft Teams | [`TEAMS_SETUP.md`](TEAMS_SETUP.md) | single Azure bot app | HTTP push (Bot Framework + Graph) | **required** |
 | Discord | [`DISCORD_SETUP.md`](DISCORD_SETUP.md) | single bot app | Gateway WebSocket (outbound) | not required |
-| Telegram | [`TELEGRAM_SETUP.md`](TELEGRAM_SETUP.md) | single bot, agent named in the message body | long polling (outbound) | not required |
+| Telegram | [`TELEGRAM_SETUP.md`](TELEGRAM_SETUP.md) | single bot, name in the message body | long polling (outbound) | not required |
 
 ## The onboarding model (same for every bridge)
 
@@ -43,18 +42,6 @@ pick the chat, confirm, done. Telegram has one, for groups; the other platforms
 show nothing, and their app is installed through the platform's own admin UI as
 their guide describes. The links are built by the running bridge, so they appear
 only while it is up, and only for an admin.
-
-### The two names an agent has
-
-An agent has a **name** — a lowercase identifier such as `flint-tracker` — and,
-optionally, a free-form **display name** such as "Flint Tracker". The identifier
-is the routing key and the only thing that addresses anything: mentions,
-in-room command arguments, and the per-agent handles a bridge mints (Slack user
-groups, Discord roles, Mattermost bot usernames) are all built from it. The
-agent's display name is presentation only — the name a bridged message is
-attributed to, wherever the platform gives Switch somewhere to put it. An agent
-with no display name is presented under its identifier, so the two coincide
-until one is set. Each guide says where its platform renders the display name.
 
 ### Registered bridge types
 

--- a/docs/old/bridges/SLACK_SETUP.md
+++ b/docs/old/bridges/SLACK_SETUP.md
@@ -175,9 +175,7 @@ from-scratch path and as a reference for what the app needs.
 Under **OAuth & Permissions → Scopes → Bot Token Scopes**:
 
 - `chat:write`, `chat:write.customize` — post agent messages, with the
-  per-message username + avatar override each agent is presented under. The
-  username carries the agent's display name, or its identifier when it has
-  none.
+  per-message username + avatar override each agent is presented under.
 - `commands` — the `/…` slash commands.
 - `channels:read`, `channels:manage` — look up, create, set topic on, and invite
   into public channels; `groups:read`, `groups:write` — the same for private
@@ -214,10 +212,9 @@ rather than a scope you tick.
 
 ### Agent name autocomplete (`agent_usergroups`)
 
-**On by default.** Every agent gets a Slack **user group** whose handle is the
-agent's identifier — the lowercase name a mention has to use, never the agent's
-display name. Set `agent_usergroups: false` in the bridge's connection config to
-turn it off.
+**On by default.** Every agent gets a Slack **user group** whose handle is its
+name. Set `agent_usergroups: false` in the bridge's connection config to turn
+it off.
 
 This is a workaround and worth naming as one: Slack offers no way to make an
 app's agents mentionable, so Switch borrows the one mentionable object an app
@@ -237,12 +234,9 @@ their description and ignores the workspace's own.
 
 **Groups made by hand are adopted.** Where a workspace will not let the bot
 create them, making them manually is the only way to use the feature — so a
-group whose **handle or name is exactly an agent's identifier** is taken to be
-that agent's, and the marker is stamped on it. The match is exact, so a
-workspace group is never captured by an agent that happens to be named
-similarly. It is also against the identifier and nothing else: a group made
-under an agent's **display name** matches no agent, is left alone, and leaves
-that agent without autocomplete.
+group whose **handle or name is exactly an agent's name** is taken to be that
+agent's, and the marker is stamped on it. The match is exact, so a workspace
+group is never captured by an agent that happens to be named similarly.
 
 Two things gate it, both outside Switch:
 

--- a/docs/old/bridges/TEAMS_SETUP.md
+++ b/docs/old/bridges/TEAMS_SETUP.md
@@ -2,8 +2,7 @@
 
 Connects a Microsoft Teams tenant to Switch. A **single Azure bot app** backs
 every Switch agent (like Slack); each agent's messages render as an **Adaptive
-Card** headed with the agent's display name — its identifier where it has
-none — and avatar.
+Card** headed with the agent's name and avatar.
 
 Teams is the most involved bridge to set up. Unlike Slack or Mattermost it has
 no persistent socket, so it is **push-based**: Microsoft calls Switch, not the

--- a/docs/old/bridges/TELEGRAM_SETUP.md
+++ b/docs/old/bridges/TELEGRAM_SETUP.md
@@ -3,10 +3,9 @@
 Connects Telegram groups and channels to Switch. A **single bot** backs every
 Switch agent. Telegram has **no per-message identity override** — nothing like a
 Discord webhook's username/avatar — so an agent is identified by its **name
-rendered at the head of each message**: the agent's display name, or its
-identifier where it has none. Addressing runs the other way and is always by
-identifier. Inbound events arrive by **long polling** (an outbound connection),
-so **no public ingress is required**; outbound goes through the Bot API.
+rendered at the head of each message**. Inbound events arrive by **long polling**
+(an outbound connection), so **no public ingress is required**; outbound goes
+through the Bot API.
 
 Rooms are **adopted, never created**: the Bot API gives a bot no way to create a
 chat. A chat's Switch room is provisioned when the bot is **added to the group**
@@ -260,8 +259,7 @@ bare.
 Rather than answer that with a usage line — whose only route out is to type the
 whole command by hand, which is what the menu was for — the bot asks for what
 is missing and Telegram opens the composer already replying to it. Answer with
-the agent's identifier alone — the same name `@agent-name` uses, not the agent's
-display name — and the command runs:
+the agent's name alone and the command runs:
 
 > **/invite_agent** needs one more thing — the registered agent to add to this
 > room.


### PR DESCRIPTION
Reverts sandbox-quantum/switch#347