### PR TITLE
feat(messages): recover recent room history from Slack

### DIFF
--- a/core/switch_core/cli/slack_backfill.py
+++ b/core/switch_core/cli/slack_backfill.py
@@ -1,0 +1,147 @@
+"""Recover recent room history from Slack instead of the message bus.
+
+The bus backfill reads the homeserver, which is both hard on it and impossible
+once it is gone. For a bridged room Slack holds the same conversation and holds
+it first, so the history can come from there with the homeserver untouched.
+
+Only Slack bridges are covered, deliberately: they are where the history worth
+keeping is, and a room bridged to nothing was never on a platform to read back.
+
+Rows are numbered below zero exactly as the bus backfill numbers them, so
+nothing is redelivered and no cursor moves. Messages the bridge relayed keep
+the event id Switch already gave them.
+
+Safe to re-run: an id is either already recorded or it is not, and the check
+happens per message.
+
+Usage:
+    just slack-backfill --dry-run
+    just slack-backfill --bridge <bridge-uuid> --room <switch-room-uuid>
+    just slack-backfill
+
+In a deployment it is the same command inside the image:
+    python -m switch_core.cli.slack_backfill --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from slack_sdk.web.async_client import AsyncWebClient
+from sqlalchemy import select
+
+from switch_core.config import SwitchConfig
+from switch_core.db.engine import create_engine_from_config, create_session_factory
+from switch_core.db.models import CollaborationBridge, Room
+from switch_core.db.stores.message_store import MessageStore
+from switch_core.messages.slack_backfill import (
+    MESSAGES_PER_ROOM,
+    backfill_channel,
+    load_sender_directory,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bridge", help="One Slack bridge id. Defaults to all active.")
+    parser.add_argument("--room", help="One Switch room id. Defaults to every room.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read Slack and report what would be written, without writing it.",
+    )
+    parser.add_argument(
+        "--messages-per-room",
+        type=int,
+        default=MESSAGES_PER_ROOM,
+        metavar="N",
+        help=(
+            "How many of a room's messages to recover, newest first "
+            f"(default {MESSAGES_PER_ROOM}). Thread replies count towards it."
+        ),
+    )
+    return parser.parse_args()
+
+
+class _ReadOnlyStore(MessageStore):
+    """Reads exactly as far as a real run and writes nothing."""
+
+    async def create_historical(self, session, message, attachments):  # type: ignore[no-untyped-def]
+        return message
+
+
+async def _run(args: argparse.Namespace) -> int:
+    config = SwitchConfig()
+    engine = create_engine_from_config(config)
+    session_factory = create_session_factory(engine)
+    store: MessageStore = _ReadOnlyStore() if args.dry_run else MessageStore()
+
+    async with session_factory() as session:
+        query = select(CollaborationBridge).where(CollaborationBridge.type == "slack")
+        if args.bridge:
+            query = query.where(CollaborationBridge.id == args.bridge)
+        else:
+            query = query.where(CollaborationBridge.status == "active")
+        bridges = list((await session.execute(query)).scalars().all())
+
+    if not bridges:
+        print("No active Slack bridge to read from.", file=sys.stderr)
+        return 2
+
+    written = 0
+    skipped: list[str] = []
+    try:
+        for bridge in bridges:
+            token = (bridge.connection_config or {}).get("bot_token")
+            if not token:
+                skipped.append(f"{bridge.display_name}: no bot token")
+                continue
+            slack = AsyncWebClient(token=token)
+
+            async with session_factory() as session:
+                senders = await load_sender_directory(session, bridge.id)
+                rooms_query = (
+                    select(Room)
+                    .where(Room.bridge_id == bridge.id)
+                    .where(Room.archived_at.is_(None))
+                    .where(Room.external_channel_id.is_not(None))
+                )
+                if args.room:
+                    rooms_query = rooms_query.where(Room.id == args.room)
+                rooms = list((await session.execute(rooms_query)).scalars().all())
+
+            print(f"\n{bridge.display_name}: {len(rooms)} room(s)")
+            for room in rooms:
+                report = await backfill_channel(
+                    slack,
+                    session_factory,
+                    room,
+                    bridge_id=bridge.id,
+                    store=store,
+                    senders=senders,
+                    messages_per_room=args.messages_per_room,
+                )
+                print(f"  {report.summary()}")
+                written += report.written
+                if report.error:
+                    skipped.append(f"{report.room_name}: {report.error}")
+    finally:
+        await engine.dispose()
+
+    verb = "would be written" if args.dry_run else "written"
+    print(f"\n{written} message(s) {verb}.")
+    if skipped:
+        print(f"\n{len(skipped)} channel(s) skipped:", file=sys.stderr)
+        for line in skipped:
+            print(f"    {line}", file=sys.stderr)
+    return 1 if skipped else 0
+
+
+def main() -> int:
+    return asyncio.run(_run(_parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/switch_core/messages/slack_backfill.py
+++ b/core/switch_core/messages/slack_backfill.py
@@ -1,0 +1,313 @@
+"""Reconstructs a bridged room's recent history from Slack.
+
+The other backfill walks the message bus. That was the only source while Matrix
+held the history, and it is the wrong source now: it reads the homeserver hard
+enough to hurt it, and after the deletion there is no homeserver to read at all.
+
+Slack has the same conversation, and for a bridged room it is the *original* —
+the bus only ever carried a copy of it. So for the rooms that matter most, the
+history can be recovered from the platform it came from, with the homeserver
+left out of it entirely.
+
+**It keeps the ids Switch already minted.** `bridge_message_map` records the
+Slack `ts` against the event id for everything the bridge ever relayed, so a
+message recovered this way is written under the id it originally had rather
+than a new one. A thread root still resolves, and anything referring to it
+still points at the right row. Only messages from before the channel was
+bridged need an id of their own, and theirs is derived from the channel and the
+`ts` so a second run recognises its own work.
+
+**Recent, not complete.** A room carries `MESSAGES_PER_ROOM` messages by
+default, newest first. What an agent reads is the recent conversation; the
+value of the twelve-hundredth message back does not justify the requests it
+costs, and a job that finishes is worth more than one that is exhaustive.
+
+Thread replies count towards that limit and are fetched for the roots in range,
+because a Switch room's conversation happens in threads: fifty channel-level
+messages would be fifty thread openings and none of the discussion under them.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+
+from switch_core.db.models import BridgeMessageMap, Client, ExternalUser, Message
+
+if TYPE_CHECKING:
+    from slack_sdk.web.async_client import AsyncWebClient
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from switch_core.db.models import Room
+    from switch_core.db.stores.message_store import MessageStore
+
+logger = logging.getLogger(__name__)
+
+# One page of Slack history. Slack allows up to 999; 200 is what a Tier 3 app
+# returns comfortably and keeps a single response small enough to hold.
+PAGE_SIZE = 200
+
+# How much of a channel's past is worth recovering, newest first. Deliberately
+# its own number rather than the bus backfill's: that one is bounded by what a
+# homeserver will tolerate being asked, this one by what an agent will ever
+# read. Raise it with `--messages-per-room`.
+MESSAGES_PER_ROOM = 50
+
+# A stop for a channel that keeps handing out pages. Only reached if the limit
+# never is, which means a channel of nothing but events the log does not keep.
+MAX_PAGES = 20
+
+
+@dataclass
+class SlackBackfillReport:
+    room_id: str
+    channel_id: str
+    room_name: str
+    api_calls: int = 0
+    seen: int = 0
+    written: int = 0
+    already_present: int = 0
+    kept_original_id: int = 0
+    unmapped_sender: int = 0
+    error: str | None = None
+
+    def summary(self) -> str:
+        if self.error:
+            return f"{self.room_name} ({self.channel_id}): SKIPPED — {self.error}"
+        line = (
+            f"{self.room_name} ({self.channel_id}): {self.written} written, "
+            f"{self.already_present} already recorded, {self.seen} seen "
+            f"in {self.api_calls} API call(s)"
+        )
+        if self.kept_original_id:
+            line += f"; {self.kept_original_id} kept their original event id"
+        if self.unmapped_sender:
+            line += f"; {self.unmapped_sender} from senders Switch does not know"
+        return line
+
+
+@dataclass
+class SenderDirectory:
+    """Slack user id → the Switch identity that speaks for them.
+
+    Built once per bridge. A user who has never spoken through Switch has no
+    puppet, and rather than create one for a message from last year the row
+    records the Slack id and whatever name Slack gives it — the log is a record
+    of what was said, and a sender it cannot name is still worth keeping.
+    """
+
+    by_slack_id: dict[str, tuple[str, str]] = field(default_factory=dict)
+
+    def resolve(self, slack_user_id: str, fallback_name: str) -> tuple[str, str, bool]:
+        known = self.by_slack_id.get(slack_user_id)
+        if known is not None:
+            return known[0], known[1], True
+        return f"slack:{slack_user_id}", fallback_name or slack_user_id, False
+
+
+async def load_sender_directory(
+    session: AsyncSession, bridge_id: str
+) -> SenderDirectory:
+    rows = (
+        await session.execute(
+            select(
+                ExternalUser.external_user_id,
+                Client.matrix_user_id,
+                Client.display_name,
+            )
+            .join(Client, Client.id == ExternalUser.client_id)
+            .where(ExternalUser.bridge_id == bridge_id)
+        )
+    ).all()
+    return SenderDirectory(
+        by_slack_id={r[0]: (r[1], r[2]) for r in rows},
+    )
+
+
+async def load_event_ids(
+    session: AsyncSession, bridge_id: str, channel_id: str
+) -> dict[str, str]:
+    """Slack `ts` → the event id Switch gave it, for this channel.
+
+    `external_post_id` is `channel:ts`, which is how the adapter writes it when
+    it relays a message, so the map is already keyed the way this needs it.
+    """
+    rows = (
+        await session.execute(
+            select(BridgeMessageMap.external_post_id, BridgeMessageMap.matrix_event_id)
+            .where(BridgeMessageMap.bridge_id == bridge_id)
+            .where(BridgeMessageMap.external_post_id.like(f"{channel_id}:%"))
+        )
+    ).all()
+    return {post_id.split(":", 1)[1]: event_id for post_id, event_id in rows}
+
+
+def _event_id_for(channel_id: str, ts: str, known: dict[str, str]) -> tuple[str, bool]:
+    """The id this message should be written under.
+
+    The one Switch already gave it if the bridge relayed it, so the row lands
+    where anything pointing at it expects. Otherwise one derived from the
+    channel and the `ts` — deterministic, so re-running recognises its own rows
+    through the unique constraint rather than writing them twice.
+    """
+    existing = known.get(ts)
+    if existing is not None:
+        return existing, True
+    return f"sw_slack_{channel_id}_{ts.replace('.', '')}", False
+
+
+def _is_worth_keeping(raw: dict[str, Any]) -> bool:
+    """Whether a Slack history entry belongs in the log.
+
+    Joins, channel topics and the rest of Slack's housekeeping carry a
+    `subtype`; a message someone typed does not. Slack's own tombstones for
+    deleted messages are excluded for the same reason the bus walk excludes a
+    leave: the log records what was said.
+    """
+    if raw.get("subtype") in {None, "thread_broadcast", "file_share"}:
+        return bool(raw.get("text") or raw.get("files"))
+    return False
+
+
+async def backfill_channel(
+    slack: AsyncWebClient,
+    session_factory: async_sessionmaker[AsyncSession],
+    room: Room,
+    *,
+    bridge_id: str,
+    store: MessageStore,
+    senders: SenderDirectory,
+    messages_per_room: int = MESSAGES_PER_ROOM,
+) -> SlackBackfillReport:
+    """Recover one channel's recent history into the message log."""
+    channel_id = room.external_channel_id or ""
+    report = SlackBackfillReport(
+        room_id=room.id, channel_id=channel_id, room_name=room.name
+    )
+
+    try:
+        candidates = await _collect(slack, channel_id, messages_per_room, report)
+    except Exception as error:  # noqa: BLE001 — one channel must not stop the rest
+        report.error = str(error)
+        logger.warning("Slack history unavailable for %s: %s", channel_id, error)
+        return report
+
+    async with session_factory() as session:
+        known = await load_event_ids(session, bridge_id, channel_id)
+
+    # Newest first, so the newest reconstructed message takes -1 and the walk
+    # runs the same direction as the bus backfill's.
+    for raw in candidates[:messages_per_room]:
+        await _write(
+            raw, session_factory, room, channel_id, known, store, senders, report
+        )
+    return report
+
+
+async def _collect(
+    slack: AsyncWebClient,
+    channel_id: str,
+    limit: int,
+    report: SlackBackfillReport,
+) -> list[dict[str, Any]]:
+    """The newest `limit` messages in a channel, thread replies included.
+
+    Roots are read first because Slack only returns those from `history`, then
+    each root that has replies is expanded. The merged list is sorted by `ts`
+    so "newest" means newest in the room rather than newest at channel level —
+    a thread answered this morning under a root from last week belongs near the
+    top, and ordering by root would bury it.
+    """
+    roots: list[dict[str, Any]] = []
+    cursor: str | None = None
+    for _ in range(MAX_PAGES):
+        page = await slack.conversations_history(
+            channel=channel_id, limit=PAGE_SIZE, cursor=cursor
+        )
+        report.api_calls += 1
+        page_messages: list[dict[str, Any]] = list(page.get("messages", []))
+        roots.extend(m for m in page_messages if _is_worth_keeping(m))
+        cursor = (page.get("response_metadata") or {}).get("next_cursor") or None
+        if len(roots) >= limit or not cursor:
+            break
+
+    collected = list(roots)
+    for root in roots[:limit]:
+        if not root.get("reply_count"):
+            continue
+        replies = await slack.conversations_replies(
+            channel=channel_id, ts=root["ts"], limit=PAGE_SIZE
+        )
+        report.api_calls += 1
+        reply_messages: list[dict[str, Any]] = list(replies.get("messages", []))
+        collected.extend(
+            m
+            for m in reply_messages
+            if m.get("ts") != root.get("ts") and _is_worth_keeping(m)
+        )
+
+    collected.sort(key=lambda m: float(m.get("ts", 0)), reverse=True)
+    return collected
+
+
+async def _write(
+    raw: dict[str, Any],
+    session_factory: async_sessionmaker[AsyncSession],
+    room: Room,
+    channel_id: str,
+    known: dict[str, str],
+    store: MessageStore,
+    senders: SenderDirectory,
+    report: SlackBackfillReport,
+) -> None:
+    ts = str(raw.get("ts", ""))
+    if not ts:
+        return
+    report.seen += 1
+    event_id, was_mapped = _event_id_for(channel_id, ts, known)
+
+    async with session_factory() as session:
+        if await store.get_by_transport_event_id(session, event_id) is not None:
+            report.already_present += 1
+            return
+
+        sender_id, sender_name, mapped_sender = senders.resolve(
+            str(raw.get("user") or raw.get("bot_id") or ""),
+            str(raw.get("username") or ""),
+        )
+        thread_ts = raw.get("thread_ts")
+        thread_root = None
+        if thread_ts and thread_ts != ts:
+            thread_root = known.get(str(thread_ts))
+
+        text = str(raw.get("text") or "")
+        message = Message(
+            room_id=room.id,
+            transport_event_id=event_id,
+            sender_matrix_id=sender_id,
+            sender_name=sender_name,
+            event_type="m.room.message",
+            msgtype="m.text",
+            body=text,
+            thread_root_event_id=thread_root,
+            content={"msgtype": "m.text", "body": text, "sender_name": sender_name},
+            sent_at=_sent_at(ts),
+        )
+        await store.create_historical(session, message, [])
+        await session.commit()
+
+    report.written += 1
+    if was_mapped:
+        report.kept_original_id += 1
+    if not mapped_sender:
+        report.unmapped_sender += 1
+
+
+def _sent_at(ts: str):  # type: ignore[no-untyped-def]
+    """Slack's `ts` is epoch seconds with microseconds after the point."""
+    from datetime import UTC, datetime
+
+    return datetime.fromtimestamp(float(ts), tz=UTC)

