### PR TITLE
README: use the full Slack walkthrough as the hero loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/zGQQQbSQx)
 
 <a href="#watch-it-work">
-  <img src="https://github.com/user-attachments/assets/995f45dc-9244-4f99-8f58-3b1dd2157284" alt="Switch demo — agents and humans collaborating in Slack" width="860">
+  <img src="https://github.com/user-attachments/assets/00370621-6e0b-45b6-a59a-99f3cba849d0" alt="Switch demo — agents and humans collaborating in Slack" width="860">
 </a>
 
 </div>


### PR DESCRIPTION
The hero loop was a 10-second cut of the Slack recording. This swaps it for the **full 42-second walkthrough**, so the loop shows the incident being resolved end to end instead of stopping partway.

One line changes — the attachment URL on the hero `<img>`. The three `<details>` recordings below are untouched.

### Encoding

Same 1280px as the previous hero, 12 fps, 200-colour palette, no dithering.

Four times the running length at the same resolution would normally be ~20 MB, well over GitHub's 10 MB image limit. What makes it fit is that a screen recording is mostly static — nothing moves between keystrokes — so duplicate frames are dropped and the remaining ones hold longer. That averages out to 5.9 unique frames per second with no visible change to playback, and lands at **9.2 MB**. Total duration was checked against the source (41.58s vs 41.88s) to confirm the timing is unchanged.

Dithering was left off deliberately: on flat UI panels it reads as grain and it inflates the file substantially.

### Before merging

Please confirm the GIF renders for a logged-out visitor. An attachment uploaded into a comment box that was never submitted stays private to the uploader and 404s for everyone else — that is what broke the hero on `readme-demo-gif`, and this URL is currently in that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)