### PR TITLE
feat(agent): read any room you are a member of without connecting (CHOO-2628)

### DIFF
--- a/connectors/claude-code-plugin/hooks/switch_hook.py
+++ b/connectors/claude-code-plugin/hooks/switch_hook.py
@@ -477,8 +477,12 @@ def handle_post_tool_use(event: dict) -> None:
     # needs no Switch credentials, so it happens before the check below — an
     # agent whose mediation cannot run still reads its room, and leaving the
     # tally climbing would tell it it is behind when it is not.
+    # A read aimed at another room says nothing about this one, so the tally
+    # only clears when the read covered the room the channel is following.
     if tool_name.endswith("read_context"):
-        _notify_channel("/read-context", {})
+        read_room = tool_input.get("room_id") if isinstance(tool_input, dict) else None
+        if read_room in (None, "", room_id):
+            _notify_channel("/read-context", {})
 
     if not _has_credentials(agent_id):
         return

--- a/connectors/claude-code-plugin/skills/switch/SKILL.md
+++ b/connectors/claude-code-plugin/skills/switch/SKILL.md
@@ -162,6 +162,21 @@ ISO-8601 string while `oldest_timestamp` is epoch milliseconds, so convert it
 rather than passing it straight back. Never conclude "there is nothing else in
 this room" from a truncated read.
 
+## Reading another room without going there
+
+`read_context` takes an optional `room_id`. Omit it — the usual case — and you
+read the room you are connected to. Pass one and you read **any room you are a
+member of** without connecting to it, so you can catch up on a room you are not
+attending without giving up the one you are.
+
+- It does not move you. Your connection, your role and your event delivery all
+  stay where they were; this is a read, not a hop. Use `connect_to_room` when
+  you actually need to *act* in the other room.
+- Membership is the boundary, and Switch enforces it: reading a room you do not
+  belong to is refused. `list_rooms` is the set you may read.
+- It clears nothing. The other room's unread count is untouched, and so is
+  yours — only reading your own connected room marks you caught up here.
+
 ## Interaction modes
 
 - **`post_message`** — broadcast to the room. Everyone sees it; other agents
@@ -743,7 +758,7 @@ failure-mode tools are covered in the sections just above.
 
 - `list_rooms` — rooms you are assigned to.
 - `connect_to_room` — enter a room. Once, then see steady state above.
-- `read_context` — room history, grouped into threads. Check `truncated`.
+- `read_context` — room history, grouped into threads. Check `truncated`. Optional `room_id` reads another room you belong to.
 - `list_participants` — the connected room's roster: `id`, `name`, `type`,
   `status`, `alias`.
 - `post_message` — broadcast to the room.

--- a/connectors/codex-plugin/skills/switch/SKILL.md
+++ b/connectors/codex-plugin/skills/switch/SKILL.md
@@ -165,6 +165,21 @@ ISO-8601 string while `oldest_timestamp` is epoch milliseconds, so convert it
 rather than passing it straight back. Never conclude "there is nothing else in
 this room" from a truncated read.
 
+## Reading another room without going there
+
+`read_context` takes an optional `room_id`. Omit it — the usual case — and you
+read the room you are connected to. Pass one and you read **any room you are a
+member of** without connecting to it, so you can catch up on a room you are not
+attending without giving up the one you are.
+
+- It does not move you. Your connection, your role and your event delivery all
+  stay where they were; this is a read, not a hop. Use `connect_to_room` when
+  you actually need to *act* in the other room.
+- Membership is the boundary, and Switch enforces it: reading a room you do not
+  belong to is refused. `list_rooms` is the set you may read.
+- It clears nothing. The other room's unread count is untouched, and so is
+  yours — only reading your own connected room marks you caught up here.
+
 ## Interaction modes
 
 - **`post_message`** — broadcast to the room. Everyone sees it; other agents
@@ -740,7 +755,7 @@ failure-mode tools are covered in the sections just above.
 
 - `list_rooms` — rooms you are assigned to.
 - `connect_to_room` — enter a room. Once, then see steady state above.
-- `read_context` — room history, grouped into threads. Check `truncated`.
+- `read_context` — room history, grouped into threads. Check `truncated`. Optional `room_id` reads another room you belong to.
 - `list_participants` — the connected room's roster: `id`, `name`, `type`,
   `status`, `alias`.
 - `post_message` — broadcast to the room.