--- a/justfile
+++ b/justfile
@@ -119,6 +119,13 @@ reconcile-messages *args:
 backfill-messages *args:
     uv run --project core python -m switch_core.cli.backfill {{ args }}
 
+# ── Recover recent room history from Slack, not the homeserver ────────────────
+# For bridged rooms Slack holds the same conversation and holds it first, so
+# this reads it there and leaves the homeserver alone. Newest messages only.
+#   just slack-backfill --dry-run
+slack-backfill *args:
+    uv run --project core python -m switch_core.cli.slack_backfill {{ args }}
+
 # ── Generate a new alembic migration ──────────────────────────────────────────
 migration msg:
     uv run --project core alembic -c core/alembic.ini revision --autogenerate -m "{{ msg }}"


### PR DESCRIPTION
Recovers a bridged room's recent history from **Slack** instead of the message bus, so the homeserver is never touched.

`just slack-backfill --dry-run` · `python -m switch_core.cli.slack_backfill` in the image.

## Why

The bus backfill reads Tuwunel hard enough to hurt it, and after the Matrix deletion there is nothing left to read. For a bridged room Slack holds the same conversation — and holds it *first*; the bus only ever carried a copy.

## What it does

- **50 messages per room**, newest first, `--messages-per-room N` to change it.
- **Thread replies count towards the limit.** A Switch room's conversation happens in threads, so fifty channel-level messages would be fifty thread openings and none of the discussion under them.
- **Keeps the ids Switch already minted.** `bridge_message_map` holds the Slack `ts` against the event id for everything relayed, so a recovered message is written under its original id and thread roots still resolve. Pre-bridging messages get an id derived from `channel` + `ts`, so a re-run recognises its own work.
- Rows numbered below zero by the same `create_historical` the bus backfill uses — nothing redelivered, no cursor moved.
- A channel the bot cannot read is reported and skipped, not fatal.

## Verified against the pilot

Scopes and membership checked first with the live bot token: `channels:history`, `groups:history`, `im:history`, `mpim:history`, `files:read`, `users:read` all granted; **237/237** live SandboxAQ Dev channels readable; `limit=200` returns 200 with a cursor (Tier 3, not the 15-message tier); 12 rapid calls, zero 429s.

Then a real dry run over the whole **SandboxAQ Prod** bridge (22 rooms):

```
121 message(s) would be written    (~165 API calls)
  cg-flint-socialmedia   43 written, 7 already recorded
  sbaq-leadership        20 written, 30 already recorded
  cg-switch-lounge       18 written, 24 already recorded
  cg-switch-war-room      0 written, 50 already recorded
  3 channels skipped: not_in_channel ×1, channel_not_found ×2
```

The "already recorded" counts are the proof the id mapping works — it recognises rows the recorder already wrote instead of duplicating them.

## Note for review

Ruff clean. mypy adds 14 errors, all the `SwitchConfig()` pydantic-settings pattern that `cli/backfill.py` already produces identically — no new *kinds*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)