### PR TITLE
release: switch-core 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,35 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.24.0] - 2026-09-06
+
+#### Security
+- Mattermost connections verify TLS by default; disabling it is now an explicit
+  opt-in (#294).
+- OIDC logins are bound to the identity provider's `(iss, sub)` pair rather than
+  email, so a changed or reused email address can no longer take over an account
+  (#291).
+- Room roster changes are gated on room membership, not on a resource's
+  write-visibility (#292).
+- Room-scoped resource endpoints now require access to the room (#293).
+- Agent registration and re-registration are confined to the owner's tenant, and
+  re-registration cannot overwrite an agent owned by someone else (#290).
+
+#### Changed
+- **Internal message transport moved to Postgres `LISTEN`/`NOTIFY`.** The
+  message/notify path and event cursors are served from Postgres instead of
+  Matrix, which is kept alongside for now. Ships a database migration
+  (`message_notify_and_cursors`) (#363).
+
+#### Added
+- Agents render under their human display name on every collaboration bridge,
+  defused so an agent still never sees its own echo (#330).
+
+#### Fixed
+- `!command` now resolves `@mentions` and runs code-wrapped commands, matching
+  `/command` behaviour — both had broken once agents gained autocomplete user
+  groups (#313).
+
 ### [0.23.0] - 2026-09-03
 
 #### Performance

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.23.0
+    version: 0.24.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.23.0',
+  'switch-core': '0.24.0',
   'switch-console': '0.32.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.23.0',
-  setup: '0.23.0',
-  'helm-chart': '0.23.0',
-  compose: '0.23.0',
+  gateway: '0.24.0',
+  setup: '0.24.0',
+  'helm-chart': '0.24.0',
+  compose: '0.24.0',
   'switch-connector': '0.9.12',
   'switch-connector-codex': '0.3.13',
   'switch-connector-opencode': '0.1.8',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.23.0',
+  'switch-core': '0.24.0',
   'switch-console': '0.32.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.23.0',
-  setup: '0.23.0',
-  'helm-chart': '0.23.0',
-  compose: '0.23.0',
+  gateway: '0.24.0',
+  setup: '0.24.0',
+  'helm-chart': '0.24.0',
+  compose: '0.24.0',
   'switch-connector': '0.9.12',
   'switch-connector-codex': '0.3.13',
   'switch-connector-opencode': '0.1.8',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.23.0"
+version = "0.24.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.23.0",
+    "switch-core": "0.24.0",
     "switch-console": "0.32.0",
     "agent-runtime": "0.4.1",
     "sidecar": "1.9.7",
-    "gateway": "0.23.0",
-    "setup": "0.23.0",
-    "helm-chart": "0.23.0",
-    "compose": "0.23.0",
+    "gateway": "0.24.0",
+    "setup": "0.24.0",
+    "helm-chart": "0.24.0",
+    "compose": "0.24.0",
     "switch-connector": "0.9.12",
     "switch-connector-codex": "0.3.13",
     "switch-connector-opencode": "0.1.8",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **switch-core 0.24.0** (minor).

- **Security** — Mattermost TLS verified by default (#294); OIDC bound to (iss, sub) (#291); room roster gated on membership (#292); room-scoped resource endpoints require room access (#293); registration/re-registration confined to owner's tenant (#290).
- **Changed** — internal message transport moved to Postgres LISTEN/NOTIFY (Matrix kept alongside); ships a DB migration (#363).
- **Added** — agents render under their display name on every bridge (#330).
- **Fixed** — `!command` resolves @mentions and runs code-wrapped commands (#313).

Bumped `core/pyproject.toml` + `artifacts.yaml`, regenerated modules (`just artifacts-check` green), cut the `## switch-core` changelog. Contracts left unchanged (agent↔runtime wire stable; no artifacts.yaml contract edits).

Package-only release — no GitHub Release; the tag + changelog are the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)