### PR TITLE
fix(mcp): preserve operation return docs

### DIFF
--- a/core/switch_core/bridges/agent/mcp/server.py
+++ b/core/switch_core/bridges/agent/mcp/server.py
@@ -84,7 +84,7 @@ mcp.add_middleware(CallContextMiddleware())
 # Every operation, registered as a tool. This loop is the only thing that makes
 # an operation an MCP tool, so the two surfaces cannot diverge.
 for _op in all_operations().values():
-    mcp.tool(_op.fn)
+    mcp.tool(_op.fn, description=_op.description)
 
 logger.debug("Registered %d operations as MCP tools", len(all_operations()))
 

--- a/core/tests/switch_core/bridges/agent/test_mcp_tool_surface.py
+++ b/core/tests/switch_core/bridges/agent/test_mcp_tool_surface.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from switch_core.bridges.agent.mcp.server import mcp
+from switch_core.bridges.agent.operations import all_operations
 
 TASK_PROTOCOL_TOOLS = {
     "delegate_task",
@@ -85,6 +86,14 @@ async def test_documented_tools_exist(tool_names: set[str]) -> None:
     assert documented <= tool_names, (
         f"documented but not registered: {sorted(documented - tool_names)}"
     )
+
+
+async def test_tool_descriptions_preserve_the_full_operation_contract() -> None:
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    operation = all_operations()["list_agents"]
+
+    assert tools[operation.name].description == operation.description
+    assert "Returns:" in tools[operation.name].description
 
 
 SKILLS = sorted(


### PR DESCRIPTION
## Summary

- pass each registry operation’s full description explicitly to FastMCP
- preserve `Returns:` contracts on the MCP surface without changing generated input schemas
- add focused coverage comparing the MCP description with the source operation contract

## Testing

- `uv run --project core ruff format --check .`
- `uv run --project core ruff check .`
- `uv run --project core mypy --config-file core/pyproject.toml core/switch_core/ connectors/`
- `uv run --project core pytest -c core/pyproject.toml core/tests/switch_core/bridges/agent/test_mcp_tool_surface.py core/tests/switch_core/bridges/agent/api/test_operations.py -q` (20 passed)

The full non-integration test command reached 2,145 passing tests; 504 database-backed tests could not initialize because no Docker daemon is available in this environment.

Closes #348