### PR TITLE
feat(gateway): make the OIDC email_verified check configurable

### DIFF
--- a/core/switch_core/config.py
+++ b/core/switch_core/config.py
@@ -58,6 +58,15 @@ class SwitchConfig(BaseSettings):
     # provider registration, e.g.
     # https://switch-gateway.<tailnet>.ts.net/gateway/auth/oidc/callback
     gateway_oidc_redirect_url: str | None = None
+    # JIT provisioning trusts the email claim, so by default a login is refused
+    # unless the IdP asserts `email_verified`. That guards against an IdP where
+    # a user can self-assert an address. It also rejects every user of an IdP
+    # that never emits the claim as true — Okta's org authorization server only
+    # sets it for users who completed its own email-verification flow, so
+    # directory-provisioned users are permanently false and cannot be fixed
+    # from the Okta side. Set false ONLY for a single-tenant IdP whose
+    # addresses are authoritative (corporate directory, HR-provisioned).
+    gateway_oidc_require_email_verified: bool = True
     # Lets the password login path be disabled (OIDC-only) without code changes.
     gateway_password_login_enabled: bool = True
     # Sets the Secure flag on the switch_auth cookie. Defaults to False so local

--- a/core/switch_core/gateway/oidc_routes.py
+++ b/core/switch_core/gateway/oidc_routes.py
@@ -94,11 +94,25 @@ async def oidc_callback(
             status_code=401, detail="OIDC token missing email or sub claim"
         )
     # Provisioning trusts the email, so an unverified (attacker-set) one must
-    # not be accepted.
+    # not be accepted — unless the deployment vouches for its IdP's addresses.
     email_verified = claims.get("email_verified")
-    if email_verified is not True and str(email_verified).lower() != "true":
-        logger.warning("OIDC login rejected: email not verified (sub %s)", sub)
-        raise HTTPException(status_code=401, detail="OIDC email is not verified")
+    verified = email_verified is True or str(email_verified).lower() == "true"
+    if not verified:
+        if config.gateway_oidc_require_email_verified:
+            logger.warning(
+                "OIDC login rejected: email_verified=%r (sub %s). If this IdP's "
+                "addresses are authoritative, set "
+                "GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED=false.",
+                email_verified,
+                sub,
+            )
+            raise HTTPException(status_code=401, detail="OIDC email is not verified")
+        logger.warning(
+            "OIDC email_verified=%r accepted (sub %s): the email claim is trusted "
+            "because GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED is false.",
+            email_verified,
+            sub,
+        )
     name = claims.get("name") or email.split("@")[0]
 
     # Bind to the immutable issuer+subject, never the mutable email.

--- a/core/tests/switch_core/gateway/test_oidc_config.py
+++ b/core/tests/switch_core/gateway/test_oidc_config.py
@@ -42,6 +42,8 @@ class TestGatewayOidcConfig:
         assert config.gateway_oidc_enabled is False
         # Password login is on by default.
         assert config.gateway_password_login_enabled is True
+        # Opting out of the verified-email check must be deliberate.
+        assert config.gateway_oidc_require_email_verified is True
 
     def test_enabled_when_all_three_set(self) -> None:
         config = SwitchConfig(

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -84,19 +84,22 @@ class TestOidcCallback:
                 "oidc_sub": "okta|123",
             }
 
+    @pytest.mark.parametrize("email_verified", [False, None, "false"])
     async def test_unverified_email_is_rejected(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         monkeypatch: pytest.MonkeyPatch,
+        email_verified: object,
     ) -> None:
-        token = {
-            "userinfo": {
-                "email": "mallory@example.com",
-                "email_verified": False,
-                "sub": "okta|9",
-                "name": "Mallory",
-            }
+        # An absent claim is as untrusted as an explicit false.
+        claims: dict[str, object] = {
+            "email": "mallory@example.com",
+            "sub": "okta|9",
+            "name": "Mallory",
         }
+        if email_verified is not None:
+            claims["email_verified"] = email_verified
+        token = {"userinfo": claims}
         monkeypatch.setattr(oidc_routes, "_client", lambda: _FakeClient(token))
 
         async with session_factory() as session:
@@ -108,6 +111,102 @@ class TestOidcCallback:
                     user_store=UserStore(),
                 )
             assert exc.value.status_code == 401
