### PR TITLE
release: switch-console 0.33.0 (+ connectors, core pin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1209,6 +1209,23 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.33.0] - 2026-09-06
+
+#### Added
+- **Local control API for programmatic agent management.** A localhost-only,
+  token-gated HTTP server in the main process (127.0.0.1 on an OS-assigned port,
+  credentials in a 0600 file in the app data dir) exposes the same
+  agent-management operations as the UI — list/read agents, list an agent's
+  sessions, and start a session (#362).
+
+#### Changed
+- Agent names are auto-lowercased as you type in the New Agent dialog, matching
+  the identifier rules (rather than rejecting after the fact).
+- Local-server mode now bundles **switch-core 0.24.0** (was 0.23.0), and picks
+  up the internal Postgres LISTEN/NOTIFY transport client-side (#363).
+- Refreshes the connectors so installs pick up the display-name skill updates
+  (Claude Code 0.9.13, Codex 0.3.14, OpenCode 0.1.9).
+
 ### [0.32.0] - 2026-09-03
 
 #### Added
@@ -2920,6 +2937,12 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
+### [0.9.13] - 2026-09-06
+#### Changed
+- Skills updated for agent display names: the switch and configure skills note
+  that agents may render under a human display name on the bridges (#330).
+  Plugin version bumps so installs re-download.
+
 ### [0.9.12] - 2026-09-03
 #### Changed
 - Pin `@sandboxaq/switch-agent-runtime@0.4.1` (was `0.3.4`) — a deleted room no
@@ -3156,6 +3179,12 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.3.14] - 2026-09-06
+#### Changed
+- Skills updated for agent display names: the switch and configure skills note
+  that agents may render under a human display name on the bridges (#330).
+  Plugin version bumps so installs re-download.
+
 ### [0.3.13] - 2026-09-03
 #### Changed
 - Pin `@sandboxaq/switch-agent-runtime@0.4.1` (was `0.3.4`) — a deleted room no
@@ -3346,6 +3375,12 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.9] - 2026-09-06
+#### Changed
+- Skill updated for agent display names: the switch skill notes that agents may
+  render under a human display name on the bridges (#330). (Delivered at the
+  next Switch Console update, which rewrites the embedded connector.)
 
 ### [0.1.8] - 2026-09-03
 #### Changed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.32.0
+    version: 0.33.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.23.0
+      switch-core: 0.24.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.12
+    version: 0.9.13
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.13
+    version: 0.3.14
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.8
+    version: 0.1.9
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.23.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.24.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,4 +60,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.23.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.24.0';

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,16 +21,16 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.24.0',
-  'switch-console': '0.32.0',
+  'switch-console': '0.33.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
   gateway: '0.24.0',
   setup: '0.24.0',
   'helm-chart': '0.24.0',
   compose: '0.24.0',
-  'switch-connector': '0.9.12',
-  'switch-connector-codex': '0.3.13',
-  'switch-connector-opencode': '0.1.8',
+  'switch-connector': '0.9.13',
+  'switch-connector-codex': '0.3.14',
+  'switch-connector-opencode': '0.1.9',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,16 +21,16 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.24.0',
-  'switch-console': '0.32.0',
+  'switch-console': '0.33.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
   gateway: '0.24.0',
   setup: '0.24.0',
   'helm-chart': '0.24.0',
   compose: '0.24.0',
-  'switch-connector': '0.9.12',
-  'switch-connector-codex': '0.3.13',
-  'switch-connector-opencode': '0.1.8',
+  'switch-connector': '0.9.13',
+  'switch-connector-codex': '0.3.14',
+  'switch-connector-opencode': '0.1.9',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,16 +21,16 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.24.0",
-    "switch-console": "0.32.0",
+    "switch-console": "0.33.0",
     "agent-runtime": "0.4.1",
     "sidecar": "1.9.7",
     "gateway": "0.24.0",
     "setup": "0.24.0",
     "helm-chart": "0.24.0",
     "compose": "0.24.0",
-    "switch-connector": "0.9.12",
-    "switch-connector-codex": "0.3.13",
-    "switch-connector-opencode": "0.1.8",
+    "switch-connector": "0.9.13",
+    "switch-connector-codex": "0.3.14",
+    "switch-connector-opencode": "0.1.9",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {


### PR DESCRIPTION
Cuts **Switch Console 0.33.0** and the connector plugins that ship with it.

**Switch Console 0.33.0** (minor)
- Local control API for programmatic agent management (#362); client-side Postgres LISTEN/NOTIFY transport (#363); auto-lowercase agent name in the New Agent dialog.

**Connector plugins** — all three bumped for the #330 display-name skill updates so installs re-download (no runtime-pin change): claude `0.9.13`, codex `0.3.14`, opencode `0.1.9`.

**Bundled core pin moved 0.23.0 → 0.24.0** — `artifacts.yaml` pin + `COMPATIBLE_SWITCH_VERSION` in `app-identity.ts`/`.canary.ts`; compose re-synced (already current).

All versions mirrored in `artifacts.yaml` and regenerated (`just artifacts-check` green).

**Depends on:** switch-core `0.24.0` (#376) tagged first (the pin points at it). I'll rebase this on main after #376 merges, then tag `switch-console-v0.33.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)