### PR TITLE
release: switch-console 0.34.0 (+ connectors, core pin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1241,6 +1241,14 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.34.0] - 2026-09-06
+
+#### Changed
+- **Local-server mode drops Matrix.** The bundled standalone stack no longer
+  runs a Tuwunel service or sets `MATRIX_*` environment, matching switch-core
+  0.25.0; an existing local stack is migrated off Matrix on start. Bundles
+  **switch-core 0.25.0** (was 0.24.x) (#380).
+
 ### [0.33.0] - 2026-09-06
 
 #### Added
@@ -2969,6 +2977,11 @@ compatibility signal. History for those is in the git log.
 
 ### [Unreleased]
 
+### [0.9.14] - 2026-09-06
+#### Changed
+- Skill updated: Matrix references removed to match the Postgres-backed message
+  store (#380). Plugin version bumps so installs re-download.
+
 ### [0.9.13] - 2026-09-06
 #### Changed
 - Skills updated for agent display names: the switch and configure skills note
@@ -3211,6 +3224,11 @@ manifest history.
 
 ### [Unreleased]
 
+### [0.3.15] - 2026-09-06
+#### Changed
+- Skill updated: Matrix references removed to match the Postgres-backed message
+  store (#380). Plugin version bumps so installs re-download.
+
 ### [0.3.14] - 2026-09-06
 #### Changed
 - Skills updated for agent display names: the switch and configure skills note
@@ -3407,6 +3425,12 @@ for humans reading a diff rather than for an installer, and an install reports
 the app version that wrote it rather than a version of its own.
 
 ### [Unreleased]
+
+### [0.1.10] - 2026-09-06
+#### Changed
+- Skill updated: Matrix references removed to match the Postgres-backed message
+  store (#380). (Delivered at the next Switch Console update, which rewrites the
+  embedded connector.)
 
 ### [0.1.9] - 2026-09-06
 #### Changed

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -66,7 +66,7 @@ artifacts:
 
   switch-console:
     description: The desktop app.
-    version: 0.33.0
+    version: 0.34.0
     declared_in: console/apps/switch-console-desktop/package.json
     # Which switch-core release this app build bundles and pulls for
     # local-server mode. DELIBERATELY NOT switch-core's version above.
@@ -78,7 +78,7 @@ artifacts:
     # main. This moves only when Switch Console is ready to bundle that release —
     # in lockstep with the bundled compose.
     pins:
-      switch-core: 0.24.0
+      switch-core: 0.25.0
 
   agent-runtime:
     description: The Switch protocol client and MCP runtime, published to a registry.
@@ -127,12 +127,12 @@ artifacts:
 
   switch-connector:
     description: The Claude Code connector plugin.
-    version: 0.9.13
+    version: 0.9.14
     declared_in: connectors/claude-code-plugin/.claude-plugin/plugin.json
 
   switch-connector-codex:
     description: The Codex connector plugin.
-    version: 0.3.14
+    version: 0.3.15
     declared_in: connectors/codex-plugin/.codex-plugin/plugin.json
 
   switch-connector-opencode:
@@ -140,7 +140,7 @@ artifacts:
       The OpenCode connector. Unlike the other two it is written by Switch
       Console rather than installed from the marketplace, because OpenCode has
       no plugin marketplace to install it from.
-    version: 0.1.9
+    version: 0.1.10
     declared_in: connectors/opencode-plugin/package.json
 
 contracts:

--- a/connectors/claude-code-plugin/.claude-plugin/plugin.json
+++ b/connectors/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "switch-connector",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Connect Claude Code to a Switch platform instance as a participating agent"
 }

--- a/connectors/codex-plugin/.codex-plugin/plugin.json
+++ b/connectors/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-codex",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Connect Codex to a Switch platform instance as a participating agent",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/connectors/opencode-plugin/package.json
+++ b/connectors/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-connector-opencode",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Connect OpenCode to a Switch platform instance as a participating agent",
   "private": true,
   "type": "module",

--- a/console/apps/switch-console-desktop/package.json
+++ b/console/apps/switch-console-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@switch-console/desktop",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",

--- a/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.canary.ts
@@ -17,4 +17,4 @@ export const RELEASE_REPO_NAME = 'switch';
 // against `switch-console.pins.switch-core` in artifacts.yaml by `just artifacts`,
 // so they can no longer drift apart — this used to say "keep in sync" and rely
 // on whoever edited one remembering the other (CHOO-1865).
-export const COMPATIBLE_SWITCH_VERSION = '0.24.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.25.0';

--- a/console/apps/switch-console-desktop/src/shared/app-identity.ts
+++ b/console/apps/switch-console-desktop/src/shared/app-identity.ts
@@ -60,7 +60,7 @@ export const RELEASE_REPO_NAME = 'switch';
 // core/pyproject.toml is the first step of cutting a switch-core release, and a
 // derived pin would immediately point local-server mode at images that are not
 // on the registry yet.
-export const COMPATIBLE_SWITCH_VERSION = '0.24.0';
+export const COMPATIBLE_SWITCH_VERSION = '0.25.0';
 
 // The last switch-core release that can still read a Matrix homeserver.
 //

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -21,16 +21,16 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.25.0',
-  'switch-console': '0.33.0',
+  'switch-console': '0.34.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
   gateway: '0.25.0',
   setup: '0.25.0',
   'helm-chart': '0.25.0',
   compose: '0.25.0',
-  'switch-connector': '0.9.13',
-  'switch-connector-codex': '0.3.14',
-  'switch-connector-opencode': '0.1.9',
+  'switch-connector': '0.9.14',
+  'switch-connector-codex': '0.3.15',
+  'switch-connector-opencode': '0.1.10',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -21,16 +21,16 @@ export interface ContractRange {
  */
 export const ARTIFACT_VERSIONS = {
   'switch-core': '0.25.0',
-  'switch-console': '0.33.0',
+  'switch-console': '0.34.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
   gateway: '0.25.0',
   setup: '0.25.0',
   'helm-chart': '0.25.0',
   compose: '0.25.0',
-  'switch-connector': '0.9.13',
-  'switch-connector-codex': '0.3.14',
-  'switch-connector-opencode': '0.1.9',
+  'switch-connector': '0.9.14',
+  'switch-connector-codex': '0.3.15',
+  'switch-connector-opencode': '0.1.10',
 } as const satisfies Record<string, string>;
 
 export type ArtifactName = keyof typeof ARTIFACT_VERSIONS;

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -21,16 +21,16 @@ class ContractRange(NamedTuple):
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
     "switch-core": "0.25.0",
-    "switch-console": "0.33.0",
+    "switch-console": "0.34.0",
     "agent-runtime": "0.4.1",
     "sidecar": "1.9.7",
     "gateway": "0.25.0",
     "setup": "0.25.0",
     "helm-chart": "0.25.0",
     "compose": "0.25.0",
-    "switch-connector": "0.9.13",
-    "switch-connector-codex": "0.3.14",
-    "switch-connector-opencode": "0.1.9",
+    "switch-connector": "0.9.14",
+    "switch-connector-codex": "0.3.15",
+    "switch-connector-opencode": "0.1.10",
 }
 
 CONTRACTS: Final[dict[str, dict[str, ContractRange]]] = {


### PR DESCRIPTION
Cuts **Switch Console 0.34.0** and the connector plugins that ship with it.

**Switch Console 0.34.0** (minor)
- Local-server mode drops the Tuwunel service + `MATRIX_*` env and migrates an existing local stack off Matrix, matching switch-core 0.25.0 (#380).

**Connector plugins** — all three bumped for the Matrix-removed skill updates so installs re-download (no runtime-pin change): claude `0.9.14`, codex `0.3.15`, opencode `0.1.10`.

**Bundled core pin moved 0.24.x → 0.25.0** — `artifacts.yaml` pin + `COMPATIBLE_SWITCH_VERSION` in `app-identity.ts`/`.canary.ts`; bundled compose re-synced (Tuwunel service removed). The `stack-compose` contract bump (speaks 2 / accepts 1) rides the core PR #385.

All versions mirrored in `artifacts.yaml` and regenerated (`just artifacts-check` green).

**Depends on:** switch-core `0.25.0` (#385) tagged first (the pin points at it). I'll rebase this on main after #385 merges, then tag `switch-console-v0.34.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)