--- a/connectors/opencode-plugin/skills/switch/SKILL.md
+++ b/connectors/opencode-plugin/skills/switch/SKILL.md
@@ -173,6 +173,21 @@ ISO-8601 string while `oldest_timestamp` is epoch milliseconds, so convert it
 rather than passing it straight back. Never conclude "there is nothing else in
 this room" from a truncated read.
 
+## Reading another room without going there
+
+`read_context` takes an optional `room_id`. Omit it — the usual case — and you
+read the room you are connected to. Pass one and you read **any room you are a
+member of** without connecting to it, so you can catch up on a room you are not
+attending without giving up the one you are.
+
+- It does not move you. Your connection, your role and your event delivery all
+  stay where they were; this is a read, not a hop. Use `connect_to_room` when
+  you actually need to *act* in the other room.
+- Membership is the boundary, and Switch enforces it: reading a room you do not
+  belong to is refused. `list_rooms` is the set you may read.
+- It clears nothing. The other room's unread count is untouched, and so is
+  yours — only reading your own connected room marks you caught up here.
+
 ## Interaction modes
 
 - **`post_message`** — broadcast to the room. Everyone sees it; other agents
@@ -743,7 +758,7 @@ failure-mode tools are covered in the sections just above.
 
 - `list_rooms` — rooms you are assigned to.
 - `connect_to_room` — enter a room. Once, then see steady state above.
-- `read_context` — room history, grouped into threads. Check `truncated`.
+- `read_context` — room history, grouped into threads. Check `truncated`. Optional `room_id` reads another room you belong to.
 - `list_participants` — the connected room's roster: `id`, `name`, `type`,
   `status`, `alias`.
 - `post_message` — broadcast to the room.

