### PR TITLE
release: switch-core 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.25.0] - 2026-09-06
+
+#### Removed
+- **Matrix is gone.** Following the 0.24.0 move to a Postgres message store,
+  switch-core no longer runs or talks to a Matrix homeserver: the Tuwunel
+  service, the `matrix-nio` dependency, and all `MATRIX_*` configuration are
+  removed, and the Helm chart drops the tuwunel deployment, service and PVC. The
+  standalone compose no longer ships a Tuwunel service. Ships a migration
+  (`drop_matrix_columns`) that drops the now-unused Matrix columns (#380).
+
+#### Changed
+- **`stack-compose` contract → speaks 2** (accepts 1). The published standalone
+  compose no longer carries the `tuwunel` service or the `MATRIX_*` environment
+  variables; Switch Console's local-server mode drives the new shape (#380).
+
 ### [0.24.1] - 2026-09-06
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ version of their own to them without also giving them a release of their own.
 
 ### [0.25.0] - 2026-09-06
 
+#### Added
+- `GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED` (default true) makes the OIDC
+  `email_verified` check configurable, so a deployment whose IdP addresses are
+  authoritative (e.g. Okta directory-provisioned users that never report the
+  claim as true) can opt out. The relaxed check logs a warning on every login
+  naming the claim value, so it is never silent (#387).
+
 #### Removed
 - **Matrix is gone.** Following the 0.24.0 move to a Postgres message store,
   switch-core no longer runs or talks to a Matrix homeserver: the Tuwunel

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.24.1
+    version: 0.25.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 
@@ -169,8 +169,8 @@ contracts:
       names, profiles, and environment variables — which Switch Console's
       local-server mode drives.
     artifacts:
-      switch-console: { speaks: 1, accepts: 1 }
-      compose: { speaks: 1, accepts: 1 }
+      switch-console: { speaks: 2, accepts: 1 }
+      compose: { speaks: 2, accepts: 1 }
 
   sidecar-control:
     description: >-

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.24.1',
+  'switch-core': '0.25.0',
   'switch-console': '0.33.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.24.1',
-  setup: '0.24.1',
-  'helm-chart': '0.24.1',
-  compose: '0.24.1',
+  gateway: '0.25.0',
+  setup: '0.25.0',
+  'helm-chart': '0.25.0',
+  compose: '0.25.0',
   'switch-connector': '0.9.13',
   'switch-connector-codex': '0.3.14',
   'switch-connector-opencode': '0.1.9',
@@ -53,8 +53,8 @@ export const CONTRACTS = {
   },
   // The interface of the published standalone compose artifact — its service names, profiles, and environment variables — which Switch Console's local-server mode drives.
   'stack-compose': {
-    'switch-console': { speaks: 1, accepts: 1 },
-    compose: { speaks: 1, accepts: 1 },
+    'switch-console': { speaks: 2, accepts: 1 },
+    compose: { speaks: 2, accepts: 1 },
   },
   // How Switch Console controls a deployed sidecar on a remote host: the ready file it reads, and the control channel it opens.
   'sidecar-control': {

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.24.1',
+  'switch-core': '0.25.0',
   'switch-console': '0.33.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.24.1',
-  setup: '0.24.1',
-  'helm-chart': '0.24.1',
-  compose: '0.24.1',
+  gateway: '0.25.0',
+  setup: '0.25.0',
+  'helm-chart': '0.25.0',
+  compose: '0.25.0',
   'switch-connector': '0.9.13',
   'switch-connector-codex': '0.3.14',
   'switch-connector-opencode': '0.1.9',
@@ -53,8 +53,8 @@ export const CONTRACTS = {
   },
   // The interface of the published standalone compose artifact — its service names, profiles, and environment variables — which Switch Console's local-server mode drives.
   'stack-compose': {
-    'switch-console': { speaks: 1, accepts: 1 },
-    compose: { speaks: 1, accepts: 1 },
+    'switch-console': { speaks: 2, accepts: 1 },
+    compose: { speaks: 2, accepts: 1 },
   },
   // How Switch Console controls a deployed sidecar on a remote host: the ready file it reads, and the control channel it opens.
   'sidecar-control': {

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.24.1"
+version = "0.25.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.24.1",
+    "switch-core": "0.25.0",
     "switch-console": "0.33.0",
     "agent-runtime": "0.4.1",
     "sidecar": "1.9.7",
-    "gateway": "0.24.1",
-    "setup": "0.24.1",
-    "helm-chart": "0.24.1",
-    "compose": "0.24.1",
+    "gateway": "0.25.0",
+    "setup": "0.25.0",
+    "helm-chart": "0.25.0",
+    "compose": "0.25.0",
     "switch-connector": "0.9.13",
     "switch-connector-codex": "0.3.14",
     "switch-connector-opencode": "0.1.9",
@@ -46,8 +46,8 @@ CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {
     },
     # The interface of the published standalone compose artifact — its service names, profiles, and environment variables — which Switch Console's local-server mode drives.
     "stack-compose": {
-        "switch-console": ContractRange(speaks=1, accepts=1),
-        "compose": ContractRange(speaks=1, accepts=1),
+        "switch-console": ContractRange(speaks=2, accepts=1),
+        "compose": ContractRange(speaks=2, accepts=1),
     },
     # How Switch Console controls a deployed sidecar on a remote host: the ready file it reads, and the control channel it opens.
     "sidecar-control": {

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2238,8 +2238,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -2334,7 +2334,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.24.1"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **switch-core 0.25.0** (minor).

- **Removed** — Matrix is gone (#380): Tuwunel service, `matrix-nio`, all `MATRIX_*` config; Helm chart drops tuwunel deployment/service/PVC; standalone compose drops the Tuwunel service. Ships a migration (`drop_matrix_columns`).
- **Changed** — `stack-compose` contract raised to **speaks 2** (accepts 1): the compose Console drives no longer carries the tuwunel service or `MATRIX_*` env.

Bumped `core/pyproject.toml` + `artifacts.yaml` (version + stack-compose contract), regenerated (`just artifacts-check` green), cut the `## switch-core` changelog. agent-protocol/gateway-api unchanged (runtime source didn't move).

Package-only release — no GitHub Release; the tag + changelog are the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)