### PR TITLE
Verify SSH host keys against known_hosts

### DIFF
--- a/console/apps/switch-console-desktop/src/main/core/ssh/config/resolve-ssh-config.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/ssh/config/resolve-ssh-config.test.ts
@@ -44,6 +44,28 @@ serveralivecountmax 2
       connectTimeout: 17,
       serverAliveInterval: 60,
       serverAliveCountMax: 2,
+      userKnownHostsFile: undefined,
+      globalKnownHostsFile: undefined,
+      strictHostKeyChecking: undefined,
+      hashKnownHosts: false,
+    });
+  });
+
+  it('parses the known-hosts options the host-key check needs', () => {
+    // `none` is a real value for these files, so it is kept rather than folded
+    // away like the other optional strings.
+    const config = parseSshGOutput(`
+userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2
+globalknownhostsfile none
+stricthostkeychecking accept-new
+hashknownhosts yes
+`);
+
+    expect(config).toMatchObject({
+      userKnownHostsFile: '~/.ssh/known_hosts ~/.ssh/known_hosts2',
+      globalKnownHostsFile: 'none',
+      strictHostKeyChecking: 'accept-new',
+      hashKnownHosts: true,
     });
   });
 });

--- a/console/apps/switch-console-desktop/src/main/core/ssh/config/resolve-ssh-config.ts
+++ b/console/apps/switch-console-desktop/src/main/core/ssh/config/resolve-ssh-config.ts
@@ -29,6 +29,12 @@ export interface ResolvedSshConfig {
   connectTimeout?: number;
   serverAliveInterval?: number;
   serverAliveCountMax?: number;
+  /** Raw `UserKnownHostsFile` line: space separated, possibly quoted, may be `none`. */
+  userKnownHostsFile?: string;
+  /** Raw `GlobalKnownHostsFile` line, in the same form. */
+  globalKnownHostsFile?: string;
+  strictHostKeyChecking?: string;
+  hashKnownHosts?: boolean;
 }
 
 export interface ResolveSshConfigOptions {
@@ -105,6 +111,12 @@ export function parseSshGOutput(output: string): ResolvedSshConfig {
     connectTimeout: latestInt('connecttimeout'),
     serverAliveInterval: latestInt('serveraliveinterval'),
     serverAliveCountMax: latestInt('serveralivecountmax'),
+    // Kept raw: `none` is a real value here (use no file), so it must not be
+    // folded away like the other optional strings.
+    userKnownHostsFile: latest('userknownhostsfile'),
+    globalKnownHostsFile: latest('globalknownhostsfile'),
+    strictHostKeyChecking: latest('stricthostkeychecking'),
+    hashKnownHosts: latest('hashknownhosts')?.trim().toLowerCase() === 'yes',
   };
 }
 