--- a/console/packages/plugins/src/agents/impl/opencode/skill-file.ts
+++ b/console/packages/plugins/src/agents/impl/opencode/skill-file.ts
@@ -181,6 +181,21 @@ ISO-8601 string while \`oldest_timestamp\` is epoch milliseconds, so convert it
 rather than passing it straight back. Never conclude "there is nothing else in
 this room" from a truncated read.
 
+## Reading another room without going there
+
+\`read_context\` takes an optional \`room_id\`. Omit it — the usual case — and you
+read the room you are connected to. Pass one and you read **any room you are a
+member of** without connecting to it, so you can catch up on a room you are not
+attending without giving up the one you are.
+
+- It does not move you. Your connection, your role and your event delivery all
+  stay where they were; this is a read, not a hop. Use \`connect_to_room\` when
+  you actually need to *act* in the other room.
+- Membership is the boundary, and Switch enforces it: reading a room you do not
+  belong to is refused. \`list_rooms\` is the set you may read.
+- It clears nothing. The other room's unread count is untouched, and so is
+  yours — only reading your own connected room marks you caught up here.
+
 ## Interaction modes
 
 - **\`post_message\`** — broadcast to the room. Everyone sees it; other agents
@@ -751,7 +766,7 @@ failure-mode tools are covered in the sections just above.
 
 - \`list_rooms\` — rooms you are assigned to.
 - \`connect_to_room\` — enter a room. Once, then see steady state above.
-- \`read_context\` — room history, grouped into threads. Check \`truncated\`.
+- \`read_context\` — room history, grouped into threads. Check \`truncated\`. Optional \`room_id\` reads another room you belong to.
 - \`list_participants\` — the connected room's roster: \`id\`, \`name\`, \`type\`,
   \`status\`, \`alias\`.
 - \`post_message\` — broadcast to the room.

--- a/console/packages/switch-agent-runtime/src/bin.ts
+++ b/console/packages/switch-agent-runtime/src/bin.ts
@@ -584,6 +584,7 @@ const mcp = new Server(
       'When you receive a task_cancel event, the task is dead — do not finalise it.',
       '',
       'read_context, post_message, send_targeted_message and the task tools all act on the room you are connected to, so connect_to_room comes first — once. That connection then holds for the rest of the session: do not reconnect before each call. Call connect_to_room again only to switch rooms, to return after switching, or when a tool fails saying you are not connected.',
+      "read_context also takes an optional room_id: pass one to read any room you are a member of without connecting to it, so you can catch up elsewhere while staying in the room you are attending. It does not move you, and it does not clear the other room's unread count. Reading a room you are not a member of is refused.",
     ].join('\n'),
   }
 );

--- a/core/switch_core/bridges/agent/operations/definitions.py
+++ b/core/switch_core/bridges/agent/operations/definitions.py
@@ -512,8 +512,9 @@ async def read_context(
     limit: int = 50,
     since: str | None = None,
     before: str | None = None,
+    room_id: str | None = None,
 ) -> dict[str, Any]:
-    """Get the conversation timeline for the connected room, grouped into threads.
+    """Get a room's conversation timeline, grouped into threads.
 
     Returns::
 
@@ -560,12 +561,18 @@ async def read_context(
             time are returned; history is paged backwards to reach them, so
             this genuinely walks into older history. Combine with `since` to
             page through a window. None = no upper bound.
-
-    The room is implicit (the session's currently connected room). Reads
-    fail if you have not called connect_to_room first.
+        room_id: Which room to read. Omit it — the usual case — and the
+            session's currently connected room is read; that read fails if
+            you are not connected to one. Pass a room id to read ANY room you
+            are a member of WITHOUT connecting to it, so you can catch up on
+            another room while staying where you are. Membership is the
+            boundary and is checked here: reading a room you do not belong to
+            is refused. A cross-room read does not change which room you are
+            connected to, and does not clear that room's unread count.
     """
     agent_id = get_agent_id()
-    room_id = await require_connected_room()
+    if room_id is None:
+        room_id = await require_connected_room()
 
     protocol = get_protocol()
     since_ms = parse_timestamp_ms(since) if since else None

--- a/core/tests/switch_core/bridges/agent/operations/test_read_context_room_argument.py
+++ b/core/tests/switch_core/bridges/agent/operations/test_read_context_room_argument.py
@@ -1,0 +1,164 @@
+"""Reading a room you are a member of without connecting to it (CHOO-2628).
+
+Catching up on another room used to mean travelling to it, which drops the
+agent out of the room it is supposed to be attending. `read_context` therefore
+takes an optional room: omit it and the connected room is read as before, pass
+one and that room is read instead, with nothing about the caller's connection
+disturbed.
+
+Membership, not connection, is the authorization boundary — and it is checked
+where it always was, inside the protocol service, so an explicit room id buys
+reach and not privilege.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from switch_core.bridges.agent.operations import context as op_context
+from switch_core.bridges.agent.operations.callctx import (
+    CallContext,
+    reset_call_context,
+    set_call_context,
+)
+from switch_core.bridges.agent.operations.definitions import read_context
+from switch_core.bridges.agent.protocol.connections import (
+    PROTOCOL_VERSION,
+    ClientDeclaration,
+    ConnectionRegistry,
+)
+
+AGENT = "agent-1"
+CONN = "conn-1"
+CONNECTED_ROOM = "room-here"
+OTHER_ROOM = "room-elsewhere"
+
+
+class _Protocol:
+    """Just enough protocol to answer a read: a registry and a recorder."""
+
+    def __init__(self, registry: ConnectionRegistry) -> None:
+        self.connections = registry
+        self.calls: list[tuple[str, str]] = []
+        self.members: set[str] = {CONNECTED_ROOM, OTHER_ROOM}
+
+    async def read_context(
+        self, agent_id: str, room_id: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        if room_id not in self.members:
+            raise PermissionError("Agent is not a member of this room")
+        self.calls.append((agent_id, room_id))
+        return {"threads": [], "truncated": False, "oldest_timestamp": None}
+
+
+@pytest.fixture
+def protocol(monkeypatch: pytest.MonkeyPatch) -> _Protocol:
+    registry = ConnectionRegistry()
+    service = _Protocol(registry)
+    monkeypatch.setattr(op_context, "_protocol", service)
+    return service
+
+
+@pytest.fixture
+def connected(protocol: _Protocol) -> None:
+    connection = protocol.connections.open(
+        agent_id=AGENT,
+        connection_id=CONN,
+        scope="single",
+        delivery_filter="all",
+        spawn_capable=False,
+        cursor=0,
+        declaration=ClientDeclaration(speaks=PROTOCOL_VERSION),
+    )
+    protocol.connections.claim_room(connection, CONNECTED_ROOM)
+
+
+@pytest.fixture
+def caller():
+    token = set_call_context(CallContext(agent_id=AGENT, session_key=CONN))
+    yield
+    reset_call_context(token)
+
+
+@pytest.fixture
+def unbound_caller():
+    """A caller with no connection at all, so no room can be defaulted."""
+    token = set_call_context(CallContext(agent_id=AGENT, session_key=None))
+    yield
+    reset_call_context(token)
+
+
+@pytest.mark.asyncio
+async def test_omitting_the_room_reads_the_one_you_are_connected_to(
+    protocol: _Protocol, connected: None, caller: None
+) -> None:
+    """The default is unchanged: the overwhelmingly common call reads here."""
+    await read_context()
+
+    assert protocol.calls == [(AGENT, CONNECTED_ROOM)]
+
+
+@pytest.mark.asyncio
+async def test_a_room_id_reads_that_room_instead(
+    protocol: _Protocol, connected: None, caller: None
+) -> None:
+    await read_context(room_id=OTHER_ROOM)
+
+    assert protocol.calls == [(AGENT, OTHER_ROOM)]
+
+
+@pytest.mark.asyncio
+async def test_reading_elsewhere_leaves_you_where_you_were(
+    protocol: _Protocol, connected: None, caller: None
+) -> None:
+    """The whole point: catching up must not cost the agent its own room."""
+    await read_context(room_id=OTHER_ROOM)
+
+    claimant = protocol.connections.claimant_of(AGENT, CONNECTED_ROOM)
+    assert claimant is not None
+    assert claimant.id == CONN
+    assert protocol.connections.claimant_of(AGENT, OTHER_ROOM) is None
+
+
+@pytest.mark.asyncio
+async def test_a_room_you_are_not_a_member_of_is_refused(
+    protocol: _Protocol, connected: None, caller: None
+) -> None:
+    """Naming a room is not the same as being allowed to read it."""
+    with pytest.raises(PermissionError):
+        await read_context(room_id="room-strangers")
+
+    assert protocol.calls == []
+
+
+@pytest.mark.asyncio
+async def test_an_unconnected_caller_can_still_read_a_room_it_names(
+    protocol: _Protocol, unbound_caller: None
+) -> None:
+    """No connection is needed when the room is explicit — membership decides."""
+    await read_context(room_id=OTHER_ROOM)
+
+    assert protocol.calls == [(AGENT, OTHER_ROOM)]
+
+
+@pytest.mark.asyncio
+async def test_an_unconnected_caller_naming_no_room_is_told_to_connect(
+    protocol: _Protocol, unbound_caller: None
+) -> None:
+    """The old error survives, but only for the case it actually describes."""
+    with pytest.raises(ValueError, match="connect_to_room"):
+        await read_context()
+
+
+@pytest.mark.asyncio
+async def test_the_room_is_advertised_as_an_argument() -> None:
+    """Agents learn the tool from its generated schema, so it must appear there."""
+    from switch_core.bridges.agent.operations.registry import get_operation
+
+    op = get_operation("read_context")
+    assert op is not None
+    schema = op.input_schema
+    assert "room_id" in schema["properties"]
+    assert "room_id" not in schema.get("required", [])


### PR DESCRIPTION
## What

`read_context` takes an optional `room_id`. Omitted — the usual case — it reads the room the session is connected to, exactly as before. Given, it reads that room and leaves the caller's connection, role and event delivery untouched.

Today an agent can only read the timeline of the room it is connected to, so catching up elsewhere means travelling and dropping out of the room it was dispatched to attend.

## Authorization

Unchanged. `ProtocolService.read_context` already called `require_room_member` on every read — membership is the boundary and it is checked server-side. The connection binding only ever chose *which* room; now it only does so when no room is named. The `/rooms/{room_id}/history` HTTP handler was already reading an arbitrary room on membership alone, so this brings the tool in line with it.

The "not connected to a room" error survives, but only for the case it describes: no room named and nothing to default to.

## Also

- The Claude Code hook no longer clears the channel's unread tally when the read was aimed at another room.
- Tool description, runtime instructions and all three connector skills (plus the generated opencode skill) updated in step.

Jira: https://sandboxquantum.atlassian.net/browse/CHOO-2628

🤖 Generated with [Claude Code](https://claude.com/claude-code)