+
+    @pytest.mark.parametrize("email_verified", [False, None, "false"])
+    async def test_unverified_email_provisions_when_check_disabled(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+        email_verified: object,
+    ) -> None:
+        # Okta's org authorization server reports false (or omits the claim)
+        # for directory-provisioned users, so a deployment that vouches for its
+        # IdP's addresses must be able to opt out.
+        claims: dict[str, object] = {
+            "email": "bob@example.com",
+            "sub": "okta|55",
+            "name": "Bob",
+        }
+        if email_verified is not None:
+            claims["email_verified"] = email_verified
+        monkeypatch.setattr(
+            oidc_routes, "_client", lambda: _FakeClient({"userinfo": claims})
+        )
+
+        async with session_factory() as session:
+            response = await oidc_routes.oidc_callback(
+                request=SimpleNamespace(),  # type: ignore[arg-type]
+                config=_config(gateway_oidc_require_email_verified=False),
+                session=session,
+                user_store=UserStore(),
+            )
+
+            assert response.status_code == 303
+            user = await UserStore().get_by_email(session, "bob@example.com")
+            assert user is not None
+            assert user.metadata_ == {
+                "oidc_iss": "https://idp.example",
+                "oidc_sub": "okta|55",
+            }
+
+    async def test_missing_email_claim_still_rejected_when_check_disabled(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Opting out of the verified-email check must not weaken anything else.
+        token = {"userinfo": {"sub": "okta|56", "email_verified": False}}
+        monkeypatch.setattr(oidc_routes, "_client", lambda: _FakeClient(token))
+
+        async with session_factory() as session:
+            with pytest.raises(HTTPException) as exc:
+                await oidc_routes.oidc_callback(
+                    request=SimpleNamespace(),  # type: ignore[arg-type]
+                    config=_config(gateway_oidc_require_email_verified=False),
+                    session=session,
+                    user_store=UserStore(),
+                )
+            assert exc.value.status_code == 401
+
+    async def test_email_collision_still_rejected_when_check_disabled(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The takeover guard is independent of the verified-email check.
+        from switch_core.gateway.auth import hash_password
+
+        async with session_factory() as session:
+            await UserStore().create(
+                session,
+                User(
+                    name="Admin",
+                    email="admin2@example.com",
+                    role="admin",
+                    password_hash=hash_password("pw"),
+                ),
+            )
+            await session.commit()
+
+        token = {
+            "userinfo": {
+                "email": "admin2@example.com",
+                "email_verified": False,
+                "sub": "okta|attacker2",
+                "name": "Not Admin",
+            }
+        }
+        monkeypatch.setattr(oidc_routes, "_client", lambda: _FakeClient(token))
+
+        async with session_factory() as session:
+            with pytest.raises(HTTPException) as exc:
+                await oidc_routes.oidc_callback(
+                    request=SimpleNamespace(),  # type: ignore[arg-type]
+                    config=_config(gateway_oidc_require_email_verified=False),
+                    session=session,
+                    user_store=UserStore(),
+                )
+            assert exc.value.status_code == 409
 
     async def test_email_collision_with_existing_account_is_rejected(
         self,

--- a/deploy/remote/helm/switch/templates/_helpers.tpl
+++ b/deploy/remote/helm/switch/templates/_helpers.tpl
@@ -293,6 +293,10 @@ Include with `nindent 12`.
 - name: GATEWAY_OIDC_REDIRECT_URL
   value: {{ .Values.switchCore.oidc.redirectUrl | quote }}
 {{- end }}
+{{- if not .Values.switchCore.oidc.requireEmailVerified }}
+- name: GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED
+  value: "false"
+{{- end }}
 {{- if not .Values.switchCore.oidc.passwordLoginEnabled }}
 - name: GATEWAY_PASSWORD_LOGIN_ENABLED
   value: "false"

--- a/deploy/remote/helm/switch/values.yaml
+++ b/deploy/remote/helm/switch/values.yaml
@@ -118,6 +118,11 @@ switchCore:
     providerLabel: "OIDC"
     # Must exactly match the redirect URI registered with the IdP.
     redirectUrl: ""
+    # Refuse a login unless the IdP asserts email_verified. Set false only for a
+    # single-tenant IdP whose addresses are authoritative — e.g. Okta's org
+    # authorization server, which reports false for every directory-provisioned
+    # user and offers no way to change that.
+    requireEmailVerified: true
     # Set false to disable password login entirely (OIDC-only).
     passwordLoginEnabled: true
   # Bearer-token resolution runs before every authenticated request and agents


### PR DESCRIPTION
Okta logs the user in, the token exchange succeeds, and we reject them ourselves on the `email_verified` claim.

```
WARNI [switch_core.gateway.oidc_routes] OIDC login rejected: email not verified (sub 00u2…)
```

## Why the claim is false

JIT provisioning trusts the email, so the callback refuses a login unless the IdP asserts `email_verified`. That is the right default against an IdP where a user can self-assert an address.

It also locks out an IdP that never reports the claim as true. On Okta’s **org** authorization server `email_verified` means "this user completed Okta’s own email-verification flow" — directory/HR-provisioned users are permanently `false`, and claim customization needs a custom authorization server, which the org issuer is not.

## Change

`GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED`, default `true`, so behaviour is unchanged unless a deployment opts out. Helm: `switchCore.oidc.requireEmailVerified`, emitted only when false.

The opt-out is disclosed, not silent — every login through it logs a warning naming the claim value and the reason it was accepted.

The rejection path now logs the actual value too. It previously said only "email not verified", which cannot distinguish an explicit `false` from an absent claim — that ambiguity cost real debugging time.

## Not relaxed

With the check disabled, a missing `email`/`sub` still 401s and the email-collision takeover guard still 409s. Both are covered by new tests, alongside the opt-out itself and the default staying `true`.

Existing rejection test parametrized over `false` / absent / `"false"`.

## Note for the rollout

Do **not** fix this by moving to a custom authorization server. Its `sub` defaults to the login rather than the `00u…` Okta ID, and identity binds on `(iss, sub)` — every user already provisioned through the org issuer would read as a new subject on a taken email and hit the 409.

## Test plan

- [x] `just test` — 2655 passed
- [x] `just typecheck` — clean
- [x] `just check`
- [x] `helm template` renders the env var when false and omits it at the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)