--- a/console/apps/switch-console-desktop/src/main/core/ssh/connect/known-hosts.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/ssh/connect/known-hosts.test.ts
@@ -1,0 +1,333 @@
+import { createHmac } from 'node:crypto';
+import { appendFile, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  checkHostKey,
+  expandHomePath,
+  formatKnownHostsLine,
+  hostLookupKeys,
+  parseKnownHostsLine,
+  readKeyType,
+  readKnownHosts,
+  rememberHostKey,
+  splitKnownHostsFiles,
+  type KnownHostsDeps,
+} from './known-hosts';
+
+/** A well-formed SSH public key blob: length-prefixed type, then the key body. */
+function keyBlob(type: string, body: string): Buffer {
+  const name = Buffer.from(type, 'ascii');
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(name.length, 0);
+  return Buffer.concat([length, name, Buffer.from(body, 'utf8')]);
+}
+
+const HOST_KEY = keyBlob('ssh-ed25519', 'the-real-key');
+const OTHER_KEY = keyBlob('ssh-ed25519', 'someone-elses-key');
+
+function line(host: string, key: Buffer, marker = ''): string {
+  return `${marker}${host} ssh-ed25519 ${key.toString('base64')}`;
+}
+
+function deps(files: Record<string, string>): KnownHostsDeps {
+  return {
+    readFile: async (path) => {
+      const contents = files[path];
+      if (contents === undefined) throw new Error(`ENOENT: ${path}`);
+      return contents;
+    },
+    appendFile: async () => {},
+    home: '/home/alice',
+  };
+}
+
+describe('parseKnownHostsLine', () => {
+  it('skips blanks and comments', () => {
+    expect(parseKnownHostsLine('')).toBeUndefined();
+    expect(parseKnownHostsLine('   ')).toBeUndefined();
+    expect(parseKnownHostsLine('# a comment')).toBeUndefined();
+  });
+
+  it('skips lines missing a key', () => {
+    expect(parseKnownHostsLine('host.example.com ssh-ed25519')).toBeUndefined();
+  });
+
+  it('reads host patterns, type and key', () => {
+    expect(parseKnownHostsLine('a.example.com,b.example.com ssh-rsa AAAA comment')).toEqual({
+      marker: undefined,
+      patterns: ['a.example.com', 'b.example.com'],
+      keyType: 'ssh-rsa',
+      key: 'AAAA',
+    });
+  });
+
+  it('reads the @revoked and @cert-authority markers', () => {
+    expect(parseKnownHostsLine('@revoked host ssh-rsa AAAA')?.marker).toBe('revoked');
+    expect(parseKnownHostsLine('@cert-authority host ssh-rsa AAAA')?.marker).toBe('cert-authority');
+  });
+});
+
+describe('hostLookupKeys', () => {
+  it('uses the bare name on port 22 and the bracketed form otherwise', () => {
+    expect(hostLookupKeys('host.example.com', 22)).toEqual(['host.example.com']);
+    expect(hostLookupKeys('host.example.com', 2222)).toEqual(['[host.example.com]:2222']);
+  });
+});
+
+describe('checkHostKey', () => {
+  const entries = (...lines: string[]) =>
+    lines.map((raw) => parseKnownHostsLine(raw)).filter((entry) => entry !== undefined);
+
+  it('matches a stored key', () => {
+    expect(
+      checkHostKey(entries(line('host.example.com', HOST_KEY)), 'host.example.com', 22, HOST_KEY)
+    ).toEqual({ kind: 'match' });
+  });
+
+  it('reports a changed key as a mismatch, not as unknown', () => {
+    // This is the case worth catching: something is answering for the host with
+    // a key we did not pin.
+    expect(
+      checkHostKey(entries(line('host.example.com', OTHER_KEY)), 'host.example.com', 22, HOST_KEY)
+    ).toEqual({ kind: 'mismatch' });
+  });
+
+  it('reports a host with no entry as unknown', () => {
+    expect(
+      checkHostKey(entries(line('other.example.com', HOST_KEY)), 'host.example.com', 22, HOST_KEY)
+    ).toEqual({ kind: 'unknown' });
+  });
+
+  it('keeps a non-default port distinct from the same name on 22', () => {
+    const stored = entries(line('host.example.com', HOST_KEY));
+    expect(checkHostKey(stored, 'host.example.com', 2222, HOST_KEY)).toEqual({ kind: 'unknown' });
+    expect(
+      checkHostKey(
+        entries(line('[host.example.com]:2222', HOST_KEY)),
+        'host.example.com',
+        2222,
+        HOST_KEY
+      )
+    ).toEqual({ kind: 'match' });
+  });
+
+  it('matches a hashed host entry', () => {
+    const salt = Buffer.from('0123456789abcdef0123', 'utf8');
+    const digest = createHmac('sha1', salt).update('host.example.com').digest('base64');
+    const hashed = `|1|${salt.toString('base64')}|${digest}`;
+    expect(checkHostKey(entries(line(hashed, HOST_KEY)), 'host.example.com', 22, HOST_KEY)).toEqual(
+      { kind: 'match' }
+    );
+  });
+
+  it('matches a wildcard pattern', () => {
+    expect(
+      checkHostKey(entries(line('*.example.com', HOST_KEY)), 'host.example.com', 22, HOST_KEY)
+    ).toEqual({ kind: 'match' });
+  });
+
+  it('honours a negated pattern even when another pattern matches', () => {
+    expect(
+      checkHostKey(
+        entries(line('*.example.com,!host.example.com', HOST_KEY)),
+        'host.example.com',
+        22,
+        HOST_KEY
+      )
+    ).toEqual({ kind: 'unknown' });
+  });
+
+  it('refuses a revoked key', () => {
+    expect(
+      checkHostKey(
+        entries(line('host.example.com', HOST_KEY, '@revoked ')),
+        'host.example.com',
+        22,
+        HOST_KEY
+      )
+    ).toEqual({ kind: 'revoked' });
+  });
+
+  it('does not treat a cert-authority line as proof of a plain key', () => {
+    // We do not validate host certificates, so a CA line must not vouch for an
+    // arbitrary key. Unknown means the key still gets pinned on first use.
+    expect(
+      checkHostKey(
+        entries(line('host.example.com', HOST_KEY, '@cert-authority ')),
+        'host.example.com',
+        22,
+        OTHER_KEY
+      )
+    ).toEqual({ kind: 'unknown' });
+  });
+
+  it('accepts the right key when the host has several stored', () => {
+    expect(
+      checkHostKey(
+        entries(line('host.example.com', OTHER_KEY), line('host.example.com', HOST_KEY)),
+        'host.example.com',
+        22,
+        HOST_KEY
+      )
+    ).toEqual({ kind: 'match' });
+  });
+});
+
+describe('readKnownHosts', () => {
+  it('reads every file and skips ones that are missing', async () => {
+    const entries = await readKnownHosts(
+      ['~/.ssh/known_hosts', '/etc/ssh/ssh_known_hosts', '/nope'],
+      deps({
+        '/home/alice/.ssh/known_hosts': `# mine\n${line('a.example.com', HOST_KEY)}\n`,
+        '/etc/ssh/ssh_known_hosts': `${line('b.example.com', HOST_KEY)}\n`,
+      })
+    );
+    expect(entries.map((entry) => entry.patterns[0])).toEqual(['a.example.com', 'b.example.com']);
+  });
+});
+
+describe('splitKnownHostsFiles', () => {
+  it('splits on spaces and keeps quoted paths whole', () => {
+    expect(splitKnownHostsFiles('~/.ssh/known_hosts "/etc/ssh/my hosts"')).toEqual([
+      '~/.ssh/known_hosts',
+      '/etc/ssh/my hosts',
+    ]);
+  });
+
+  it('drops none, which is how OpenSSH says use no file', () => {
+    expect(splitKnownHostsFiles('none')).toEqual([]);
+    expect(splitKnownHostsFiles(undefined)).toEqual([]);
+  });
+});
+
+describe('expandHomePath', () => {
+  it('expands a leading tilde', () => {
+    expect(expandHomePath('~/.ssh/known_hosts', '/home/alice')).toBe(
+      '/home/alice/.ssh/known_hosts'
+    );
+    expect(expandHomePath('/etc/ssh/ssh_known_hosts', '/home/alice')).toBe(
+      '/etc/ssh/ssh_known_hosts'
+    );
+  });
+});
+
+describe('readKeyType', () => {
+  it('reads the algorithm name out of a key blob', () => {
+    expect(readKeyType(HOST_KEY)).toBe('ssh-ed25519');
+  });
+
+  it('returns undefined for something that is not a key blob', () => {
+    expect(readKeyType(Buffer.from('junk'))).toBeUndefined();
+    expect(readKeyType(Buffer.alloc(2))).toBeUndefined();
+  });
+});
+
+describe('formatKnownHostsLine', () => {
+  it('writes a plain entry', () => {
+    expect(formatKnownHostsLine('host.example.com', 22, 'ssh-ed25519', HOST_KEY)).toBe(
+      `host.example.com ssh-ed25519 ${HOST_KEY.toString('base64')}\n`
+    );
+  });
+
+  it('writes a hashed entry that reads back as a match', () => {
+    const written = formatKnownHostsLine('host.example.com', 2222, 'ssh-ed25519', HOST_KEY, {
+      hash: true,
+      salt: Buffer.from('0123456789abcdef0123', 'utf8'),
+    });
+    const entry = parseKnownHostsLine(written);
+    expect(entry).toBeDefined();
+    expect(checkHostKey([entry!], 'host.example.com', 2222, HOST_KEY)).toEqual({ kind: 'match' });
+  });
+});
+
+describe('rememberHostKey', () => {
+  function recorder(existing: string | Error): {
+    deps: KnownHostsDeps;
+    written: string[];
+  } {
+    const written: string[] = [];
+    return {
+      written,
+      deps: {
+        readFile: async () => {
+          if (existing instanceof Error) throw existing;
+          return existing;
+        },
+        appendFile: async (_path, contents) => {
+          written.push(contents);
+        },
+        home: '/home/alice',
+      },
+    };
+  }
+
+  const NEW_LINE = 'new.example.com ssh-ed25519 AAAA\n';
+
+  it('starts a line when known_hosts does not end in one', async () => {
+    // Appending straight onto a hand-edited file would weld the new entry to
+    // the last one and lose both.
+    const { deps: recording, written } = recorder('good.example.com ssh-ed25519 BBBB');
+    expect(await rememberHostKey('~/.ssh/known_hosts', NEW_LINE, recording)).toBe(true);
+    expect(written).toEqual([`\n${NEW_LINE}`]);
+  });
+
+  it('does not add a blank line when the file already ends in one', async () => {
+    const { deps: recording, written } = recorder('good.example.com ssh-ed25519 BBBB\n');
+    expect(await rememberHostKey('~/.ssh/known_hosts', NEW_LINE, recording)).toBe(true);
+    expect(written).toEqual([NEW_LINE]);
+  });
+
+  it('writes the first entry of a new or empty file as-is', async () => {
+    const missing = recorder(new Error('ENOENT'));
+    expect(await rememberHostKey('~/.ssh/known_hosts', NEW_LINE, missing.deps)).toBe(true);
+    expect(missing.written).toEqual([NEW_LINE]);
+
+    const empty = recorder('');
+    expect(await rememberHostKey('~/.ssh/known_hosts', NEW_LINE, empty.deps)).toBe(true);
+    expect(empty.written).toEqual([NEW_LINE]);
+  });
+
+  it('refuses a path that is not absolute once expanded', async () => {
+    const { deps: recording, written } = recorder('');
+    expect(await rememberHostKey('relative/known_hosts', NEW_LINE, recording)).toBe(false);
+    expect(written).toEqual([]);
+  });
+
+  it('reports failure rather than throwing when the file cannot be written', async () => {
+    const { deps: recording } = recorder('');
+    expect(
+      await rememberHostKey('~/.ssh/known_hosts', NEW_LINE, {
+        ...recording,
+        appendFile: async () => {
+          throw new Error('EACCES');
+        },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('a real known_hosts file on disk', () => {
+  it('survives a first-use append and reads back as a match', async () => {
+    // The end-to-end shape of the thing: a file with no trailing newline, an
+    // append, then a re-read that must find both the old and the new entry.
+    const dir = await mkdtemp(join(tmpdir(), 'switch-known-hosts-'));
+    const file = join(dir, 'known_hosts');
+    await writeFile(file, `good.example.com ssh-ed25519 ${OTHER_KEY.toString('base64')}`);
+
+    const realDeps: KnownHostsDeps = {
+      readFile: async (path) => await readFile(path, 'utf8'),
+      appendFile: async (path, contents) => await appendFile(path, contents),
+      home: '/home/alice',
+    };
+
+    const line = formatKnownHostsLine('new.example.com', 2222, 'ssh-ed25519', HOST_KEY);
+    expect(await rememberHostKey(file, line, realDeps)).toBe(true);
+
+    const entries = await readKnownHosts([file], realDeps);
+    expect(entries).toHaveLength(2);
+    expect(checkHostKey(entries, 'good.example.com', 22, OTHER_KEY)).toEqual({ kind: 'match' });
+    expect(checkHostKey(entries, 'new.example.com', 2222, HOST_KEY)).toEqual({ kind: 'match' });
+  });
+});

--- a/console/apps/switch-console-desktop/src/main/core/ssh/connect/known-hosts.ts
+++ b/console/apps/switch-console-desktop/src/main/core/ssh/connect/known-hosts.ts
@@ -1,0 +1,254 @@
+// OpenSSH known_hosts handling for the ssh2 host-key check.
+//
+// ssh2 accepts any host key when no `hostVerifier` is given, so without this the
+// Console would complete a connection to whatever answers on the address and hand
+// it the user's credentials or forwarded agent. This reads the same known_hosts
+// files OpenSSH would use for the host (resolved from `ssh -G`), pins the key on
+// first use, and refuses to connect when a pinned key changes.
+
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { appendFile, readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
+
+export type KnownHostsMarker = 'cert-authority' | 'revoked';
+
+export interface KnownHostsEntry {
+  marker?: KnownHostsMarker;
+  /** Raw host patterns, still comma-separated as written in the file. */
+  patterns: string[];
+  keyType: string;
+  /** base64 key blob exactly as stored. */
+  key: string;
+}
+
+export type HostKeyVerdict =
+  /** A stored key for this host matches the one offered. */
+  | { kind: 'match' }
+  /** A key is stored for this host and it is NOT the one offered. */
+  | { kind: 'mismatch' }
+  /** The offered key is explicitly revoked. */
+  | { kind: 'revoked' }
+  /** Nothing is stored for this host. */
+  | { kind: 'unknown' };
+
+/**
+ * Parse one known_hosts line. Returns undefined for blanks, comments, and lines
+ * we cannot make sense of, which is what OpenSSH does: an unreadable line is
+ * skipped rather than treated as an error.
+ */
+export function parseKnownHostsLine(line: string): KnownHostsEntry | undefined {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) return undefined;
+
+  let fields = trimmed.split(/\s+/);
+  let marker: KnownHostsMarker | undefined;
+  if (fields[0] === '@cert-authority' || fields[0] === '@revoked') {
+    marker = fields[0].slice(1) as KnownHostsMarker;
+    fields = fields.slice(1);
+  }
+
+  const [hosts, keyType, key] = fields;
+  if (!hosts || !keyType || !key) return undefined;
+
+  return { marker, patterns: hosts.split(','), keyType, key };
+}
+
+function hashedPatternMatches(pattern: string, host: string): boolean {
+  // |1|<base64 salt>|<base64 HMAC-SHA1 of the host under that salt>
+  const parts = pattern.split('|');
+  if (parts.length !== 4 || parts[1] !== '1') return false;
+  const [, , salt, digest] = parts;
+  try {
+    const expected = createHmac('sha1', Buffer.from(salt, 'base64')).update(host).digest('base64');
+    return expected === digest;
+  } catch {
+    return false;
+  }
+}
+
+function globPatternMatches(pattern: string, host: string): boolean {
+  if (!pattern.includes('*') && !pattern.includes('?')) return pattern === host;
+  const source = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${source}$`).test(host);
+}
+
+/**
+ * The names OpenSSH looks a host up under. A non-default port is only ever
+ * stored in the bracketed form, so both are checked and `[host]:22` is not.
+ */
+export function hostLookupKeys(host: string, port: number): string[] {
+  return port === 22 ? [host] : [`[${host}]:${port}`];
+}
+
+function entryMatchesHost(entry: KnownHostsEntry, lookupKeys: string[]): boolean {
+  let matched = false;
+  for (const pattern of entry.patterns) {
+    // A leading `!` excludes the host outright, even if a later pattern matches.
+    const negated = pattern.startsWith('!');
+    const bare = negated ? pattern.slice(1) : pattern;
+    const hit = bare.startsWith('|')
+      ? lookupKeys.some((name) => hashedPatternMatches(bare, name))
+      : lookupKeys.some((name) => globPatternMatches(bare, name));
+    if (!hit) continue;
+    if (negated) return false;
+    matched = true;
+  }
+  return matched;
+}
+
+function sameKey(storedBase64: string, offered: Buffer): boolean {
+  let stored: Buffer;
+  try {
+    stored = Buffer.from(storedBase64, 'base64');
+  } catch {
+    return false;
+  }
+  if (stored.length !== offered.length) return false;
+  return timingSafeEqual(stored, offered);
+}
+
+/**
+ * Decide what the known_hosts entries say about the key a server just offered.
+ *
+ * A `@cert-authority` line is reported as `unknown` rather than `match`: this
+ * does not validate host certificates, and treating a CA line as proof would
+ * accept any key for that host. Reporting it unknown means the host still gets
+ * pinned on first use and a later change is still caught.
+ */
+export function checkHostKey(
+  entries: KnownHostsEntry[],
+  host: string,
+  port: number,
+  offeredKey: Buffer
+): HostKeyVerdict {
+  const lookupKeys = hostLookupKeys(host, port);
+  let sawHost = false;
+
+  for (const entry of entries) {
+    if (!entryMatchesHost(entry, lookupKeys)) continue;
+    if (entry.marker === 'cert-authority') continue;
+
+    const keyMatches = sameKey(entry.key, offeredKey);
+    if (entry.marker === 'revoked') {
+      if (keyMatches) return { kind: 'revoked' };
+      continue;
+    }
+    if (keyMatches) return { kind: 'match' };
+    sawHost = true;
+  }
+
+  return sawHost ? { kind: 'mismatch' } : { kind: 'unknown' };
+}
+
+export function expandHomePath(path: string, home: string = homedir()): string {
+  if (path === '~') return home;
+  if (path.startsWith('~/')) return join(home, path.slice(2));
+  return path;
+}
+
+/**
+ * Split the space-separated file list `ssh -G` prints, honouring the double
+ * quotes OpenSSH uses around paths that contain spaces.
+ */
+export function splitKnownHostsFiles(value: string | undefined): string[] {
+  if (!value) return [];
+  const paths: string[] = [];
+  for (const match of value.matchAll(/"([^"]*)"|(\S+)/g)) {
+    const path = match[1] ?? match[2];
+    if (path && path.toLowerCase() !== 'none') paths.push(path);
+  }
+  return paths;
+}
+
+export interface KnownHostsDeps {
+  readFile: (path: string) => Promise<string>;
+  appendFile: (path: string, contents: string) => Promise<void>;
+  home: string;
+}
+
+export function defaultKnownHostsDeps(): KnownHostsDeps {
+  return {
+    readFile: async (path) => await readFile(path, 'utf8'),
+    // 0o600: the file records which hosts this user connects to.
+    appendFile: async (path, contents) => await appendFile(path, contents, { mode: 0o600 }),
+    home: homedir(),
+  };
+}
+
+/** Read and parse every readable known_hosts file. Missing files are not an error. */
+export async function readKnownHosts(
+  files: string[],
+  deps: KnownHostsDeps
+): Promise<KnownHostsEntry[]> {
+  const entries: KnownHostsEntry[] = [];
+  for (const file of files) {
+    let contents: string;
+    try {
+      contents = await deps.readFile(expandHomePath(file, deps.home));
+    } catch {
+      continue;
+    }
+    for (const line of contents.split(/\r?\n/)) {
+      const entry = parseKnownHostsLine(line);
+      if (entry) entries.push(entry);
+    }
+  }
+  return entries;
+}
+
+/**
+ * Read the algorithm name out of an SSH public key blob, which starts with a
+ * 4-byte big-endian length followed by that many bytes of name.
+ */
+export function readKeyType(key: Buffer): string | undefined {
+  if (key.length < 4) return undefined;
+  const length = key.readUInt32BE(0);
+  if (length === 0 || length > 64 || key.length < 4 + length) return undefined;
+  const name = key.subarray(4, 4 + length).toString('ascii');
+  return /^[\x21-\x7e]+$/.test(name) ? name : undefined;
+}
+
+export function formatKnownHostsLine(
+  host: string,
+  port: number,
+  keyType: string,
+  key: Buffer,
+  options: { hash?: boolean; salt?: Buffer } = {}
+): string {
+  const [name] = hostLookupKeys(host, port);
+  if (!options.hash) return `${name} ${keyType} ${key.toString('base64')}\n`;
+  // Same 20-byte SHA1-sized salt OpenSSH uses for hashed entries.
+  const salt = options.salt ?? randomBytes(20);
+  const digest = createHmac('sha1', salt).update(name).digest('base64');
+  return `|1|${salt.toString('base64')}|${digest} ${keyType} ${key.toString('base64')}\n`;
+}
+
+/** Append a first-use entry. A failure here must not fail the connection. */
+export async function rememberHostKey(
+  file: string,
+  line: string,
+  deps: KnownHostsDeps
+): Promise<boolean> {
+  const path = expandHomePath(file, deps.home);
+  if (!isAbsolute(path)) return false;
+  try {
+    // A hand-edited known_hosts often has no trailing newline. Appending
+    // straight onto it would weld the new entry to the last one and lose both,
+    // so start a line first when the file does not already end in one.
+    let separator = '';
+    try {
+      const existing = await deps.readFile(path);
+      if (existing !== '' && !existing.endsWith('\n')) separator = '\n';
+    } catch {
+      // No file yet, so there is nothing to run into.
+    }
+    await deps.appendFile(path, `${separator}${line}`);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/console/apps/switch-console-desktop/src/main/core/ssh/connect/resolve-ssh-connect-config.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/ssh/connect/resolve-ssh-connect-config.test.ts
@@ -776,4 +776,60 @@ describe('resolveSshConnectConfig', () => {
     expect(readFiles).toEqual([expect.stringContaining('/.ssh/corp_ed25519')]);
     expect(result.config.privateKey).toBe('ALIAS KEY');
   });
+
+  it('always attaches a host-key check, because ssh2 trusts any key without one', async () => {
+    const result = await resolveSshConnectConfig(
+      { kind: 'transient', config: { ...baseConfig(), password: 'secret' } },
+      deps()
+    );
+
+    expect(typeof result.config.hostVerifier).toBe('function');
+  });
+
+  it('refuses a host key that does not match the alias-resolved known_hosts', async () => {
+    const readKnownHosts: string[] = [];
+    const result = await resolveSshConnectConfig(
+      {
+        kind: 'transient',
+        config: { ...baseConfig({ sshConfigAlias: 'corp-dev' }), password: 'secret' },
+      },
+      deps({
+        resolveSshConfig: async () => ({
+          hostname: 'dev.internal',
+          user: 'deploy',
+          port: 2222,
+          identityFile: [],
+          identityAgentDisabled: false,
+          identitiesOnly: false,
+          forwardAgent: false,
+          userKnownHostsFile: '/home/alice/.ssh/known_hosts',
+          globalKnownHostsFile: 'none',
+          strictHostKeyChecking: 'ask',
+          hashKnownHosts: false,
+        }),
+        knownHosts: {
+          readFile: async (path) => {
+            readKnownHosts.push(path);
+            // A key pinned for this host, but not the one the server offers.
+            return `[dev.internal]:2222 ssh-ed25519 ${Buffer.from('pinned').toString('base64')}\n`;
+          },
+          appendFile: async () => {
+            throw new Error('a mismatched key must never be recorded');
+          },
+          home: '/home/alice',
+        },
+      })
+    );
+
+    const verifier = result.config.hostVerifier as (
+      key: Buffer,
+      verify: (ok: boolean) => void
+    ) => void;
+    const accepted = await new Promise<boolean>((resolve) => {
+      verifier(Buffer.from('a different key'), resolve);
+    });
+
+    expect(accepted).toBe(false);
+    expect(readKnownHosts).toEqual(['/home/alice/.ssh/known_hosts']);
+  });
 });

--- a/console/apps/switch-console-desktop/src/main/core/ssh/connect/resolve-ssh-connect-config.ts
+++ b/console/apps/switch-console-desktop/src/main/core/ssh/connect/resolve-ssh-connect-config.ts
@@ -17,8 +17,10 @@ import {
   type ProxyTokens,
   type TransportResult,
 } from '../transport/transports';
+import { splitKnownHostsFiles, type KnownHostsDeps } from './known-hosts';
 import { buildAuthConfig } from './ssh-connect-auth';
 import { applyForwardAgent } from './ssh-connect-forward-agent';
+import { createHostVerifier, normalizeStrictHostKeyChecking } from './ssh-connect-host-key';
 
 const { createAgent } = ssh2;
 
@@ -45,7 +47,12 @@ export interface SshConnectDeps {
   ) => Omit<TransportResult, 'process'>;
   createAgent: (socketPath: string) => BaseAgent;
   env: Record<string, string | undefined>;
+  knownHosts?: Partial<KnownHostsDeps>;
 }
+
+// What OpenSSH uses when no ssh-config alias resolved these for us.
+const DEFAULT_USER_KNOWN_HOSTS_FILE = '~/.ssh/known_hosts';
+const DEFAULT_GLOBAL_KNOWN_HOSTS_FILES = '/etc/ssh/ssh_known_hosts';
 
 function defaultDeps(): SshConnectDeps {
   return {
@@ -57,6 +64,37 @@ function defaultDeps(): SshConnectDeps {
     createAgent,
     env: process.env,
   };
+}
+
+function buildHostVerifier(
+  host: string,
+  port: number,
+  resolved: ResolvedSshConfig | undefined,
+  deps: SshConnectDeps,
+  onDebug: (message: string) => void
+) {
+  const userFiles = splitKnownHostsFiles(
+    resolved?.userKnownHostsFile ?? DEFAULT_USER_KNOWN_HOSTS_FILE
+  );
+  const globalFiles = splitKnownHostsFiles(
+    resolved?.globalKnownHostsFile ?? DEFAULT_GLOBAL_KNOWN_HOSTS_FILES
+  );
+
+  return createHostVerifier(
+    {
+      host,
+      port,
+      knownHostsFiles: [...userFiles, ...globalFiles],
+      // OpenSSH records a first-use key in the first user file only. With
+      // `UserKnownHostsFile none` there is nowhere to record it, so the key is
+      // checked but never pinned.
+      writeToFile: userFiles[0],
+      strictHostKeyChecking: normalizeStrictHostKeyChecking(resolved?.strictHostKeyChecking),
+      hashKnownHosts: resolved?.hashKnownHosts === true,
+      onDebug,
+    },
+    deps.knownHosts ?? {}
+  );
 }
 
 export async function resolveSshConnectConfig(
@@ -92,6 +130,13 @@ export async function resolveSshConnectConfig(
   applyForwardAgent(config, forwardAgent, resolved, authResult, deps);
 
   let debugLogs: string[] = [];
+  // ssh2 trusts any host key unless a hostVerifier says otherwise, so this is
+  // what stops the Console handing credentials and a forwarded agent to whoever
+  // answers the address. It reads the same known_hosts OpenSSH would.
+  config.hostVerifier = buildHostVerifier(host, port, resolved, deps, (message) =>
+    debugLogs.push(message)
+  );
+
   let cleanup = () => {};
   const tokens: ProxyTokens = { host, port, username, originalHost: alias ?? base.host };
   const proxyCommand = alias ? resolved?.proxyCommand : undefined;

--- a/console/apps/switch-console-desktop/src/main/core/ssh/connect/ssh-connect-host-key.test.ts
+++ b/console/apps/switch-console-desktop/src/main/core/ssh/connect/ssh-connect-host-key.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import type { KnownHostsDeps } from './known-hosts';
+import {
+  createHostVerifier,
+  normalizeStrictHostKeyChecking,
+  type HostKeyPolicy,
+} from './ssh-connect-host-key';
+
+function keyBlob(body: string): Buffer {
+  const name = Buffer.from('ssh-ed25519', 'ascii');
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(name.length, 0);
+  return Buffer.concat([length, name, Buffer.from(body, 'utf8')]);
+}
+
+const HOST_KEY = keyBlob('the-real-key');
+const OTHER_KEY = keyBlob('someone-elses-key');
+
+const KNOWN_HOSTS = '/home/alice/.ssh/known_hosts';
+
+function policy(overrides: Partial<HostKeyPolicy> = {}): HostKeyPolicy {
+  return {
+    host: 'host.example.com',
+    port: 22,
+    knownHostsFiles: [KNOWN_HOSTS],
+    writeToFile: KNOWN_HOSTS,
+    strictHostKeyChecking: 'ask',
+    hashKnownHosts: false,
+    ...overrides,
+  };
+}
+
+function deps(contents: string | Error): { deps: Partial<KnownHostsDeps>; appended: string[] } {
+  const appended: string[] = [];
+  return {
+    appended,
+    deps: {
+      readFile: async () => {
+        if (contents instanceof Error) throw contents;
+        return contents;
+      },
+      appendFile: async (_path, line) => {
+        appended.push(line);
+      },
+      home: '/home/alice',
+    },
+  };
+}
+
+async function verify(
+  hostKeyPolicy: HostKeyPolicy,
+  knownHostsDeps: Partial<KnownHostsDeps>,
+  key: Buffer
+): Promise<boolean> {
+  const verifier = createHostVerifier(hostKeyPolicy, knownHostsDeps);
+  return await new Promise<boolean>((resolve) => {
+    verifier(key, resolve);
+  });
+}
+
+describe('normalizeStrictHostKeyChecking', () => {
+  it('reads the values OpenSSH accepts and falls back to ask', () => {
+    expect(normalizeStrictHostKeyChecking('yes')).toBe('yes');
+    expect(normalizeStrictHostKeyChecking('  ACCEPT-NEW ')).toBe('accept-new');
+    expect(normalizeStrictHostKeyChecking('off')).toBe('off');
+    expect(normalizeStrictHostKeyChecking(undefined)).toBe('ask');
+    expect(normalizeStrictHostKeyChecking('nonsense')).toBe('ask');
+  });
+});
+
+describe('createHostVerifier', () => {
+  const storedLine = (key: Buffer) => `host.example.com ssh-ed25519 ${key.toString('base64')}\n`;
+
+  it('accepts the pinned key', async () => {
+    const { deps: knownHosts, appended } = deps(storedLine(HOST_KEY));
+    expect(await verify(policy(), knownHosts, HOST_KEY)).toBe(true);
+    expect(appended).toEqual([]);
+  });
+
+  it('refuses a key that is not the pinned one', async () => {
+    // The MITM case: the address answers, but with a key we never pinned.
+    const { deps: knownHosts, appended } = deps(storedLine(OTHER_KEY));
+    expect(await verify(policy(), knownHosts, HOST_KEY)).toBe(false);
+    expect(appended).toEqual([]);
+  });
+
+  it('refuses a revoked key', async () => {
+    const { deps: knownHosts } = deps(`@revoked ${storedLine(HOST_KEY)}`);
+    expect(await verify(policy(), knownHosts, HOST_KEY)).toBe(false);
+  });
+
+  it('pins an unknown host on first use', async () => {
+    const { deps: knownHosts, appended } = deps('');
+    expect(await verify(policy(), knownHosts, HOST_KEY)).toBe(true);
+    expect(appended).toEqual([storedLine(HOST_KEY)]);
+  });
+
+  it('pins an unknown host when known_hosts does not exist yet', async () => {
+    const { deps: knownHosts, appended } = deps(new Error('ENOENT'));
+    expect(await verify(policy(), knownHosts, HOST_KEY)).toBe(true);
+    expect(appended).toEqual([storedLine(HOST_KEY)]);
+  });
+
+  it('refuses an unknown host under StrictHostKeyChecking=yes', async () => {
+    const { deps: knownHosts, appended } = deps('');
+    expect(await verify(policy({ strictHostKeyChecking: 'yes' }), knownHosts, HOST_KEY)).toBe(
+      false
+    );
+    expect(appended).toEqual([]);
+  });
+
+  it('still refuses a changed key under StrictHostKeyChecking=no', async () => {
+    // `no` only relaxes the unknown-host prompt. A key that changed under us is
+    // refused whatever the setting says.
+    const { deps: knownHosts } = deps(storedLine(OTHER_KEY));
+    expect(await verify(policy({ strictHostKeyChecking: 'no' }), knownHosts, HOST_KEY)).toBe(false);
+  });
+
+  it('connects without recording when there is no file to write to', async () => {
+    const { deps: knownHosts, appended } = deps('');
+    expect(await verify(policy({ writeToFile: undefined }), knownHosts, HOST_KEY)).toBe(true);
+    expect(appended).toEqual([]);
+  });
+
+  it('connects even when the key cannot be written', async () => {
+    const { deps: knownHosts } = deps('');
+    expect(
+      await verify(
+        policy(),
+        {
+          ...knownHosts,
+          appendFile: async () => {
+            throw new Error('EACCES');
+          },
+        },
+        HOST_KEY
+      )
+    ).toBe(true);
+  });
+
+  it('writes a hashed entry when HashKnownHosts is on', async () => {
+    const { deps: knownHosts, appended } = deps('');
+    expect(await verify(policy({ hashKnownHosts: true }), knownHosts, HOST_KEY)).toBe(true);
+    expect(appended).toHaveLength(1);
+    expect(appended[0]).toMatch(/^\|1\|[^|]+\|[^ ]+ ssh-ed25519 /);
+  });
+
+  it('reports the outcome through the debug log', async () => {
+    const messages: string[] = [];
+    const { deps: knownHosts } = deps(storedLine(OTHER_KEY));
+    await verify(policy({ onDebug: (message) => messages.push(message) }), knownHosts, HOST_KEY);
+    expect(messages.join('\n')).toContain('does NOT match known_hosts');
+  });
+});

--- a/console/apps/switch-console-desktop/src/main/core/ssh/connect/ssh-connect-host-key.ts
+++ b/console/apps/switch-console-desktop/src/main/core/ssh/connect/ssh-connect-host-key.ts
@@ -1,0 +1,121 @@
+// Builds the ssh2 `hostVerifier` from the host's OpenSSH known_hosts state.
+import type { HostVerifier } from 'ssh2';
+import {
+  checkHostKey,
+  defaultKnownHostsDeps,
+  formatKnownHostsLine,
+  readKeyType,
+  readKnownHosts,
+  rememberHostKey,
+  type KnownHostsDeps,
+} from './known-hosts';
+
+/** The StrictHostKeyChecking values OpenSSH accepts, lowercased. */
+export type StrictHostKeyChecking = 'yes' | 'no' | 'off' | 'ask' | 'accept-new';
+
+export interface HostKeyPolicy {
+  host: string;
+  port: number;
+  /** known_hosts files to read, in the order OpenSSH would read them. */
+  knownHostsFiles: string[];
+  /** The file a first-use key is written to. Omit to never write. */
+  writeToFile?: string;
+  strictHostKeyChecking: StrictHostKeyChecking;
+  hashKnownHosts: boolean;
+  onDebug?: (message: string) => void;
+}
+
+export function normalizeStrictHostKeyChecking(value: string | undefined): StrictHostKeyChecking {
+  switch (value?.trim().toLowerCase()) {
+    case 'yes':
+      return 'yes';
+    case 'no':
+      return 'no';
+    case 'off':
+      return 'off';
+    case 'accept-new':
+      return 'accept-new';
+    default:
+      // OpenSSH's default is `ask`, and anything unrecognised is treated as it.
+      return 'ask';
+  }
+}
+
+/**
+ * Trust an unknown host on first use?
+ *
+ * `yes` refuses, matching OpenSSH. `no`/`off`/`accept-new` accept and record the
+ * key, also matching OpenSSH. `ask` would prompt, which this path cannot do: it
+ * runs inside a pooled connection with no window to prompt from, and refusing
+ * would make every first connection fail. It records the key instead, so the
+ * host is pinned from then on and a later change is refused.
+ */
+function acceptsUnknownHost(strict: StrictHostKeyChecking): boolean {
+  return strict !== 'yes';
+}
+
+export function createHostVerifier(
+  policy: HostKeyPolicy,
+  depsOverride: Partial<KnownHostsDeps> = {}
+): HostVerifier {
+  const deps: KnownHostsDeps = { ...defaultKnownHostsDeps(), ...depsOverride };
+  const debug = policy.onDebug ?? (() => {});
+  const where = `${policy.host}:${policy.port}`;
+
+  return (key, verify) => {
+    void (async () => {
+      let accepted: boolean;
+      try {
+        const entries = await readKnownHosts(policy.knownHostsFiles, deps);
+        const verdict = checkHostKey(entries, policy.host, policy.port, key);
+
+        if (verdict.kind === 'match') {
+          debug(`host key for ${where} matches known_hosts`);
+          accepted = true;
+        } else if (verdict.kind === 'revoked') {
+          debug(`host key for ${where} is revoked in known_hosts, refusing`);
+          accepted = false;
+        } else if (verdict.kind === 'mismatch') {
+          // The stored key changed. Either the host was rebuilt or someone is
+          // in the middle, and we cannot tell which, so refuse either way.
+          debug(`host key for ${where} does NOT match known_hosts, refusing`);
+          accepted = false;
+        } else if (acceptsUnknownHost(policy.strictHostKeyChecking)) {
+          await recordFirstUse(policy, key, deps, debug);
+          accepted = true;
+        } else {
+          debug(`host key for ${where} is unknown and StrictHostKeyChecking=yes, refusing`);
+          accepted = false;
+        }
+      } catch (error) {
+        // Fail closed: an unreadable known_hosts must not become blind trust.
+        debug(`host key check for ${where} failed: ${String(error)}`);
+        accepted = false;
+      }
+      verify(accepted);
+    })();
+  };
+}
+
+async function recordFirstUse(
+  policy: HostKeyPolicy,
+  key: Buffer,
+  deps: KnownHostsDeps,
+  debug: (message: string) => void
+): Promise<void> {
+  const where = `${policy.host}:${policy.port}`;
+  const keyType = readKeyType(key);
+  if (!policy.writeToFile || !keyType) {
+    debug(`host key for ${where} accepted on first use but not recorded`);
+    return;
+  }
+  const line = formatKnownHostsLine(policy.host, policy.port, keyType, key, {
+    hash: policy.hashKnownHosts,
+  });
+  const written = await rememberHostKey(policy.writeToFile, line, deps);
+  debug(
+    written
+      ? `host key for ${where} accepted on first use and added to ${policy.writeToFile}`
+      : `host key for ${where} accepted on first use but ${policy.writeToFile} is not writable`
+  );
+}


### PR DESCRIPTION
ssh2 accepts any host key when no `hostVerifier` is set, and the Console never sets one. So a remote connection completes against whatever answers on the address and hands it the user's password or private key, plus the forwarded agent socket when agent forwarding is on. There is no host-key check today at all.

This adds one. It reads the same known_hosts files OpenSSH would use for that host (resolved from `ssh -G`, so aliases and `UserKnownHostsFile` / `GlobalKnownHostsFile` are honoured), matches plain, hashed, glob and negated patterns, honours `@revoked`, pins the key on first use, and refuses when a pinned key changes. `StrictHostKeyChecking` is respected: `yes` refuses an unknown host, anything else accepts and records it. A changed key is refused under every setting. An unreadable known_hosts fails closed rather than turning into blind trust.

`@cert-authority` lines are reported as unknown rather than as a match. This does not validate host certificates, and ssh2 never advertises the `*-cert-v01@openssh.com` algorithms, so a server cannot present one on this path anyway.

Tests: 44 new cases over the parser, the matcher and the verifier, plus an end-to-end case proving the resolved ConnectConfig refuses a changed key, and one against a real known_hosts file on disk. 153/153 in the ssh suite, 3100/3101 across the node project (the one failure is session-spawner, which fails the same way on main).