### PR TITLE
release: switch-core 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.24.1] - 2026-09-06
+
+#### Changed
+- The one-time history backfill now carries a bounded amount of each room's
+  history — 50 messages per room, newest first, instead of walking every room
+  to its start (an unbounded migration that could never finish on a busy,
+  long-lived channel and ran at boot with switch-core waiting on it). Override
+  with `--messages-per-room` (`0` restores the old full walk). A capped room is
+  marked backfilled and reported as `capped`, not `incomplete` (#379).
+
 ### [0.24.0] - 2026-09-06
 
 #### Security

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.24.0
+    version: 0.24.1
     declared_in: core/pyproject.toml
     published_as: switch-core
 

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.24.0',
+  'switch-core': '0.24.1',
   'switch-console': '0.33.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.24.0',
-  setup: '0.24.0',
-  'helm-chart': '0.24.0',
-  compose: '0.24.0',
+  gateway: '0.24.1',
+  setup: '0.24.1',
+  'helm-chart': '0.24.1',
+  compose: '0.24.1',
   'switch-connector': '0.9.13',
   'switch-connector-codex': '0.3.14',
   'switch-connector-opencode': '0.1.9',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.24.0',
+  'switch-core': '0.24.1',
   'switch-console': '0.33.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.24.0',
-  setup: '0.24.0',
-  'helm-chart': '0.24.0',
-  compose: '0.24.0',
+  gateway: '0.24.1',
+  setup: '0.24.1',
+  'helm-chart': '0.24.1',
+  compose: '0.24.1',
   'switch-connector': '0.9.13',
   'switch-connector-codex': '0.3.14',
   'switch-connector-opencode': '0.1.9',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.24.0"
+version = "0.24.1"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.24.0",
+    "switch-core": "0.24.1",
     "switch-console": "0.33.0",
     "agent-runtime": "0.4.1",
     "sidecar": "1.9.7",
-    "gateway": "0.24.0",
-    "setup": "0.24.0",
-    "helm-chart": "0.24.0",
-    "compose": "0.24.0",
+    "gateway": "0.24.1",
+    "setup": "0.24.1",
+    "helm-chart": "0.24.1",
+    "compose": "0.24.1",
     "switch-connector": "0.9.13",
     "switch-connector-codex": "0.3.14",
     "switch-connector-opencode": "0.1.9",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2445,7 +2445,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **switch-core 0.24.1** (patch).

- **Changed** — the one-time history backfill now carries a bounded 50 messages per room (newest first) instead of an unbounded walk to each room's start; override with `--messages-per-room` (`0` = old behaviour). A capped room is marked backfilled and reported as `capped`, not `incomplete` (#379).

Bumped `core/pyproject.toml` + `artifacts.yaml`, regenerated (`just artifacts-check` green), cut the `## switch-core` changelog. No migration, no contract change, no cascade (core-only).

Package-only release — no GitHub Release; the tag + changelog are the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)