### PR TITLE
fix(gateway): link a verified OIDC identity to its account by email

### DIFF
--- a/core/switch_core/config.py
+++ b/core/switch_core/config.py
@@ -60,9 +60,16 @@ class SwitchConfig(BaseSettings):
     #
     # This only controls whether an unverified login is accepted at all — for
     # a brand-new identity, or one already linked to an account. It never lets
-    # an unverified email link a new identity into a *different*, pre-existing
-    # account: that always requires the IdP to assert `email_verified=true`,
-    # regardless of this setting. See UserStore.get_or_create_oidc_user.
+    # an unverified email link a *new* identity into a *different*,
+    # pre-existing account: that always requires the IdP to assert
+    # `email_verified=true`, regardless of this setting. See
+    # UserStore.get_or_create_oidc_user.
+    #
+    # Exception: a legacy identity linked before issuers were tracked at all
+    # resolves, and has its issuer backfilled, purely by matching its stored
+    # subject — it never consults email, `email_verified`, or this setting.
+    # That is not new here; it is the same subject-only match this login has
+    # always done for such a row. See OidcIdentity's docstring in models.py.
     gateway_oidc_require_email_verified: bool = True
     # Lets the password login path be disabled (OIDC-only) without code changes.
     gateway_password_login_enabled: bool = True

--- a/core/switch_core/config.py
+++ b/core/switch_core/config.py
@@ -57,6 +57,12 @@ class SwitchConfig(BaseSettings):
     # directory-provisioned users are permanently false and cannot be fixed
     # from the Okta side. Set false ONLY for a single-tenant IdP whose
     # addresses are authoritative (corporate directory, HR-provisioned).
+    #
+    # This only controls whether an unverified login is accepted at all — for
+    # a brand-new identity, or one already linked to an account. It never lets
+    # an unverified email link a new identity into a *different*, pre-existing
+    # account: that always requires the IdP to assert `email_verified=true`,
+    # regardless of this setting. See UserStore.get_or_create_oidc_user.
     gateway_oidc_require_email_verified: bool = True
     # Lets the password login path be disabled (OIDC-only) without code changes.
     gateway_password_login_enabled: bool = True

--- a/core/switch_core/db/models.py
+++ b/core/switch_core/db/models.py
@@ -71,15 +71,34 @@ class OidcIdentity(Base):
     predates the issuer being tracked at all (``oidc_sub`` stored alone); the
     application never writes a NULL issuer itself. Such a row still matches on
     ``sub`` alone and has its issuer backfilled on the next login, same as
-    before this identity had its own table — ``sub`` is unique per issuer, so
-    matching on it alone is safe in practice given a deployment registers one
-    issuer.
+    before this identity had its own table. ``UNIQUE(iss, sub)`` does not
+    constrain these rows at all — Postgres treats every NULL as distinct from
+    every other NULL — so ``ix_oidc_identities_sub_null_iss`` separately
+    enforces at most one NULL-issuer row per ``sub``; without it two different
+    users could each hold one for the same ``sub``, and which one a login
+    resolved to would depend on row order, silently annexing one account and
+    orphaning the other.
+
+    Matching a legacy row on ``sub`` alone, with no issuer or email in the
+    comparison at all, is only safe because a deployment has exactly one
+    configured issuer (``gateway_oidc_issuer_url``) today. The moment a second
+    issuer exists — a later multi-tenancy phase — two different real-world
+    identities could share the same subject string, and a legacy row would
+    resolve to whichever one asserts it first regardless of which issuer
+    actually owns it. Re-verify or purge sub-only rows before a deployment is
+    ever configured with more than one issuer.
     """
 
     __tablename__ = "oidc_identities"
     __table_args__ = (
         UniqueConstraint("iss", "sub", name="uq_oidc_identities_iss_sub"),
         Index("ix_oidc_identities_sub", "sub"),
+        Index(
+            "ix_oidc_identities_sub_null_iss",
+            "sub",
+            unique=True,
+            postgresql_where=text("iss IS NULL"),
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)

--- a/core/switch_core/db/models.py
+++ b/core/switch_core/db/models.py
@@ -51,6 +51,13 @@ class User(Base):
     )
 
 
+# An OIDC login matches an account on email case-insensitively (CHOO-2624):
+# the IdP and the person typing a password don't reliably agree on casing for
+# the same mailbox, so a case-sensitive compare would silently defeat the
+# "same account" guarantee. Backs UserStore.get_by_email's lower() compare.
+Index("ix_users_email_lower", func.lower(User.email))
+
+
 class OidcIdentity(Base):
     """A verified IdP identity linked to a user (CHOO-2624).
 
@@ -59,16 +66,25 @@ class OidcIdentity(Base):
     verified email, not on login method, so a password sign-up that later
     signs in with an IdP sharing its email gets this identity added to the
     same account rather than a second one.
+
+    ``iss`` is nullable only for rows migrated from a pre-CHOO-2624 login that
+    predates the issuer being tracked at all (``oidc_sub`` stored alone); the
+    application never writes a NULL issuer itself. Such a row still matches on
+    ``sub`` alone and has its issuer backfilled on the next login, same as
+    before this identity had its own table — ``sub`` is unique per issuer, so
+    matching on it alone is safe in practice given a deployment registers one
+    issuer.
     """
 
     __tablename__ = "oidc_identities"
     __table_args__ = (
         UniqueConstraint("iss", "sub", name="uq_oidc_identities_iss_sub"),
+        Index("ix_oidc_identities_sub", "sub"),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     user_id: Mapped[str] = mapped_column(Text, ForeignKey("users.id"), nullable=False)
-    iss: Mapped[str] = mapped_column(Text, nullable=False)
+    iss: Mapped[str | None] = mapped_column(Text, nullable=True)
     sub: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/core/switch_core/db/models.py
+++ b/core/switch_core/db/models.py
@@ -51,6 +51,30 @@ class User(Base):
     )
 
 
+class OidcIdentity(Base):
+    """A verified IdP identity linked to a user (CHOO-2624).
+
+    One row per linked ``(iss, sub)``, unique so a subject can never bind to
+    more than one account. A user may hold several — accounts are keyed on
+    verified email, not on login method, so a password sign-up that later
+    signs in with an IdP sharing its email gets this identity added to the
+    same account rather than a second one.
+    """
+
+    __tablename__ = "oidc_identities"
+    __table_args__ = (
+        UniqueConstraint("iss", "sub", name="uq_oidc_identities_iss_sub"),
+    )
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(Text, ForeignKey("users.id"), nullable=False)
+    iss: Mapped[str] = mapped_column(Text, nullable=False)
+    sub: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[str] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
 # ── API Keys ─────────────────────────────────────────────────────────────────
 
 

--- a/core/switch_core/db/stores/user_store.py
+++ b/core/switch_core/db/stores/user_store.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from switch_core.db.models import User
+from switch_core.db.models import OidcIdentity, User
 
 
 class OidcIdentityConflictError(Exception):
-    """An OIDC login's email already belongs to a different local account.
+    """An unverified OIDC login's email already belongs to a different account.
 
     Raised instead of silently linking the IdP identity to a pre-existing
-    account: auto-linking by email is an account-takeover vector.
+    account: an unverified email is attacker-controllable, so trusting it to
+    pick an account is an account-takeover vector. A verified email links
+    instead — see ``get_or_create_oidc_user``.
     """
 
 
@@ -29,20 +31,13 @@ class UserStore:
     async def get_by_oidc_identity(
         self, session: AsyncSession, *, iss: str, sub: str
     ) -> User | None:
-        """Find the user bound to this IdP identity by its immutable (iss, sub).
-
-        Legacy rows (provisioned before iss was stored) carry only ``oidc_sub``;
-        those match on sub alone and get their ``oidc_iss`` backfilled by the
-        caller. ``sub`` is unique per issuer, so matching on it is safe.
-        """
+        """Find the user linked to this IdP identity by its immutable (iss, sub)."""
         result = await session.execute(
-            select(User).where(User.metadata_["oidc_sub"].astext == sub)
+            select(User)
+            .join(OidcIdentity, OidcIdentity.user_id == User.id)
+            .where(OidcIdentity.iss == iss, OidcIdentity.sub == sub)
         )
-        for user in result.scalars().all():
-            stored_iss = (user.metadata_ or {}).get("oidc_iss")
-            if stored_iss is None or stored_iss == iss:
-                return user
-        return None
+        return result.scalar_one_or_none()
 
     async def get_or_create_oidc_user(
         self,
@@ -52,42 +47,48 @@ class UserStore:
         email: str,
         name: str,
         sub: str,
+        email_verified: bool,
     ) -> User:
         """Resolve an OIDC identity to a gateway user, provisioning on first
         login (JIT).
 
-        Identity is bound to the immutable ``(iss, sub)`` pair, never to the
-        mutable email: an existing user is only returned when its stored IdP
-        subject matches. A brand-new subject provisions a fresh ``user`` (no
-        password hash). If the email is already taken by a different local
-        account (a password user, or a different IdP subject), we refuse rather
-        than link, so a token bearing someone else's email cannot take over
-        their account (including the seeded admin).
+        Accounts are keyed on verified email, not on login method: a subject
+        already linked to a user is returned as-is (looked up on the
+        immutable ``(iss, sub)`` pair, never the mutable email). Otherwise, a
+        *verified* email that matches an existing account links this identity
+        to it — one user can hold several linked identities — so someone who
+        signed up with a password and later signs in with an IdP sharing that
+        email lands in the same account instead of a second one.
+
+        An unverified email must never pick an existing account: that is an
+        attacker-controllable claim, so a collision with a pre-existing
+        account is refused rather than linked. A brand-new email — verified
+        or not — provisions a fresh ``user`` (no password hash).
         """
         user = await self.get_by_oidc_identity(session, iss=iss, sub=sub)
         if user is not None:
-            meta = dict(user.metadata_ or {})
-            if meta.get("oidc_iss") != iss:
-                meta["oidc_iss"] = iss
-                user.metadata_ = meta
-                await session.flush()
             return user
 
-        if await self.get_by_email(session, email) is not None:
-            raise OidcIdentityConflictError(
-                f"An account with email {email!r} already exists and is not "
-                "linked to this identity."
-            )
+        existing = await self.get_by_email(session, email)
+        if existing is not None:
+            if not email_verified:
+                raise OidcIdentityConflictError(
+                    f"An account with email {email!r} already exists and this "
+                    "identity's email is not verified."
+                )
+            await self._link_identity(session, user=existing, iss=iss, sub=sub)
+            return existing
 
-        user = User(
-            name=name,
-            email=email,
-            role="user",
-            password_hash=None,
-            metadata_={"oidc_iss": iss, "oidc_sub": sub},
-        )
+        user = User(name=name, email=email, role="user", password_hash=None)
         await self.create(session, user)
+        await self._link_identity(session, user=user, iss=iss, sub=sub)
         return user
+
+    async def _link_identity(
+        self, session: AsyncSession, *, user: User, iss: str, sub: str
+    ) -> None:
+        session.add(OidcIdentity(user_id=user.id, iss=iss, sub=sub))
+        await session.flush()
 
     async def get_all(self, session: AsyncSession) -> list[User]:
         result = await session.execute(select(User))

--- a/core/switch_core/db/stores/user_store.py
+++ b/core/switch_core/db/stores/user_store.py
@@ -23,6 +23,21 @@ class OidcIdentityConflictError(Exception):
     account: an unverified email is attacker-controllable, so trusting it to
     pick an account is an account-takeover vector. A verified email links
     instead — see ``get_or_create_oidc_user``.
+
+    A rejected security decision, not a retry-able condition — distinct from
+    ``OidcIdentityRaceError``, so an operator watching for the latter is not
+    drowned in the former (or vice versa).
+    """
+
+
+class OidcIdentityRaceError(Exception):
+    """Two logins raced to provision or link the same identity or email twice
+    in a row.
+
+    Transient contention, not a security decision: the caller should retry
+    the login rather than treat this as an attack signal. Kept separate from
+    ``OidcIdentityConflictError`` so the two can be told apart in logs and
+    given different HTTP treatment at the callback.
     """
 
 
@@ -39,15 +54,32 @@ class UserStore:
         reliably agree on the casing of the same mailbox, and accounts must
         be the same account regardless. Backed by ``ix_users_email_lower``.
 
-        Uses the first match rather than requiring exactly one: two rows
-        differing only in case could already exist from before this method
-        compared case-insensitively, and a login must not turn that into a
-        500.
+        ``users.email`` is still case-sensitively unique, so two rows
+        differing only in case can already exist from before this method
+        compared case-insensitively. A login must not turn that into a 500,
+        but silently guessing between two real accounts — one of which could
+        be an admin — is exactly the kind of quiet fallback CLAUDE.md rules
+        out: ordering is made deterministic (oldest account wins, as the
+        presumed original) and the ambiguity itself is logged loudly so it
+        gets noticed and cleaned up rather than repeating unnoticed on every
+        login.
         """
         result = await session.execute(
-            select(User).where(func.lower(User.email) == email.lower())
+            select(User)
+            .where(func.lower(User.email) == email.lower())
+            .order_by(User.created_at, User.id)
         )
-        return result.scalars().first()
+        users = result.scalars().all()
+        if len(users) > 1:
+            logger.error(
+                "Multiple users share email %r case-insensitively (ids: %s); "
+                "returning the oldest. This is pre-existing duplicate data, "
+                "not something this login caused — merge or rename the "
+                "extra account(s).",
+                email,
+                [u.id for u in users],
+            )
+        return users[0] if users else None
 
     async def get_by_oidc_identity(
         self, session: AsyncSession, *, iss: str, sub: str
@@ -57,6 +89,8 @@ class UserStore:
         A row with no stored issuer predates CHOO-2624 tracking one at all; it
         matches on ``sub`` alone and has its issuer backfilled here, same as
         this identity did before it had its own table.
+        ``ix_oidc_identities_sub_null_iss`` guarantees at most one such row per
+        ``sub``, so this is a well-defined lookup and not a guess between rows.
         """
         result = await session.execute(
             select(User)
@@ -72,7 +106,7 @@ class UserStore:
                 OidcIdentity.iss.is_(None), OidcIdentity.sub == sub
             )
         )
-        identity = legacy.scalars().first()
+        identity = legacy.scalar_one_or_none()
         if identity is None:
             return None
         identity.iss = iss
@@ -100,15 +134,24 @@ class UserStore:
         signed up with a password and later signs in with an IdP sharing that
         email lands in the same account instead of a second one.
 
-        An unverified email must never pick an existing account: that is an
-        attacker-controllable claim, so a collision with a pre-existing
-        account is refused rather than linked. A brand-new email — verified
-        or not — provisions a fresh ``user`` (no password hash).
+        An unverified email must never pick an *existing, different* account:
+        that is an attacker-controllable claim, so a collision is refused
+        rather than linked. A brand-new email — verified or not — provisions
+        a fresh ``user`` (no password hash), stored lower-cased so accounts
+        this method creates don't add new case variants of their own; this
+        does not touch the casing of any pre-existing row. This guarantee
+        does not extend to a legacy identity already linked before issuers
+        were tracked (see ``get_by_oidc_identity``): that keeps resolving,
+        and backfilling its issuer, purely by matching ``sub`` — without
+        consulting email, ``email_verified``, or even the issuer on the
+        incoming claim — exactly as it did before this identity had its own
+        table.
 
         Two logins racing to provision or link the same identity or the same
-        new email hit a unique-constraint conflict rather than either one
-        silently overwriting the other; this retries once against whichever
-        row won, so the raced request resolves to that row instead of a 500.
+        new email hit a unique-constraint conflict inside a savepoint rather
+        than either one silently overwriting the other or losing the rest of
+        the caller's transaction; this retries once against whichever row
+        won, so the raced request resolves to that row instead of a 500.
         """
         for attempt in range(1, _MAX_ATTEMPTS + 1):
             user = await self.get_by_oidc_identity(session, iss=iss, sub=sub)
@@ -123,27 +166,32 @@ class UserStore:
                         "this identity's email is not verified."
                     )
                 try:
-                    await self._link_identity(session, user=existing, iss=iss, sub=sub)
+                    async with session.begin_nested():
+                        await self._link_identity(
+                            session, user=existing, iss=iss, sub=sub
+                        )
                 except IntegrityError:
-                    await self._recover_from_race(session, attempt)
+                    self._raise_if_exhausted(attempt)
                     continue
                 return existing
 
-            user = User(name=name, email=email, role="user", password_hash=None)
+            user = User(name=name, email=email.lower(), role="user", password_hash=None)
             try:
-                await self.create(session, user)
-                await self._link_identity(session, user=user, iss=iss, sub=sub)
+                async with session.begin_nested():
+                    await self.create(session, user)
+                    await self._link_identity(session, user=user, iss=iss, sub=sub)
             except IntegrityError:
-                await self._recover_from_race(session, attempt)
+                self._raise_if_exhausted(attempt)
                 continue
             return user
 
         raise AssertionError("unreachable: the loop above always returns or raises")
 
-    async def _recover_from_race(self, session: AsyncSession, attempt: int) -> None:
-        await session.rollback()
+    def _raise_if_exhausted(self, attempt: int) -> None:
+        # The savepoint above already rolled back just the failed write, not
+        # the caller's whole transaction, so nothing to undo here.
         if attempt == _MAX_ATTEMPTS:
-            raise OidcIdentityConflictError(
+            raise OidcIdentityRaceError(
                 "OIDC identity resolution raced twice in a row; refusing to "
                 "guess a winner a third time."
             )
@@ -151,13 +199,16 @@ class UserStore:
     async def _link_identity(
         self, session: AsyncSession, *, user: User, iss: str, sub: str
     ) -> None:
+        session.add(OidcIdentity(user_id=user.id, iss=iss, sub=sub))
+        await session.flush()
         # The most security-relevant event this store performs: it decides
         # which account an external identity provider can now sign in as.
+        # Logged only after the flush succeeds, so a racer that loses to a
+        # concurrent write (see get_or_create_oidc_user) never logs a link
+        # that didn't happen.
         logger.warning(
             "Linking OIDC identity (iss=%r, sub=%r) to user %s", iss, sub, user.id
         )
-        session.add(OidcIdentity(user_id=user.id, iss=iss, sub=sub))
-        await session.flush()
 
     async def get_all(self, session: AsyncSession) -> list[User]:
         result = await session.execute(select(User))

--- a/core/switch_core/db/stores/user_store.py
+++ b/core/switch_core/db/stores/user_store.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
-from sqlalchemy import select
+import logging
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from switch_core.db.models import OidcIdentity, User
+
+logger = logging.getLogger(__name__)
+
+# One retry: after a unique-constraint conflict, the row the other transaction
+# just committed is visible to the retry's lookups, so a second collision
+# would mean something other than the race this exists for.
+_MAX_ATTEMPTS = 2
 
 
 class OidcIdentityConflictError(Exception):
@@ -25,19 +35,49 @@ class UserStore:
         return await session.get(User, user_id)
 
     async def get_by_email(self, session: AsyncSession, email: str) -> User | None:
-        result = await session.execute(select(User).where(User.email == email))
-        return result.scalar_one_or_none()
+        """Case-insensitive: an IdP and a person typing a password don't
+        reliably agree on the casing of the same mailbox, and accounts must
+        be the same account regardless. Backed by ``ix_users_email_lower``.
+
+        Uses the first match rather than requiring exactly one: two rows
+        differing only in case could already exist from before this method
+        compared case-insensitively, and a login must not turn that into a
+        500.
+        """
+        result = await session.execute(
+            select(User).where(func.lower(User.email) == email.lower())
+        )
+        return result.scalars().first()
 
     async def get_by_oidc_identity(
         self, session: AsyncSession, *, iss: str, sub: str
     ) -> User | None:
-        """Find the user linked to this IdP identity by its immutable (iss, sub)."""
+        """Find the user linked to this IdP identity by its immutable (iss, sub).
+
+        A row with no stored issuer predates CHOO-2624 tracking one at all; it
+        matches on ``sub`` alone and has its issuer backfilled here, same as
+        this identity did before it had its own table.
+        """
         result = await session.execute(
             select(User)
             .join(OidcIdentity, OidcIdentity.user_id == User.id)
             .where(OidcIdentity.iss == iss, OidcIdentity.sub == sub)
         )
-        return result.scalar_one_or_none()
+        user = result.scalar_one_or_none()
+        if user is not None:
+            return user
+
+        legacy = await session.execute(
+            select(OidcIdentity).where(
+                OidcIdentity.iss.is_(None), OidcIdentity.sub == sub
+            )
+        )
+        identity = legacy.scalars().first()
+        if identity is None:
+            return None
+        identity.iss = iss
+        await session.flush()
+        return await session.get(User, identity.user_id)
 
     async def get_or_create_oidc_user(
         self,
@@ -64,29 +104,58 @@ class UserStore:
         attacker-controllable claim, so a collision with a pre-existing
         account is refused rather than linked. A brand-new email — verified
         or not — provisions a fresh ``user`` (no password hash).
+
+        Two logins racing to provision or link the same identity or the same
+        new email hit a unique-constraint conflict rather than either one
+        silently overwriting the other; this retries once against whichever
+        row won, so the raced request resolves to that row instead of a 500.
         """
-        user = await self.get_by_oidc_identity(session, iss=iss, sub=sub)
-        if user is not None:
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            user = await self.get_by_oidc_identity(session, iss=iss, sub=sub)
+            if user is not None:
+                return user
+
+            existing = await self.get_by_email(session, email)
+            if existing is not None:
+                if not email_verified:
+                    raise OidcIdentityConflictError(
+                        f"An account with email {email!r} already exists and "
+                        "this identity's email is not verified."
+                    )
+                try:
+                    await self._link_identity(session, user=existing, iss=iss, sub=sub)
+                except IntegrityError:
+                    await self._recover_from_race(session, attempt)
+                    continue
+                return existing
+
+            user = User(name=name, email=email, role="user", password_hash=None)
+            try:
+                await self.create(session, user)
+                await self._link_identity(session, user=user, iss=iss, sub=sub)
+            except IntegrityError:
+                await self._recover_from_race(session, attempt)
+                continue
             return user
 
-        existing = await self.get_by_email(session, email)
-        if existing is not None:
-            if not email_verified:
-                raise OidcIdentityConflictError(
-                    f"An account with email {email!r} already exists and this "
-                    "identity's email is not verified."
-                )
-            await self._link_identity(session, user=existing, iss=iss, sub=sub)
-            return existing
+        raise AssertionError("unreachable: the loop above always returns or raises")
 
-        user = User(name=name, email=email, role="user", password_hash=None)
-        await self.create(session, user)
-        await self._link_identity(session, user=user, iss=iss, sub=sub)
-        return user
+    async def _recover_from_race(self, session: AsyncSession, attempt: int) -> None:
+        await session.rollback()
+        if attempt == _MAX_ATTEMPTS:
+            raise OidcIdentityConflictError(
+                "OIDC identity resolution raced twice in a row; refusing to "
+                "guess a winner a third time."
+            )
 
     async def _link_identity(
         self, session: AsyncSession, *, user: User, iss: str, sub: str
     ) -> None:
+        # The most security-relevant event this store performs: it decides
+        # which account an external identity provider can now sign in as.
+        logger.warning(
+            "Linking OIDC identity (iss=%r, sub=%r) to user %s", iss, sub, user.id
+        )
         session.add(OidcIdentity(user_id=user.id, iss=iss, sub=sub))
         await session.flush()
 

--- a/core/switch_core/db/stores/user_store.py
+++ b/core/switch_core/db/stores/user_store.py
@@ -56,28 +56,32 @@ class UserStore:
 
         ``users.email`` is still case-sensitively unique, so two rows
         differing only in case can already exist from before this method
-        compared case-insensitively. A login must not turn that into a 500,
-        but silently guessing between two real accounts — one of which could
-        be an admin — is exactly the kind of quiet fallback CLAUDE.md rules
-        out: ordering is made deterministic (oldest account wins, as the
-        presumed original) and the ambiguity itself is logged loudly so it
+        compared case-insensitively. A login must not turn that into a 500;
+        neither should it silently guess between two real accounts — one of
+        which could be an admin — since a random pick that happens to change
+        between calls is a worse failure mode than a wrong-but-stable one, and
+        a wrong one nobody hears about is worse than either. So the pick is
+        made deterministic — ordered by ``id``, which is an arbitrary but
+        stable tiebreak, not a claim that the lower id is the "real" or
+        original account — and the ambiguity itself is logged loudly so it
         gets noticed and cleaned up rather than repeating unnoticed on every
         login.
         """
         result = await session.execute(
             select(User)
             .where(func.lower(User.email) == email.lower())
-            .order_by(User.created_at, User.id)
+            .order_by(User.id)
         )
         users = result.scalars().all()
         if len(users) > 1:
             logger.error(
                 "Multiple users share email %r case-insensitively (ids: %s); "
-                "returning the oldest. This is pre-existing duplicate data, "
-                "not something this login caused — merge or rename the "
-                "extra account(s).",
+                "returning %s (lowest id, an arbitrary but stable pick). This "
+                "is pre-existing duplicate data, not something this login "
+                "caused — merge or rename the extra account(s).",
                 email,
                 [u.id for u in users],
+                users[0].id,
             )
         return users[0] if users else None
 

--- a/core/switch_core/gateway/oidc_routes.py
+++ b/core/switch_core/gateway/oidc_routes.py
@@ -9,7 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import RedirectResponse
 
 from switch_core.config import SwitchConfig
-from switch_core.db.stores.user_store import OidcIdentityConflictError, UserStore
+from switch_core.db.stores.user_store import (
+    OidcIdentityConflictError,
+    OidcIdentityRaceError,
+    UserStore,
+)
 from switch_core.gateway.auth import set_session_cookie
 from switch_core.gateway.dependencies import get_config, get_session, get_user_store
 
@@ -128,6 +132,17 @@ async def oidc_callback(
     except OidcIdentityConflictError as exc:
         logger.warning("OIDC identity conflict: %s", exc)
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except OidcIdentityRaceError as exc:
+        # Transient contention, not a rejected security decision (see the
+        # exception's docstring) — 503 so an operator's dashboards can tell
+        # this apart from the 409s above rather than lumping a retry storm in
+        # with attack signal.
+        logger.warning("OIDC identity resolution raced: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Login is temporarily contended, please try again",
+            headers={"Retry-After": "1"},
+        ) from exc
     await session.commit()
 
     # Verify-at-login only: we don't persist the IdP tokens. Land the browser

--- a/core/switch_core/gateway/oidc_routes.py
+++ b/core/switch_core/gateway/oidc_routes.py
@@ -115,13 +115,15 @@ async def oidc_callback(
         )
     name = claims.get("name") or email.split("@")[0]
 
-    # Bind to the immutable issuer+subject, never the mutable email.
+    # A returning identity is looked up on the immutable issuer+subject, never
+    # the mutable email; email only decides which account a *new* identity
+    # lands in, and only once it's verified (see get_or_create_oidc_user).
     iss = claims.get("iss") or config.gateway_oidc_issuer_url
     if not iss:
         raise HTTPException(status_code=401, detail="OIDC token missing issuer")
     try:
         user = await user_store.get_or_create_oidc_user(
-            session, iss=iss, email=email, name=name, sub=sub
+            session, iss=iss, email=email, name=name, sub=sub, email_verified=verified
         )
     except OidcIdentityConflictError as exc:
         logger.warning("OIDC identity conflict: %s", exc)

--- a/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
+++ b/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
@@ -27,20 +27,22 @@ considers two NULLs equal — so a separate partial unique index enforces at
 most one such row per subject; without it, two different users sharing a
 legacy subject would both migrate cleanly and a login would then resolve to
 whichever one the lookup happened to see first. The pre-flight check below
-refuses to proceed rather than guess if it ever finds two users sharing an
-``oidc_sub`` value at all, not only the no-issuer case: two full pairs
-sharing the same ``(iss, sub)`` would otherwise die on the new unique
-constraint with a bare violation instead of a message naming which users are
-involved, and a legacy row sharing a subject with a full-pair row would
-migrate cleanly on *both* sides and then never resolve on the legacy side
-again — later logins would always match the full pair first, silently
-orphaning whichever account only the legacy row named. Either way that is a
-data problem for a human to resolve by hand, not one this migration should
-paper over by silently picking a side. The check also catches — and blocks —
-the rare legitimate case of two different issuers happening to assign the
-same subject string to two different users: telling that apart from a real
-collision automatically isn't implemented, so a human has to look and
-disambiguate it by hand either way.
+refuses to proceed rather than guess whenever a subject shared by more than
+one user is actually ambiguous: either the same ``(iss, sub)`` pair repeats
+(a real collision — it would die on the new unique constraint anyway, but
+with a bare violation instead of a message naming which users are involved),
+or the group includes a NULL issuer (a legacy row sharing a subject with
+another row of any kind, which would migrate cleanly on both sides and then
+never resolve on the legacy side again, since a later login always matches a
+recorded issuer first). Either way that is a data problem for a human to
+resolve by hand, not one this migration should paper over by silently
+picking a side.
+
+A subject shared by rows that each carry a distinct, non-NULL issuer is not
+ambiguous — a later login matches exactly one of them by its exact
+``(iss, sub)`` pair — and the tenant work ahead is exactly what will make
+that a normal shape once more than one issuer exists, so this migration must
+not refuse it: the check allows that case through.
 
 The email column also gains a case-insensitive index: linking now matches an
 existing account by email, and a compare that ignored case here would defeat
@@ -71,30 +73,32 @@ def upgrade() -> None:
             WHERE metadata ? 'oidc_sub'
             GROUP BY metadata->>'oidc_sub'
             HAVING count(*) > 1
+               AND (
+                    count(*) FILTER (WHERE metadata->>'oidc_iss' IS NULL) > 0
+                    OR count(*) FILTER (WHERE metadata->>'oidc_iss' IS NOT NULL)
+                       <> count(DISTINCT metadata->>'oidc_iss')
+                          FILTER (WHERE metadata->>'oidc_iss' IS NOT NULL)
+               )
             """
         )
     ).fetchall()
     if duplicates:
         raise RuntimeError(
             "Refusing to migrate: more than one user's oidc_sub metadata "
-            "names the same subject, and this migration cannot safely tell "
-            "them apart — two users sharing an identical (iss, sub) pair "
-            "would violate the unique constraint this migration adds, and a "
-            "legacy (no-issuer) row sharing a subject with a full pair would "
-            "migrate cleanly but then never be reachable again, since a "
-            "later login always matches the full pair first: "
+            "names the same subject in a way that is genuinely ambiguous — "
+            "either an identical (iss, sub) pair repeats (which would "
+            "violate the unique constraint this migration adds anyway), or "
+            "a legacy (no-issuer) row shares the subject with another row, "
+            "which would migrate cleanly on both sides and then never be "
+            "reachable again, since a later login always matches a recorded "
+            "issuer first: "
             + ", ".join(
                 f"{row.sub!r}: issuers {[iss or '<no issuer>' for iss in row.issuers]}"
                 for row in duplicates
             )
-            + ". This includes the rare legitimate case of two different "
-            "issuers happening to assign the same subject string to two "
-            "different users — telling that apart from a real collision "
-            "automatically isn't implemented, so it blocks here too. Resolve "
-            "by hand: for a real collision, decide which account owns the "
+            + ". Resolve by hand — decide which account actually owns the "
             "subject and clear oidc_sub from users.metadata for the "
-            "other(s); for a coincidence, disambiguate the values yourself "
-            "(this migration will not do it for you) — then re-run."
+            "other(s) — then re-run this migration."
         )
 
     op.create_table(

--- a/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
+++ b/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
@@ -1,0 +1,83 @@
+"""oidc identities become a table, not a metadata pair
+
+Revision ID: 04f27f37e474
+Revises: c8e4a10b7f36
+
+Accounts are now keyed on verified email, not on login method (CHOO-2624): a
+verified OIDC identity links to the account with a matching email instead of
+being refused. A single ``oidc_iss``/``oidc_sub`` pair in ``users.metadata``
+can only ever name one identity per user, which cannot represent that — a
+password sign-up that later links a second IdP needs a second identity on the
+same account. Identity moves into its own table instead: one row per linked
+``(iss, sub)``, unique so a subject can never be bound to more than one
+account, with a user able to hold several.
+
+Existing ``oidc_iss``/``oidc_sub`` pairs are copied into the new table and
+removed from ``metadata``, which becomes the single remaining source of truth
+going forward. Older rows that predate ``oidc_iss`` being stored (``oidc_sub``
+only, no issuer) can't be attributed to an issuer here and are left as-is;
+the application no longer reads them, but the next login from that IdP
+resolves the account the same way any first-time link does now — by the
+verified email matching the existing account — so no manual fix-up is needed.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "04f27f37e474"
+down_revision: str | Sequence[str] | None = "c8e4a10b7f36"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oidc_identities",
+        sa.Column("id", sa.Text(), primary_key=True),
+        sa.Column("user_id", sa.Text(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("iss", sa.Text(), nullable=False),
+        sa.Column("sub", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("iss", "sub", name="uq_oidc_identities_iss_sub"),
+    )
+
+    connection = op.get_bind()
+    connection.execute(
+        sa.text(
+            """
+            INSERT INTO oidc_identities (id, user_id, iss, sub)
+            SELECT gen_random_uuid()::text, id, metadata->>'oidc_iss', metadata->>'oidc_sub'
+            FROM users
+            WHERE metadata ? 'oidc_sub' AND metadata ? 'oidc_iss'
+            """
+        )
+    )
+    connection.execute(
+        sa.text(
+            "UPDATE users SET metadata = metadata - 'oidc_iss' - 'oidc_sub' "
+            "WHERE metadata ? 'oidc_sub' AND metadata ? 'oidc_iss'"
+        )
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET metadata = coalesce(metadata, '{}'::jsonb)
+                || jsonb_build_object('oidc_iss', oidc_identities.iss, 'oidc_sub', oidc_identities.sub)
+            FROM oidc_identities
+            WHERE oidc_identities.user_id = users.id
+            """
+        )
+    )
+    op.drop_table("oidc_identities")

--- a/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
+++ b/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
@@ -26,11 +26,21 @@ out or forked into a second account by a changed email.
 considers two NULLs equal — so a separate partial unique index enforces at
 most one such row per subject; without it, two different users sharing a
 legacy subject would both migrate cleanly and a login would then resolve to
-whichever one the lookup happened to see first. Two users cannot share a
-legacy subject in practice (each was some real person's login), so this
-refuses to proceed rather than guess which one is right if it ever finds one:
-that is a data problem for a human to resolve by hand, not one this migration
-should paper over by silently picking a side.
+whichever one the lookup happened to see first. The pre-flight check below
+refuses to proceed rather than guess if it ever finds two users sharing an
+``oidc_sub`` value at all, not only the no-issuer case: two full pairs
+sharing the same ``(iss, sub)`` would otherwise die on the new unique
+constraint with a bare violation instead of a message naming which users are
+involved, and a legacy row sharing a subject with a full-pair row would
+migrate cleanly on *both* sides and then never resolve on the legacy side
+again — later logins would always match the full pair first, silently
+orphaning whichever account only the legacy row named. Either way that is a
+data problem for a human to resolve by hand, not one this migration should
+paper over by silently picking a side. The check also catches — and blocks —
+the rare legitimate case of two different issuers happening to assign the
+same subject string to two different users: telling that apart from a real
+collision automatically isn't implemented, so a human has to look and
+disambiguate it by hand either way.
 
 The email column also gains a case-insensitive index: linking now matches an
 existing account by email, and a compare that ignored case here would defeat
@@ -54,9 +64,11 @@ def upgrade() -> None:
     duplicates = connection.execute(
         sa.text(
             """
-            SELECT metadata->>'oidc_sub' AS sub, count(*) AS n
+            SELECT metadata->>'oidc_sub' AS sub,
+                   count(*) AS n,
+                   array_agg(metadata->>'oidc_iss') AS issuers
             FROM users
-            WHERE metadata ? 'oidc_sub' AND NOT (metadata ? 'oidc_iss')
+            WHERE metadata ? 'oidc_sub'
             GROUP BY metadata->>'oidc_sub'
             HAVING count(*) > 1
             """
@@ -64,13 +76,25 @@ def upgrade() -> None:
     ).fetchall()
     if duplicates:
         raise RuntimeError(
-            "Refusing to migrate: more than one user shares the same legacy "
-            "oidc_sub with no recorded issuer, which cannot be told apart by "
-            "subject alone: "
-            + ", ".join(f"{row.sub!r} ({row.n} users)" for row in duplicates)
-            + ". Resolve by hand — decide which account actually owns each "
+            "Refusing to migrate: more than one user's oidc_sub metadata "
+            "names the same subject, and this migration cannot safely tell "
+            "them apart — two users sharing an identical (iss, sub) pair "
+            "would violate the unique constraint this migration adds, and a "
+            "legacy (no-issuer) row sharing a subject with a full pair would "
+            "migrate cleanly but then never be reachable again, since a "
+            "later login always matches the full pair first: "
+            + ", ".join(
+                f"{row.sub!r}: issuers {[iss or '<no issuer>' for iss in row.issuers]}"
+                for row in duplicates
+            )
+            + ". This includes the rare legitimate case of two different "
+            "issuers happening to assign the same subject string to two "
+            "different users — telling that apart from a real collision "
+            "automatically isn't implemented, so it blocks here too. Resolve "
+            "by hand: for a real collision, decide which account owns the "
             "subject and clear oidc_sub from users.metadata for the "
-            "other(s) — then re-run this migration."
+            "other(s); for a coincidence, disambiguate the values yourself "
+            "(this migration will not do it for you) — then re-run."
         )
 
     op.create_table(

--- a/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
+++ b/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
@@ -14,11 +14,17 @@ account, with a user able to hold several.
 
 Existing ``oidc_iss``/``oidc_sub`` pairs are copied into the new table and
 removed from ``metadata``, which becomes the single remaining source of truth
-going forward. Older rows that predate ``oidc_iss`` being stored (``oidc_sub``
-only, no issuer) can't be attributed to an issuer here and are left as-is;
-the application no longer reads them, but the next login from that IdP
-resolves the account the same way any first-time link does now — by the
-verified email matching the existing account — so no manual fix-up is needed.
+going forward. Rows that predate ``oidc_iss`` being stored (``oidc_sub`` only)
+are copied too, with a NULL issuer — the application still resolves those by
+subject alone and backfills the issuer on next login, exactly as it did
+before this identity had its own table, so a flag-off deployment (whose IdP
+never emits ``email_verified``, e.g. Okta's org authorization server for
+directory users) keeps logging that account in rather than being newly locked
+out or forked into a second account by a changed email.
+
+The email column also gains a case-insensitive index: linking now matches an
+existing account by email, and a compare that ignored case here would defeat
+the very guarantee this migration exists to add.
 """
 
 from collections.abc import Sequence
@@ -37,7 +43,7 @@ def upgrade() -> None:
         "oidc_identities",
         sa.Column("id", sa.Text(), primary_key=True),
         sa.Column("user_id", sa.Text(), sa.ForeignKey("users.id"), nullable=False),
-        sa.Column("iss", sa.Text(), nullable=False),
+        sa.Column("iss", sa.Text(), nullable=True),
         sa.Column("sub", sa.Text(), nullable=False),
         sa.Column(
             "created_at",
@@ -47,6 +53,8 @@ def upgrade() -> None:
         ),
         sa.UniqueConstraint("iss", "sub", name="uq_oidc_identities_iss_sub"),
     )
+    op.create_index("ix_oidc_identities_sub", "oidc_identities", ["sub"])
+    op.create_index("ix_users_email_lower", "users", [sa.text("lower(email)")])
 
     connection = op.get_bind()
     connection.execute(
@@ -55,20 +63,40 @@ def upgrade() -> None:
             INSERT INTO oidc_identities (id, user_id, iss, sub)
             SELECT gen_random_uuid()::text, id, metadata->>'oidc_iss', metadata->>'oidc_sub'
             FROM users
-            WHERE metadata ? 'oidc_sub' AND metadata ? 'oidc_iss'
+            WHERE metadata ? 'oidc_sub'
             """
         )
     )
     connection.execute(
         sa.text(
             "UPDATE users SET metadata = metadata - 'oidc_iss' - 'oidc_sub' "
-            "WHERE metadata ? 'oidc_sub' AND metadata ? 'oidc_iss'"
+            "WHERE metadata ? 'oidc_sub'"
         )
     )
 
 
 def downgrade() -> None:
+    """Best effort, not a full inverse.
+
+    A user linked to more than one identity — impossible under the old
+    single-slot ``metadata`` pair this recreates — keeps only one of them,
+    picked by whichever row this UPDATE visits last for that user. That loss
+    is inherent to the old shape, not a defect in this statement: there is
+    nowhere to put a second identity once ``oidc_identities`` is gone.
+    """
     connection = op.get_bind()
+    connection.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET metadata = coalesce(metadata, '{}'::jsonb)
+                || jsonb_build_object('oidc_sub', oidc_identities.sub)
+            FROM oidc_identities
+            WHERE oidc_identities.user_id = users.id
+                AND oidc_identities.iss IS NULL
+            """
+        )
+    )
     connection.execute(
         sa.text(
             """
@@ -77,7 +105,10 @@ def downgrade() -> None:
                 || jsonb_build_object('oidc_iss', oidc_identities.iss, 'oidc_sub', oidc_identities.sub)
             FROM oidc_identities
             WHERE oidc_identities.user_id = users.id
+                AND oidc_identities.iss IS NOT NULL
             """
         )
     )
+    op.drop_index("ix_users_email_lower", table_name="users")
+    op.drop_index("ix_oidc_identities_sub", table_name="oidc_identities")
     op.drop_table("oidc_identities")

--- a/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
+++ b/core/switch_core/migrations/versions/04f27f37e474_oidc_identities_table.py
@@ -22,6 +22,16 @@ never emits ``email_verified``, e.g. Okta's org authorization server for
 directory users) keeps logging that account in rather than being newly locked
 out or forked into a second account by a changed email.
 
+``UNIQUE(iss, sub)`` does not constrain a NULL issuer at all — Postgres never
+considers two NULLs equal — so a separate partial unique index enforces at
+most one such row per subject; without it, two different users sharing a
+legacy subject would both migrate cleanly and a login would then resolve to
+whichever one the lookup happened to see first. Two users cannot share a
+legacy subject in practice (each was some real person's login), so this
+refuses to proceed rather than guess which one is right if it ever finds one:
+that is a data problem for a human to resolve by hand, not one this migration
+should paper over by silently picking a side.
+
 The email column also gains a case-insensitive index: linking now matches an
 existing account by email, and a compare that ignored case here would defeat
 the very guarantee this migration exists to add.
@@ -39,6 +49,30 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    connection = op.get_bind()
+
+    duplicates = connection.execute(
+        sa.text(
+            """
+            SELECT metadata->>'oidc_sub' AS sub, count(*) AS n
+            FROM users
+            WHERE metadata ? 'oidc_sub' AND NOT (metadata ? 'oidc_iss')
+            GROUP BY metadata->>'oidc_sub'
+            HAVING count(*) > 1
+            """
+        )
+    ).fetchall()
+    if duplicates:
+        raise RuntimeError(
+            "Refusing to migrate: more than one user shares the same legacy "
+            "oidc_sub with no recorded issuer, which cannot be told apart by "
+            "subject alone: "
+            + ", ".join(f"{row.sub!r} ({row.n} users)" for row in duplicates)
+            + ". Resolve by hand — decide which account actually owns each "
+            "subject and clear oidc_sub from users.metadata for the "
+            "other(s) — then re-run this migration."
+        )
+
     op.create_table(
         "oidc_identities",
         sa.Column("id", sa.Text(), primary_key=True),
@@ -54,9 +88,15 @@ def upgrade() -> None:
         sa.UniqueConstraint("iss", "sub", name="uq_oidc_identities_iss_sub"),
     )
     op.create_index("ix_oidc_identities_sub", "oidc_identities", ["sub"])
+    op.create_index(
+        "ix_oidc_identities_sub_null_iss",
+        "oidc_identities",
+        ["sub"],
+        unique=True,
+        postgresql_where=sa.text("iss IS NULL"),
+    )
     op.create_index("ix_users_email_lower", "users", [sa.text("lower(email)")])
 
-    connection = op.get_bind()
     connection.execute(
         sa.text(
             """
@@ -79,10 +119,13 @@ def downgrade() -> None:
     """Best effort, not a full inverse.
 
     A user linked to more than one identity — impossible under the old
-    single-slot ``metadata`` pair this recreates — keeps only one of them,
-    picked by whichever row this UPDATE visits last for that user. That loss
-    is inherent to the old shape, not a defect in this statement: there is
-    nowhere to put a second identity once ``oidc_identities`` is gone.
+    single-slot ``metadata`` pair this recreates — keeps only one of them.
+    When an UPDATE ... FROM matches a target row against more than one source
+    row, PostgreSQL applies exactly one of them and which one is unspecified
+    — not a documented "last write wins" order, just whichever the query
+    plan happens to produce. That loss is inherent to the old shape, not a
+    defect in this statement: there is nowhere to put a second identity once
+    ``oidc_identities`` is gone.
     """
     connection = op.get_bind()
     connection.execute(
@@ -110,5 +153,6 @@ def downgrade() -> None:
         )
     )
     op.drop_index("ix_users_email_lower", table_name="users")
+    op.drop_index("ix_oidc_identities_sub_null_iss", table_name="oidc_identities")
     op.drop_index("ix_oidc_identities_sub", table_name="oidc_identities")
     op.drop_table("oidc_identities")

--- a/core/tests/switch_core/db/stores/test_user_store_oidc.py
+++ b/core/tests/switch_core/db/stores/test_user_store_oidc.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from switch_core.db.models import User
+from switch_core.db.models import OidcIdentity, User
 from switch_core.db.stores.user_store import OidcIdentityConflictError, UserStore
 
 _ISS = "https://idp.example.com"
@@ -62,9 +66,9 @@ class TestGetOrCreateOidcUser:
     async def test_verified_email_links_to_existing_account(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        # The reversal this fix makes: someone who signed up with a password
-        # and later signs in with an IdP sharing that verified email lands in
-        # the same account, not a second one.
+        # Accounts are keyed on verified email, not on login method: a
+        # password sign-up that later signs in with an IdP sharing that
+        # verified email lands in the same account, not a second one.
         store = UserStore()
         async with session_factory() as session:
             existing = User(
@@ -94,6 +98,34 @@ class TestGetOrCreateOidcUser:
                 session, iss=_ISS, sub="okta|42"
             )
             assert by_identity is not None and by_identity.id == existing.id
+
+    async def test_verified_email_links_case_insensitively(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # Accounts must be the same account regardless of how the mailbox's
+        # case was typed at signup versus how the IdP asserts it.
+        store = UserStore()
+        async with session_factory() as session:
+            existing = User(
+                name="Pat",
+                email="pat@example.com",
+                role="user",
+                password_hash="bcrypt-hash",
+            )
+            await store.create(session, existing)
+            await session.commit()
+
+            linked = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="Pat@Example.com",
+                name="Pat",
+                sub="okta|43",
+                email_verified=True,
+            )
+            await session.commit()
+
+            assert linked.id == existing.id
 
     async def test_two_subjects_same_issuer_can_both_link_to_one_account(
         self, session_factory: async_sessionmaker[AsyncSession]
@@ -135,9 +167,8 @@ class TestGetOrCreateOidcUser:
     async def test_unverified_email_collision_with_different_identity_is_refused(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        # The takeover this closes: an existing (password) admin must not be
-        # handed to an OIDC login that merely shares its email with a
-        # different, unverified subject.
+        # An unverified email is attacker-controllable, so a collision with an
+        # existing (password) account must be refused, never linked.
         store = UserStore()
         async with session_factory() as session:
             admin = User(
@@ -195,3 +226,203 @@ class TestGetOrCreateOidcUser:
                 email_verified=True,
             )
             assert again.id == owner.id
+
+    async def test_legacy_identity_without_issuer_matches_by_sub_and_backfills(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # A row migrated from before the issuer was tracked at all (oidc_sub
+        # only) must keep resolving on sub alone, exactly as it did when this
+        # identity lived in users.metadata instead of its own table.
+        store = UserStore()
+        async with session_factory() as session:
+            legacy_user = User(
+                name="Legacy",
+                email="legacy@example.com",
+                role="user",
+                password_hash=None,
+            )
+            await store.create(session, legacy_user)
+            session.add(OidcIdentity(user_id=legacy_user.id, iss=None, sub="okta|7"))
+            await session.commit()
+
+            got = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="legacy@example.com",
+                name="Legacy",
+                sub="okta|7",
+                email_verified=True,
+            )
+            assert got.id == legacy_user.id
+
+            result = await session.execute(
+                select(OidcIdentity).where(OidcIdentity.sub == "okta|7")
+            )
+            identity = result.scalar_one()
+            assert identity.iss == _ISS
+
+    async def test_legacy_identity_without_issuer_resolves_even_if_email_changed(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # A deployment with GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED=false (e.g. an
+        # Okta org authorization server, which never emits email_verified for
+        # directory users) matched a legacy sub-only row before this identity
+        # had its own table, regardless of email. That must still hold: the
+        # account is not orphaned, and no second account is forked, just
+        # because the claimed email no longer matches.
+        store = UserStore()
+        async with session_factory() as session:
+            legacy_admin = User(
+                name="Admin",
+                email="admin-old@example.com",
+                role="admin",
+                password_hash=None,
+            )
+            await store.create(session, legacy_admin)
+            session.add(OidcIdentity(user_id=legacy_admin.id, iss=None, sub="okta|8"))
+            await session.commit()
+
+            got = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="admin-new@example.com",
+                name="Admin",
+                sub="okta|8",
+                email_verified=False,
+            )
+            assert got.id == legacy_admin.id
+            assert got.role == "admin"
+            assert got.email == "admin-old@example.com"
+
+    async def test_linking_an_identity_is_logged(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        store = UserStore()
+        with caplog.at_level(
+            logging.WARNING, logger="switch_core.db.stores.user_store"
+        ):
+            async with session_factory() as session:
+                user = await store.get_or_create_oidc_user(
+                    session,
+                    iss=_ISS,
+                    email="logged@example.com",
+                    name="Logged",
+                    sub="okta|logged",
+                    email_verified=True,
+                )
+                await session.commit()
+
+        assert any(
+            _ISS in record.message
+            and "okta|logged" in record.message
+            and user.id in record.message
+            for record in caplog.records
+        )
+
+    async def test_iss_sub_unique_constraint_is_enforced_at_the_db_level(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        store = UserStore()
+        async with session_factory() as session:
+            first = User(name="A", email="a@example.com", role="user")
+            second = User(name="B", email="b@example.com", role="user")
+            await store.create(session, first)
+            await store.create(session, second)
+            session.add(OidcIdentity(user_id=first.id, iss=_ISS, sub="dup"))
+            await session.commit()
+
+            session.add(OidcIdentity(user_id=second.id, iss=_ISS, sub="dup"))
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+    async def test_concurrent_creation_of_the_same_identity_resolves_to_the_winner(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Two logins racing to provision the same brand-new (iss, sub) collide
+        # on the unique constraint; the loser must resolve to the winner's
+        # row instead of surfacing that as a 500.
+        store = UserStore()
+        async with session_factory() as winner_session:
+            winner = await store.get_or_create_oidc_user(
+                winner_session,
+                iss=_ISS,
+                email="race@example.com",
+                name="Race",
+                sub="okta|race",
+                email_verified=True,
+            )
+            await winner_session.commit()
+
+        async with session_factory() as session:
+            original_lookup = store.get_by_oidc_identity
+            calls = {"n": 0}
+
+            async def lookup_that_misses_once(
+                sess: AsyncSession, *, iss: str, sub: str
+            ):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    return None
+                return await original_lookup(sess, iss=iss, sub=sub)
+
+            monkeypatch.setattr(store, "get_by_oidc_identity", lookup_that_misses_once)
+
+            resolved = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="someone-else@example.com",
+                name="Other",
+                sub="okta|race",
+                email_verified=True,
+            )
+            assert resolved.id == winner.id
+
+    async def test_concurrent_new_email_provisioning_resolves_to_one_account(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Two logins racing to provision the same brand-new email collide on
+        # the email unique constraint; the loser must link its identity to
+        # the winner's row instead of surfacing that as a 500.
+        store = UserStore()
+        async with session_factory() as winner_session:
+            winner = await store.get_or_create_oidc_user(
+                winner_session,
+                iss=_ISS,
+                email="shared-new@example.com",
+                name="First",
+                sub="okta|first",
+                email_verified=True,
+            )
+            await winner_session.commit()
+
+        async with session_factory() as session:
+            original_lookup = store.get_by_email
+            calls = {"n": 0}
+
+            async def lookup_that_misses_once(sess: AsyncSession, email: str):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    return None
+                return await original_lookup(sess, email)
+
+            monkeypatch.setattr(store, "get_by_email", lookup_that_misses_once)
+
+            resolved = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="shared-new@example.com",
+                name="Second",
+                sub="okta|second",
+                email_verified=True,
+            )
+            assert resolved.id == winner.id
+
+            for sub in ("okta|first", "okta|second"):
+                identity = await store.get_by_oidc_identity(session, iss=_ISS, sub=sub)
+                assert identity is not None and identity.id == winner.id

--- a/core/tests/switch_core/db/stores/test_user_store_oidc.py
+++ b/core/tests/switch_core/db/stores/test_user_store_oidc.py
@@ -158,25 +158,33 @@ class TestGetOrCreateOidcUser:
         # users.email is still case-sensitively unique, so two rows differing
         # only by case can exist from before get_by_email compared
         # case-insensitively (or from a path that bypasses this store
-        # entirely). A login must not crash on that, but silently guessing
-        # between two real accounts is exactly the quiet fallback CLAUDE.md
-        # rules out: the choice must be deterministic and disclosed.
+        # entirely). A login must not crash on that, and it must not silently
+        # guess between two real accounts either — a pick that could change
+        # between calls, or that nobody is ever told about, is worse than a
+        # stable pick that gets logged. This asserts stability and disclosure,
+        # not "the right one": which id sorts lowest is arbitrary, so the test
+        # doesn't assign either row a role that implies it should win.
         store = UserStore()
         async with session_factory() as session:
-            older = User(name="Old", email="dup@example.com", role="admin")
-            newer = User(name="New", email="Dup@Example.com", role="user")
-            await store.create(session, older)
-            await store.create(session, newer)
+            first = User(name="First", email="dup@example.com", role="user")
+            second = User(name="Second", email="Dup@Example.com", role="user")
+            await store.create(session, first)
+            await store.create(session, second)
             await session.commit()
+            expected = min(first.id, second.id)
 
             with caplog.at_level(
                 logging.ERROR, logger="switch_core.db.stores.user_store"
             ):
-                found = await store.get_by_email(session, "DUP@EXAMPLE.COM")
+                # Called twice: the point being tested is that this is a
+                # stable pick, not one that happens to vary between calls.
+                first_call = await store.get_by_email(session, "DUP@EXAMPLE.COM")
+                second_call = await store.get_by_email(session, "dup@example.com")
 
-            assert found is not None and found.id == older.id
+            assert first_call is not None and first_call.id == expected
+            assert second_call is not None and second_call.id == expected
             assert any(
-                older.id in record.message and newer.id in record.message
+                first.id in record.message and second.id in record.message
                 for record in caplog.records
             )
 

--- a/core/tests/switch_core/db/stores/test_user_store_oidc.py
+++ b/core/tests/switch_core/db/stores/test_user_store_oidc.py
@@ -8,7 +8,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from switch_core.db.models import OidcIdentity, User
-from switch_core.db.stores.user_store import OidcIdentityConflictError, UserStore
+from switch_core.db.stores.user_store import (
+    OidcIdentityConflictError,
+    OidcIdentityRaceError,
+    UserStore,
+)
 
 _ISS = "https://idp.example.com"
 
@@ -34,6 +38,25 @@ class TestGetOrCreateOidcUser:
 
             again = await store.get_by_oidc_identity(session, iss=_ISS, sub="okta|9")
             assert again is not None and again.id == user.id
+
+    async def test_new_user_email_is_stored_lowercase(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # An account this method creates should not add a new case variant of
+        # its own, even though the lookup that precedes creation is already
+        # case-insensitive and would have caught a collision either way.
+        store = UserStore()
+        async with session_factory() as session:
+            user = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="New.Person@Example.com",
+                name="New",
+                sub="okta|10",
+                email_verified=True,
+            )
+            await session.commit()
+            assert user.email == "new.person@example.com"
 
     async def test_same_identity_is_returned_and_keeps_role(
         self, session_factory: async_sessionmaker[AsyncSession]
@@ -126,6 +149,36 @@ class TestGetOrCreateOidcUser:
             await session.commit()
 
             assert linked.id == existing.id
+
+    async def test_pre_existing_case_duplicate_emails_resolve_deterministically_and_log(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # users.email is still case-sensitively unique, so two rows differing
+        # only by case can exist from before get_by_email compared
+        # case-insensitively (or from a path that bypasses this store
+        # entirely). A login must not crash on that, but silently guessing
+        # between two real accounts is exactly the quiet fallback CLAUDE.md
+        # rules out: the choice must be deterministic and disclosed.
+        store = UserStore()
+        async with session_factory() as session:
+            older = User(name="Old", email="dup@example.com", role="admin")
+            newer = User(name="New", email="Dup@Example.com", role="user")
+            await store.create(session, older)
+            await store.create(session, newer)
+            await session.commit()
+
+            with caplog.at_level(
+                logging.ERROR, logger="switch_core.db.stores.user_store"
+            ):
+                found = await store.get_by_email(session, "DUP@EXAMPLE.COM")
+
+            assert found is not None and found.id == older.id
+            assert any(
+                older.id in record.message and newer.id in record.message
+                for record in caplog.records
+            )
 
     async def test_two_subjects_same_issuer_can_both_link_to_one_account(
         self, session_factory: async_sessionmaker[AsyncSession]
@@ -336,6 +389,65 @@ class TestGetOrCreateOidcUser:
             session.add(OidcIdentity(user_id=second.id, iss=_ISS, sub="dup"))
             with pytest.raises(IntegrityError):
                 await session.commit()
+
+    async def test_null_issuer_sub_unique_constraint_is_enforced_at_the_db_level(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # UNIQUE(iss, sub) does not constrain a NULL issuer at all — Postgres
+        # never treats two NULLs as equal — so this must be a separate,
+        # partial index; without it, two different users could each hold a
+        # legacy identity for the same subject and a lookup would resolve to
+        # whichever one it saw first.
+        store = UserStore()
+        async with session_factory() as session:
+            first = User(name="A", email="legacy-a@example.com", role="user")
+            second = User(name="B", email="legacy-b@example.com", role="admin")
+            await store.create(session, first)
+            await store.create(session, second)
+            session.add(OidcIdentity(user_id=first.id, iss=None, sub="dup-legacy"))
+            await session.commit()
+
+            session.add(OidcIdentity(user_id=second.id, iss=None, sub="dup-legacy"))
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+    async def test_race_exhausted_twice_raises_a_distinct_contention_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A single retry is meant for one raced write, not a store that keeps
+        # lying about what exists; a second collision must raise loudly under
+        # its own error type rather than being retried forever or mistaken
+        # for the security-rejection OidcIdentityConflictError.
+        store = UserStore()
+        async with session_factory() as winner_session:
+            await store.get_or_create_oidc_user(
+                winner_session,
+                iss=_ISS,
+                email="always-races@example.com",
+                name="Winner",
+                sub="okta|always-races",
+                email_verified=True,
+            )
+            await winner_session.commit()
+
+        async with session_factory() as session:
+
+            async def always_misses(sess: AsyncSession, *, iss: str, sub: str):
+                return None
+
+            monkeypatch.setattr(store, "get_by_oidc_identity", always_misses)
+
+            with pytest.raises(OidcIdentityRaceError):
+                await store.get_or_create_oidc_user(
+                    session,
+                    iss=_ISS,
+                    email="someone-else-again@example.com",
+                    name="Loser",
+                    sub="okta|always-races",
+                    email_verified=True,
+                )
 
     async def test_concurrent_creation_of_the_same_identity_resolves_to_the_winner(
         self,

--- a/core/tests/switch_core/db/stores/test_user_store_oidc.py
+++ b/core/tests/switch_core/db/stores/test_user_store_oidc.py
@@ -16,12 +16,20 @@ class TestGetOrCreateOidcUser:
         store = UserStore()
         async with session_factory() as session:
             user = await store.get_or_create_oidc_user(
-                session, iss=_ISS, email="new@example.com", name="New", sub="okta|9"
+                session,
+                iss=_ISS,
+                email="new@example.com",
+                name="New",
+                sub="okta|9",
+                email_verified=True,
             )
             await session.commit()
             assert user.role == "user"
             assert user.password_hash is None
-            assert user.metadata_ == {"oidc_iss": _ISS, "oidc_sub": "okta|9"}
+            assert user.metadata_ is None
+
+            again = await store.get_by_oidc_identity(session, iss=_ISS, sub="okta|9")
+            assert again is not None and again.id == user.id
 
     async def test_same_identity_is_returned_and_keeps_role(
         self, session_factory: async_sessionmaker[AsyncSession]
@@ -29,24 +37,107 @@ class TestGetOrCreateOidcUser:
         store = UserStore()
         async with session_factory() as session:
             first = await store.get_or_create_oidc_user(
-                session, iss=_ISS, email="a@example.com", name="A", sub="okta|1"
+                session,
+                iss=_ISS,
+                email="a@example.com",
+                name="A",
+                sub="okta|1",
+                email_verified=True,
             )
             await session.commit()
             first.role = "admin"
             await session.commit()
 
             again = await store.get_or_create_oidc_user(
-                session, iss=_ISS, email="a@example.com", name="A", sub="okta|1"
+                session,
+                iss=_ISS,
+                email="a@example.com",
+                name="A",
+                sub="okta|1",
+                email_verified=True,
             )
             assert again.id == first.id
             assert again.role == "admin"
 
-    async def test_email_collision_with_different_identity_is_refused(
+    async def test_verified_email_links_to_existing_account(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        # The takeover this fix closes: an existing (password) admin must not be
-        # returned to an OIDC login that merely shares its email with a
-        # different subject.
+        # The reversal this fix makes: someone who signed up with a password
+        # and later signs in with an IdP sharing that verified email lands in
+        # the same account, not a second one.
+        store = UserStore()
+        async with session_factory() as session:
+            existing = User(
+                name="Pat",
+                email="pat@example.com",
+                role="user",
+                password_hash="bcrypt-hash",
+            )
+            await store.create(session, existing)
+            await session.commit()
+
+            linked = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="pat@example.com",
+                name="Pat",
+                sub="okta|42",
+                email_verified=True,
+            )
+            await session.commit()
+
+            assert linked.id == existing.id
+            # Password login must not be weakened by the link.
+            assert linked.password_hash == "bcrypt-hash"
+
+            by_identity = await store.get_by_oidc_identity(
+                session, iss=_ISS, sub="okta|42"
+            )
+            assert by_identity is not None and by_identity.id == existing.id
+
+    async def test_two_subjects_same_issuer_can_both_link_to_one_account(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # A user may hold several identities (e.g. two Google accounts
+        # forwarding to one mailbox at the IdP) without either one being able
+        # to impersonate the other: each keeps its own (iss, sub) row and
+        # both resolve back to the same account, never to each other.
+        store = UserStore()
+        async with session_factory() as session:
+            first = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="shared@example.com",
+                name="Shared",
+                sub="okta|1",
+                email_verified=True,
+            )
+            await session.commit()
+
+            second = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="shared@example.com",
+                name="Shared",
+                sub="okta|2",
+                email_verified=True,
+            )
+            await session.commit()
+
+            assert second.id == first.id
+            assert (
+                await store.get_by_oidc_identity(session, iss=_ISS, sub="okta|1")
+            ).id == first.id  # type: ignore[union-attr]
+            assert (
+                await store.get_by_oidc_identity(session, iss=_ISS, sub="okta|2")
+            ).id == first.id  # type: ignore[union-attr]
+
+    async def test_unverified_email_collision_with_different_identity_is_refused(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        # The takeover this closes: an existing (password) admin must not be
+        # handed to an OIDC login that merely shares its email with a
+        # different, unverified subject.
         store = UserStore()
         async with session_factory() as session:
             admin = User(
@@ -65,29 +156,42 @@ class TestGetOrCreateOidcUser:
                     email="admin@example.com",
                     name="Different",
                     sub="okta|1",
+                    email_verified=False,
                 )
 
-    async def test_legacy_row_without_iss_matches_by_sub_and_backfills(
+    async def test_identity_already_bound_elsewhere_is_never_relinked(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
+        # Once (iss, sub) is bound, that lookup — not the email on the
+        # incoming claim — decides the account, so a stale or changed email on
+        # the same subject can never move the identity to someone else's row.
         store = UserStore()
         async with session_factory() as session:
-            legacy = User(
-                name="Legacy",
-                email="legacy@example.com",
-                role="user",
-                password_hash=None,
-                metadata_={"oidc_sub": "okta|7"},
-            )
-            await store.create(session, legacy)
-            await session.commit()
-
-            got = await store.get_or_create_oidc_user(
+            owner = await store.get_or_create_oidc_user(
                 session,
                 iss=_ISS,
-                email="legacy@example.com",
-                name="Legacy",
-                sub="okta|7",
+                email="owner@example.com",
+                name="Owner",
+                sub="okta|owned",
+                email_verified=True,
             )
-            assert got.id == legacy.id
-            assert got.metadata_ == {"oidc_sub": "okta|7", "oidc_iss": _ISS}
+            await session.commit()
+
+            other = User(
+                name="Other",
+                email="other@example.com",
+                role="user",
+                password_hash="bcrypt-hash",
+            )
+            await store.create(session, other)
+            await session.commit()
+
+            again = await store.get_or_create_oidc_user(
+                session,
+                iss=_ISS,
+                email="other@example.com",
+                name="Owner",
+                sub="okta|owned",
+                email_verified=True,
+            )
+            assert again.id == owner.id

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 import switch_core.gateway.oidc_routes as oidc_routes
 from switch_core.config import SwitchConfig
 from switch_core.db.models import OidcIdentity, User
-from switch_core.db.stores.user_store import UserStore
+from switch_core.db.stores.user_store import OidcIdentityRaceError, UserStore
 from switch_core.gateway.auth import hash_password
 from switch_core.gateway.auth_routes import auth_config
 
@@ -357,6 +357,41 @@ class TestOidcCallback:
             assert user is not None
             assert user.role == "admin"
             assert user.email == "legacy-admin@example.com"
+
+    async def test_identity_race_contention_maps_to_503(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A raced login is transient contention, not a rejected security
+        # decision (that's OidcIdentityConflictError's 409) — it must not
+        # surface as a generic 500, and it must be told apart from a 409 so
+        # an operator can distinguish a retry storm from an attack signal.
+        token = {
+            "userinfo": {
+                "email": "race@example.com",
+                "email_verified": True,
+                "sub": "okta|race-503",
+                "name": "Race",
+            }
+        }
+        monkeypatch.setattr(oidc_routes, "_client", lambda: _FakeClient(token))
+
+        class _AlwaysRacingStore:
+            async def get_or_create_oidc_user(self, *args: object, **kwargs: object):
+                raise OidcIdentityRaceError("raced twice in a row")
+
+        async with session_factory() as session:
+            with pytest.raises(HTTPException) as exc:
+                await oidc_routes.oidc_callback(
+                    request=SimpleNamespace(),  # type: ignore[arg-type]
+                    config=_config(),
+                    session=session,
+                    user_store=_AlwaysRacingStore(),  # type: ignore[arg-type]
+                )
+            assert exc.value.status_code == 503
+            assert exc.value.headers is not None
+            assert exc.value.headers.get("Retry-After") == "1"
 
     async def test_missing_email_claim_raises_401(
         self,

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -10,6 +10,7 @@ import switch_core.gateway.oidc_routes as oidc_routes
 from switch_core.config import SwitchConfig
 from switch_core.db.models import User
 from switch_core.db.stores.user_store import UserStore
+from switch_core.gateway.auth import hash_password
 from switch_core.gateway.auth_routes import auth_config
 
 
@@ -75,10 +76,11 @@ class TestOidcCallback:
             assert user is not None
             assert user.role == "user"
             assert user.password_hash is None
-            assert user.metadata_ == {
-                "oidc_iss": "https://idp.example",
-                "oidc_sub": "okta|123",
-            }
+            assert user.metadata_ is None
+            linked = await UserStore().get_by_oidc_identity(
+                session, iss="https://idp.example", sub="okta|123"
+            )
+            assert linked is not None and linked.id == user.id
 
     @pytest.mark.parametrize("email_verified", [False, None, "false"])
     async def test_unverified_email_is_rejected(
@@ -140,10 +142,10 @@ class TestOidcCallback:
             assert response.status_code == 303
             user = await UserStore().get_by_email(session, "bob@example.com")
             assert user is not None
-            assert user.metadata_ == {
-                "oidc_iss": "https://idp.example",
-                "oidc_sub": "okta|55",
-            }
+            linked = await UserStore().get_by_oidc_identity(
+                session, iss="https://idp.example", sub="okta|55"
+            )
+            assert linked is not None and linked.id == user.id
 
     async def test_missing_email_claim_still_rejected_when_check_disabled(
         self,
@@ -170,8 +172,6 @@ class TestOidcCallback:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # The takeover guard is independent of the verified-email check.
-        from switch_core.gateway.auth import hash_password
-
         async with session_factory() as session:
             await UserStore().create(
                 session,
@@ -204,15 +204,15 @@ class TestOidcCallback:
                 )
             assert exc.value.status_code == 409
 
-    async def test_email_collision_with_existing_account_is_rejected(
+    async def test_verified_email_links_to_existing_account(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # A verified token whose email matches an existing account but whose
-        # subject does not must not take that account over.
-        from switch_core.gateway.auth import hash_password
-
+        # A verified token whose email matches an existing (password) account
+        # but whose subject does not must land the login in that account,
+        # rather than being refused: accounts are keyed on verified email, not
+        # on login method.
         async with session_factory() as session:
             admin = User(
                 name="Admin",
@@ -222,26 +222,93 @@ class TestOidcCallback:
             )
             await UserStore().create(session, admin)
             await session.commit()
+            admin_id = admin.id
 
         token = {
             "userinfo": {
                 "email": "admin@example.com",
                 "email_verified": True,
-                "sub": "okta|attacker",
-                "name": "Not Admin",
+                "sub": "okta|second-device",
+                "name": "Admin",
             }
         }
         monkeypatch.setattr(oidc_routes, "_client", lambda: _FakeClient(token))
 
         async with session_factory() as session:
-            with pytest.raises(HTTPException) as exc:
-                await oidc_routes.oidc_callback(
-                    request=SimpleNamespace(),  # type: ignore[arg-type]
-                    config=_config(),
-                    session=session,
-                    user_store=UserStore(),
-                )
-            assert exc.value.status_code == 409
+            response = await oidc_routes.oidc_callback(
+                request=SimpleNamespace(),  # type: ignore[arg-type]
+                config=_config(),
+                session=session,
+                user_store=UserStore(),
+            )
+            assert response.status_code == 303
+
+            user = await UserStore().get_by_email(session, "admin@example.com")
+            assert user is not None
+            assert user.id == admin_id
+            # The link must not weaken password login on the account.
+            assert user.password_hash is not None
+            assert user.role == "admin"
+
+            linked = await UserStore().get_by_oidc_identity(
+                session, iss="https://idp.example", sub="okta|second-device"
+            )
+            assert linked is not None and linked.id == admin_id
+
+    async def test_bound_identity_is_not_relinked_by_a_different_claimed_email(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Once (iss, sub) is linked, that binding decides the account on every
+        # later login, regardless of what email the claim carries this time.
+        token = {
+            "userinfo": {
+                "email": "carol@example.com",
+                "email_verified": True,
+                "sub": "okta|77",
+                "name": "Carol",
+            }
+        }
+        monkeypatch.setattr(oidc_routes, "_client", lambda: _FakeClient(token))
+
+        async with session_factory() as session:
+            first = await oidc_routes.oidc_callback(
+                request=SimpleNamespace(),  # type: ignore[arg-type]
+                config=_config(),
+                session=session,
+                user_store=UserStore(),
+            )
+            assert first.status_code == 303
+            carol = await UserStore().get_by_email(session, "carol@example.com")
+            assert carol is not None
+            carol_id = carol.id
+
+        other_email_token = {
+            "userinfo": {
+                "email": "carol-renamed@example.com",
+                "email_verified": True,
+                "sub": "okta|77",
+                "name": "Carol",
+            }
+        }
+        monkeypatch.setattr(
+            oidc_routes, "_client", lambda: _FakeClient(other_email_token)
+        )
+
+        async with session_factory() as session:
+            response = await oidc_routes.oidc_callback(
+                request=SimpleNamespace(),  # type: ignore[arg-type]
+                config=_config(),
+                session=session,
+                user_store=UserStore(),
+            )
+            assert response.status_code == 303
+            linked = await UserStore().get_by_oidc_identity(
+                session, iss="https://idp.example", sub="okta|77"
+            )
+            assert linked is not None and linked.id == carol_id
+            assert linked.email == "carol@example.com"
 
     async def test_missing_email_claim_raises_401(
         self,

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import switch_core.gateway.oidc_routes as oidc_routes
 from switch_core.config import SwitchConfig
-from switch_core.db.models import User
+from switch_core.db.models import OidcIdentity, User
 from switch_core.db.stores.user_store import UserStore
 from switch_core.gateway.auth import hash_password
 from switch_core.gateway.auth_routes import auth_config
@@ -309,6 +309,54 @@ class TestOidcCallback:
             )
             assert linked is not None and linked.id == carol_id
             assert linked.email == "carol@example.com"
+
+    async def test_legacy_sub_only_identity_logs_in_when_check_disabled_despite_unverified_and_changed_email(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A deployment that disabled the verified-email check (its IdP never
+        # emits the claim, e.g. an Okta org authorization server for
+        # directory users) must keep logging a pre-existing sub-only identity
+        # in — main did, by matching on sub alone regardless of email — even
+        # though this account's email claim has since changed and is
+        # unverified. Losing this would be both a lockout and, worse, a
+        # silent fork into a brand-new "user"-role account.
+        async with session_factory() as session:
+            legacy = User(
+                name="Legacy Admin",
+                email="legacy-admin@example.com",
+                role="admin",
+                password_hash=None,
+            )
+            await UserStore().create(session, legacy)
+            session.add(OidcIdentity(user_id=legacy.id, iss=None, sub="okta|legacy"))
+            await session.commit()
+            legacy_id = legacy.id
+
+        token = {
+            "userinfo": {
+                "email": "legacy-admin-new-address@example.com",
+                "email_verified": False,
+                "sub": "okta|legacy",
+                "name": "Legacy Admin",
+            }
+        }
+        monkeypatch.setattr(oidc_routes, "_client", lambda: _FakeClient(token))
+
+        async with session_factory() as session:
+            response = await oidc_routes.oidc_callback(
+                request=SimpleNamespace(),  # type: ignore[arg-type]
+                config=_config(gateway_oidc_require_email_verified=False),
+                session=session,
+                user_store=UserStore(),
+            )
+            assert response.status_code == 303
+
+            user = await UserStore().get(session, legacy_id)
+            assert user is not None
+            assert user.role == "admin"
+            assert user.email == "legacy-admin@example.com"
 
     async def test_missing_email_claim_raises_401(
         self,

--- a/core/tests/switch_core/test_migration_oidc_identities_backfill.py
+++ b/core/tests/switch_core/test_migration_oidc_identities_backfill.py
@@ -163,3 +163,89 @@ async def test_backfill_refuses_when_two_users_share_a_legacy_subject(
             assert table_exists.scalar() is False
     finally:
         await engine.dispose()
+
+
+async def test_backfill_refuses_when_two_users_share_an_identical_full_pair(
+    backfill_url: str,
+) -> None:
+    # Two users with the exact same (iss, sub) would otherwise die on the new
+    # UNIQUE(iss, sub) constraint mid-migration with a bare violation and no
+    # indication which users are involved; the pre-flight check must catch
+    # this case too, not only the no-issuer one.
+    engine = create_async_engine(backfill_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(_upgrade_to(_PRE_MIGRATION_REVISION))
+
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    """
+                    INSERT INTO users (id, name, email, role, password_hash, metadata)
+                    VALUES
+                        ('full-a', 'A', 'full-a@example.com', 'admin', NULL,
+                         '{"oidc_iss": "https://idp.example", "oidc_sub": "okta|shared-full"}'),
+                        ('full-b', 'B', 'full-b@example.com', 'user', NULL,
+                         '{"oidc_iss": "https://idp.example", "oidc_sub": "okta|shared-full"}')
+                    """
+                )
+            )
+
+        with pytest.raises(RuntimeError, match="okta\\|shared-full"):
+            async with engine.begin() as connection:
+                await connection.run_sync(_upgrade_to(_MIGRATION_UNDER_TEST))
+
+        async with engine.connect() as connection:
+            table_exists = await connection.execute(
+                text(
+                    "SELECT to_regclass('public.oidc_identities') IS NOT NULL AS exists"
+                )
+            )
+            assert table_exists.scalar() is False
+    finally:
+        await engine.dispose()
+
+
+async def test_backfill_refuses_when_a_legacy_row_shares_a_subject_with_a_full_pair(
+    backfill_url: str,
+) -> None:
+    # The case that previously failed silently: a legacy (no-issuer) row and
+    # a full-pair row sharing one subject would both migrate cleanly on their
+    # own — no constraint stops either insert — and the legacy row would then
+    # be permanently unreachable, since a later login always matches the
+    # full pair via the exact (iss, sub) lookup first. The pre-flight must
+    # catch this even though neither row alone, nor together, would trip
+    # either unique index at insert time.
+    engine = create_async_engine(backfill_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(_upgrade_to(_PRE_MIGRATION_REVISION))
+
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    """
+                    INSERT INTO users (id, name, email, role, password_hash, metadata)
+                    VALUES
+                        ('orphaned-legacy', 'Legacy', 'orphaned-legacy@example.com',
+                         'admin', NULL, '{"oidc_sub": "okta|mixed-shared"}'),
+                        ('winning-full', 'Full', 'winning-full@example.com', 'user',
+                         NULL,
+                         '{"oidc_iss": "https://idp.example", "oidc_sub": "okta|mixed-shared"}')
+                    """
+                )
+            )
+
+        with pytest.raises(RuntimeError, match="okta\\|mixed-shared"):
+            async with engine.begin() as connection:
+                await connection.run_sync(_upgrade_to(_MIGRATION_UNDER_TEST))
+
+        async with engine.connect() as connection:
+            table_exists = await connection.execute(
+                text(
+                    "SELECT to_regclass('public.oidc_identities') IS NOT NULL AS exists"
+                )
+            )
+            assert table_exists.scalar() is False
+    finally:
+        await engine.dispose()

--- a/core/tests/switch_core/test_migration_oidc_identities_backfill.py
+++ b/core/tests/switch_core/test_migration_oidc_identities_backfill.py
@@ -165,6 +165,56 @@ async def test_backfill_refuses_when_two_users_share_a_legacy_subject(
         await engine.dispose()
 
 
+async def test_backfill_allows_two_distinct_issuers_sharing_a_subject(
+    backfill_url: str,
+) -> None:
+    # Two full-pair rows sharing a subject string but naming two different,
+    # non-NULL issuers are not ambiguous: UNIQUE(iss, sub) is satisfied by
+    # both, the NULL-issuer partial index doesn't apply to either, and a
+    # later login matches exactly one of them by its exact (iss, sub) pair.
+    # This is also the shape the coming multi-issuer tenant work will make
+    # routine, so the pre-flight must not refuse it.
+    engine = create_async_engine(backfill_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(_upgrade_to(_PRE_MIGRATION_REVISION))
+
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    """
+                    INSERT INTO users (id, name, email, role, password_hash, metadata)
+                    VALUES
+                        ('issuer-a-user', 'A', 'issuer-a-user@example.com', 'user',
+                         NULL,
+                         '{"oidc_iss": "https://idp-a.example", "oidc_sub": "shared-across-issuers"}'),
+                        ('issuer-b-user', 'B', 'issuer-b-user@example.com', 'user',
+                         NULL,
+                         '{"oidc_iss": "https://idp-b.example", "oidc_sub": "shared-across-issuers"}')
+                    """
+                )
+            )
+
+        async with engine.begin() as connection:
+            await connection.run_sync(_upgrade_to(_MIGRATION_UNDER_TEST))
+
+        async with engine.connect() as connection:
+            identities = (
+                await connection.execute(
+                    text(
+                        "SELECT user_id, iss, sub FROM oidc_identities ORDER BY user_id"
+                    )
+                )
+            ).all()
+    finally:
+        await engine.dispose()
+
+    assert identities == [
+        ("issuer-a-user", "https://idp-a.example", "shared-across-issuers"),
+        ("issuer-b-user", "https://idp-b.example", "shared-across-issuers"),
+    ]
+
+
 async def test_backfill_refuses_when_two_users_share_an_identical_full_pair(
     backfill_url: str,
 ) -> None:

--- a/core/tests/switch_core/test_migration_oidc_identities_backfill.py
+++ b/core/tests/switch_core/test_migration_oidc_identities_backfill.py
@@ -122,3 +122,44 @@ async def test_backfill_migrates_full_pairs_and_legacy_rows_and_leaves_others_al
     # A row untouched by OIDC (no oidc_sub key, NULL metadata outright) is
     # left exactly as it was.
     assert by_id["password"] is None
+
+
+async def test_backfill_refuses_when_two_users_share_a_legacy_subject(
+    backfill_url: str,
+) -> None:
+    # Two users with the same oidc_sub and no recorded issuer can't be told
+    # apart by subject alone; UNIQUE(sub) WHERE iss IS NULL would reject the
+    # second INSERT anyway, but the pre-flight check exists to fail with a
+    # message a human can act on instead of a bare constraint violation.
+    engine = create_async_engine(backfill_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(_upgrade_to(_PRE_MIGRATION_REVISION))
+
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    """
+                    INSERT INTO users (id, name, email, role, password_hash, metadata)
+                    VALUES
+                        ('claimant-a', 'A', 'claimant-a@example.com', 'admin', NULL,
+                         '{"oidc_sub": "okta|shared"}'),
+                        ('claimant-b', 'B', 'claimant-b@example.com', 'user', NULL,
+                         '{"oidc_sub": "okta|shared"}')
+                    """
+                )
+            )
+
+        with pytest.raises(RuntimeError, match="okta\\|shared"):
+            async with engine.begin() as connection:
+                await connection.run_sync(_upgrade_to(_MIGRATION_UNDER_TEST))
+
+        async with engine.connect() as connection:
+            table_exists = await connection.execute(
+                text(
+                    "SELECT to_regclass('public.oidc_identities') IS NOT NULL AS exists"
+                )
+            )
+            assert table_exists.scalar() is False
+    finally:
+        await engine.dispose()

--- a/core/tests/switch_core/test_migration_oidc_identities_backfill.py
+++ b/core/tests/switch_core/test_migration_oidc_identities_backfill.py
@@ -1,0 +1,124 @@
+"""The oidc_identities backfill migration moves real data correctly.
+
+`test_migration_parity.py` replays the chain into an *empty* database, so it
+can never catch a bug in the data the `04f27f37e474` migration moves — a
+lost, duplicated or misattributed row would pass every other test and only
+show up against a deployment's actual `users` table. This test seeds rows the
+way years of real logins would have left them, stops the chain one revision
+short of the migration under test, then runs it and inspects what came out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic.config import Config
+from alembic.runtime.environment import EnvironmentContext
+from alembic.script import ScriptDirectory
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+_CORE = Path(__file__).resolve().parents[2]
+_BACKFILL_DB = "migration_oidc_identities_backfill"
+
+_PRE_MIGRATION_REVISION = "c8e4a10b7f36"
+_MIGRATION_UNDER_TEST = "04f27f37e474"
+
+
+def _script_directory(config: Config) -> ScriptDirectory:
+    config.set_main_option("script_location", str(_CORE / "switch_core" / "migrations"))
+    return ScriptDirectory.from_config(config)
+
+
+def _upgrade_to(revision: str) -> Any:
+    def upgrade(connection: Connection) -> None:
+        config = Config(str(_CORE / "alembic.ini"))
+        script = _script_directory(config)
+
+        def do_upgrade(current_revision: str, context: Any) -> Any:
+            return script._upgrade_revs(revision, current_revision)
+
+        with EnvironmentContext(config, script, fn=do_upgrade) as environment:
+            environment.configure(connection=connection)
+            with environment.begin_transaction():
+                environment.run_migrations()
+
+    return upgrade
+
+
+@pytest.fixture
+async def backfill_url(postgres_url: str) -> Any:
+    admin = create_async_engine(postgres_url, isolation_level="AUTOCOMMIT")
+    async with admin.connect() as connection:
+        await connection.execute(text(f'DROP DATABASE IF EXISTS "{_BACKFILL_DB}"'))
+        await connection.execute(text(f'CREATE DATABASE "{_BACKFILL_DB}"'))
+    await admin.dispose()
+
+    base, _, _ = postgres_url.rpartition("/")
+    try:
+        yield f"{base}/{_BACKFILL_DB}"
+    finally:
+        admin = create_async_engine(postgres_url, isolation_level="AUTOCOMMIT")
+        async with admin.connect() as connection:
+            await connection.execute(text(f'DROP DATABASE IF EXISTS "{_BACKFILL_DB}"'))
+        await admin.dispose()
+
+
+async def test_backfill_migrates_full_pairs_and_legacy_rows_and_leaves_others_alone(
+    backfill_url: str,
+) -> None:
+    engine = create_async_engine(backfill_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(_upgrade_to(_PRE_MIGRATION_REVISION))
+
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    """
+                    INSERT INTO users (id, name, email, role, password_hash, metadata)
+                    VALUES
+                        ('full', 'Full', 'full@example.com', 'user', NULL,
+                         '{"oidc_iss": "https://idp.example", "oidc_sub": "okta|9"}'),
+                        ('legacy', 'Legacy', 'legacy@example.com', 'user', NULL,
+                         '{"oidc_sub": "okta|7"}'),
+                        ('password', 'Password', 'password@example.com', 'user',
+                         'bcrypt-hash', NULL)
+                    """
+                )
+            )
+
+        async with engine.begin() as connection:
+            await connection.run_sync(_upgrade_to(_MIGRATION_UNDER_TEST))
+
+        async with engine.connect() as connection:
+            identities = (
+                await connection.execute(
+                    text(
+                        "SELECT user_id, iss, sub FROM oidc_identities ORDER BY user_id"
+                    )
+                )
+            ).all()
+            metadata = (
+                await connection.execute(
+                    text("SELECT id, metadata FROM users ORDER BY id")
+                )
+            ).all()
+    finally:
+        await engine.dispose()
+
+    assert identities == [
+        ("full", "https://idp.example", "okta|9"),
+        ("legacy", None, "okta|7"),
+    ]
+
+    by_id = {row.id: row.metadata for row in metadata}
+    # Migrated rows lose the pair from metadata — the table is now the only
+    # place it lives.
+    assert by_id["full"] == {}
+    assert by_id["legacy"] == {}
+    # A row untouched by OIDC (no oidc_sub key, NULL metadata outright) is
+    # left exactly as it was.
+    assert by_id["password"] is None


### PR DESCRIPTION
## Summary

CHOO-2624 (multi-tenancy Phase 2) requires accounts to be keyed on verified
email, not on login method: someone who signs up with a password and later
signs in with an IdP sharing that verified email must land in the same
account, not a second one — otherwise a later change of login policy forces
a manual account merge.

Today `get_or_create_oidc_user` refuses that case with `OidcIdentityConflictError`
(409 at the callback), added in a previous security fix that closed a real
account-takeover bug (unverified/attacker-set email logging in as an existing
user, e.g. the seeded admin). This PR keeps that fix's protection but narrows
the refusal to exactly the case that's actually unsafe.

## What changed

- `get_or_create_oidc_user` now:
  1. Looks up the identity by the immutable `(iss, sub)` pair first, as before — a
     bound identity is never re-evaluated by email.
  2. If not found, and the *verified* email matches an existing account, links
     this identity to that account instead of refusing.
  3. If the email is **not** verified and it matches an existing account, it
     still refuses (`OidcIdentityConflictError` / 409) — an unverified email is
     attacker-controllable and must never pick an account, including when
     `GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED=false` lets an unverified login
     through at all (that flag only decides whether an unverified login is
     accepted for *provisioning or continuing to match* an identity; it never
     turns on linking a new identity into a pre-existing *different* account —
     see the caveat under "Fixes, round 2" below, though: a legacy sub-only
     identity is a separate path that bypasses this entirely).
  4. If the email is new, provisions a fresh user (`password_hash=None`,
     stored lower-cased) either way.

- Identity storage moves out of a single `oidc_iss`/`oidc_sub` pair in
  `users.metadata` into a new `oidc_identities` table: one row per linked
  `(iss, sub)`, unique on that pair. The old shape could only ever name one
  IdP identity per user; a user who links a second IdP (or a second account
  at the same IdP) now gets a second row instead of overwriting the first or
  being blocked.

- A migration (`04f27f37e474`) creates the table, backfills existing
  `oidc_iss`/`oidc_sub` pairs (including sub-only legacy rows) out of
  `users.metadata` into it, and adds a case-insensitive index on
  `users.email`.

## Fixes, round 1 (adversarial review before merge)

**A. Legacy sub-only rows were a lockout and a silent account fork
(regression from main).** The first version of the migration left rows whose
`metadata` had `oidc_sub` but no `oidc_iss` untouched, and nothing read that
key again. Two consequences: (1) with `GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED=false`
— which exists specifically for IdPs like Okta's org authorization server
that never emit `email_verified` for directory users — such an account would
now get a permanent 409 instead of the login main gave it; (2) if that
identity's claimed email had since changed, the sub-only match was gone and
the email match missed too, silently provisioning a brand-new `role="user"`
account and orphaning the original (possibly admin) one. Fixed by backfilling
sub-only rows into `oidc_identities` with a NULL issuer, and teaching
`get_by_oidc_identity` to match on `sub` alone when no issuer is stored,
backfilling the issuer once a login supplies one.

**B. Email matching was case-sensitive**, silently defeating the ticket.
Fixed with a `lower()` compare backed by a functional index (refined further
in round 2 — see below).

**C. A lost race returned a 500.** Two concurrent first logins for the same
`(iss, sub)`, or for the same brand-new email, raised an uncaught
`IntegrityError`. Fixed with a catch-and-retry (refined to use a savepoint in
round 2 — see below).

**D. Linking was silent.** `_link_identity` now logs (moved to after the
flush in round 2 — see below).

**E. The migration wasn't honest about its downgrade.** `downgrade()`'s
docstring now states the data loss directly (corrected further in round 2).

**F. Test gaps.** Added a real migration-chain replay over seeded data
(`test_migration_oidc_identities_backfill.py`), a DB-level unique-constraint
test, deterministic race tests, and restored a successor for the deleted
legacy-row test.

**G. Test comments narrated the change rather than the rule.** Reworded.

## Fixes, round 2 (adversarial re-review of round 1)

**1. NULL-issuer rows escaped the unique constraint entirely.** `UNIQUE(iss, sub)`
does not constrain a NULL issuer at all — Postgres treats every NULL as
distinct from every other NULL — so two different users could each hold a
legacy sub-only identity for the same subject, both insert cleanly, and
`get_by_oidc_identity`'s `.scalars().first()` (no `ORDER BY`) would resolve to
whichever one it saw first, backfilling the issuer onto it and leaving the
other permanently unreachable: one account silently annexed, one silently
orphaned, decided by row order. Fixed with:
  - A partial unique index, `ix_oidc_identities_sub_null_iss` — `UNIQUE(sub)
    WHERE iss IS NULL` — so at most one such row can exist per subject.
  - A migration pre-flight check that refuses to proceed (raises, does not
    silently pick a side) if duplicate legacy subjects already exist in the
    data, with a message naming the colliding subject(s) for a human to
    resolve by hand.
  - `get_by_oidc_identity`'s legacy lookup switched from `.scalars().first()`
    to `.scalar_one_or_none()`, since uniqueness is now guaranteed — a second
    match would mean the index failed to do its job and should raise loudly,
    not be silently resolved.
  - New tests: a DB-level test that the partial index rejects a second
    NULL-issuer row for the same subject, and a migration test that the
    pre-flight refuses when duplicate legacy subjects are seeded (verified
    manually too, against real Postgres, alongside the happy path and a
    direct-insert check of the partial index).

**2. Section H undersold the exposure and two docstrings overclaimed.** Fixed
by making H explicit that the legacy sub-only path bypasses email entirely
(see the updated H below), and rewording `config.py`'s docstring, the "only a
verified email may link" framing, and `models.py`'s `OidcIdentity` docstring
to state the legacy carve-out rather than imply an absolute. `models.py` also
now says explicitly what breaks the "sub is unique per issuer" assumption
(a second configured issuer) instead of asserting it as a permanent
invariant.

**3. `get_by_email` traded a loud failure for a silent choice.** Switching
from `scalar_one_or_none()` to `.scalars().first()` in round 1 fixed the
crash but introduced an undisclosed, non-deterministic pick between two
pre-existing case-duplicate rows (possible because `users.email` is still
case-sensitively unique and the new index is not unique — duplicates were
already possible before this PR and are not newly created by it, but the
*read* path previously would have crashed on them instead of quietly picking
one). Fixed: `get_by_email` now orders deterministically and logs a
`logger.error` disclosing the ambiguity when more than one match is found,
rather than resolving it silently. New user creation via
`get_or_create_oidc_user` also stores email lower-cased, so this method
doesn't create new case variants going forward (pre-existing rows of any
casing are untouched). New test:
`test_pre_existing_case_duplicate_emails_resolve_deterministically_and_log`
(the original version of this fix and its test both had a bug — see round 3,
item 1, below).

**4. The race retry rolled back the caller's whole transaction.** `_recover_from_race`'s
`session.rollback()` undid everything in the session, not just the failed
write — the same class of bug `room_store.py` documents from production
(`add_client`'s comment on the second write's `IntegrityError` rolling back
an otherwise-fine transaction). Switched to `session.begin_nested()`
savepoints around each risky write, matching the pattern already established
in `reference_type_store.py`. Latent today since the OIDC callback's session
holds nothing else, but this is a public store method.

**5. Three smaller fixes:**
  - `OidcIdentityConflictError` no longer doubles as both "genuine security
    rejection" and "transient race, retry"; the latter is now a distinct
    `OidcIdentityRaceError`, mapped to `503` (with `Retry-After`) at the
    callback instead of `409`, so an operator's logs/dashboards can tell a
    retry storm apart from actual rejected takeover attempts.
  - `_link_identity` now logs only after `session.flush()` succeeds, so a
    losing racer never logs a link that didn't happen.
  - The `downgrade()` docstring's claim that data loss is decided by
    "whichever row this UPDATE visits last" was wrong — Postgres does not
    define an order for which source row an ambiguous `UPDATE ... FROM`
    applies. Reworded to say the choice is unspecified, not sequential.

## Fixes, round 3 (adversarial re-review of round 2)

**1. The "deterministic tiebreak" test was flaky, and the property it
claimed was not actually implemented.** Round 2's fix ordered
`get_by_email`'s duplicate-resolution by `(created_at, id)`. Postgres's
`now()` is fixed for the whole transaction, so two case-duplicate rows
created in the same transaction — exactly what the test did — tie on
`created_at` and the real tiebreak was `id`, a random UUID: the outcome
varied between runs (observed 5/12 passing before this fix), and on a
losing run the pick was the opposite of what the docstring and test claimed
("oldest wins"). Fixed by dropping `created_at` from the ordering entirely
and ordering by `id` alone, with the docstring and log message now stating
plainly that this is an arbitrary-but-stable tiebreak, not a claim that the
lower id is the "real" or original account. The test no longer asserts an
age relationship; it asserts the pick is stable across repeated calls (and
no longer assigns either duplicate a role that implied one should win). Run
12 times after the fix: 12/12 passing.

**2. The migration pre-flight covered only half the collision space.** The
duplicate check grouped rows lacking `oidc_iss` against each other, so two
gaps went uncaught: two users sharing an *identical* full `(iss, sub)` pair
would still pass the pre-flight and die on the new unique constraint
mid-migration with a bare violation instead of an actionable message; worse,
a sub-only row and a full-pair row sharing one `sub` passed cleanly with
**no failure at all** — both migrated, and the sub-only row became
permanently unreachable, since `get_by_oidc_identity` always tries the exact
`(iss, sub)` match first. Fixed by grouping every row carrying `oidc_sub`
(not only issuer-less ones). New tests:
`test_backfill_refuses_when_two_users_share_an_identical_full_pair` and, for
the case that previously failed silently,
`test_backfill_refuses_when_a_legacy_row_shares_a_subject_with_a_full_pair`.
(The first version of this fix over-corrected — see round 4, item 1, below.)

**3. The `OidcIdentityRaceError` → 503 mapping had no route-level test** —
only the store-level raise was covered. Added
`test_identity_race_contention_maps_to_503`, using a fake store that always
raises, asserting both the status code and the `Retry-After` header.

**4. Two comments cited `CLAUDE.md` by name.** This repository is public;
a comment should state the rule it invokes (a stable, disclosed pick beats a
silent or unstable one) rather than point an outside reader at an internal
file they have no reason to treat as authoritative. Reworded in
`user_store.py` and `test_user_store_oidc.py`.

## Fixes, round 4 (adversarial re-review of round 3)

**1. The round-3 pre-flight widening over-blocked a case that isn't
actually broken.** Grouping by every row carrying `oidc_sub` and refusing on
any duplicate also refused two full-pair rows sharing a subject but naming
two *different*, non-null issuers — a shape that is not ambiguous at all:
`UNIQUE(iss, sub)` is satisfied by both, the NULL-issuer partial index
applies to neither, and a later login matches exactly one of them by its
exact `(iss, sub)` pair. Telling this apart from a real collision is not
hard, and the previous version's docstring/message admitted skipping the
distinction rather than making it. Fixed by narrowing the `HAVING` clause to
the two shapes that are genuinely ambiguous: an identical `(iss, sub)` pair
repeating, or any NULL issuer present in a group of more than one subject.
A subject shared only by rows with distinct non-null issuers now passes
through untouched — which matters beyond this migration, since the tenant
work ahead is expected to make exactly that shape routine once more than one
issuer exists; an over-strict check here would have turned this migration
into something that blocks the deployments the next phase creates. Dropped
the docstring paragraph and error-message clause that had apologized for
over-blocking, since the case is no longer blocked. New test:
`test_backfill_allows_two_distinct_issuers_sharing_a_subject`, alongside the
existing refusal tests for the two shapes that still correctly block.

**Flagged, not fixed — out of scope for this PR:** every failure on this
callback (401, 409, 503) currently returns a raw FastAPI JSON error body to
a browser, because the gateway registers no exception handler for this route
and the frontend handles none of these responses either. The sensible shape
is a redirect back to the login page carrying an error the frontend can
render, and that applies to all of this endpoint's failure modes uniformly,
not just the two this PR adds (503) or touches (409) — it belongs in its own
change rather than being special-cased here for just the codes this PR
happens to touch.

## H. Flagged for a human decision — not implemented

Any account with a matching *verified* email is claimable by an OIDC login,
by design — that's the ticket. This is not a bug; it is the direct, intended
consequence of "verified email decides the account" applied without
exception. But two specific accounts deserve a deliberate decision rather
than an implicit one, because both are fixed, guessable, login-less
addresses that the system itself relies on:

- **The seeded `GATEWAY_ADMIN_EMAIL` admin**, which exists in every
  deployment. If an attacker controls (or an IdP asserts a verified claim
  for) that exact address, they get the admin account.
- **`agent-bootstrap@switch.local`**, seeded by a sibling PR (#399,
  `work/multi-tenancy-phase2-agent-reg`) as the non-admin owner for agents
  registered through the deployment-wide registration token — it exists so
  that shared token doesn't confer admin authority. Today it is protected by
  exactly the refusal this PR removes. Once this lands, whoever can make an
  IdP assert that address with `email_verified=true` becomes the *owner* of
  every agent registered through the bootstrap path — not admin, but
  owner-based authorization treats that as full management rights over those
  agents and everything they own.

These are the same class of problem, so the right shape is **a
not-linkable list of seeded system addresses**, not a special case for the
admin alone. A mitigation that protects only `GATEWAY_ADMIN_EMAIL` would
still leave the bootstrap account exposed.

**Important limitation of any email-based mitigation, including the
recommendation below:** the legacy sub-only identity path (fix A / round-2
item 1) bypasses email, `email_verified`, and even the claim's issuer
entirely — it resolves purely by matching a stored subject. This is not a
regression (main did the same) and is deliberately preserved and tested. But
it means that if either seeded account ever accumulates a legacy sub-only
identity row, no email-address-based protection closes that path: the
account would still be claimable by subject alone. Anyone adopting the
recommendation below should know it protects the *email-based* linking path
only.

One of the steering devs gave an initial instinct here, explicitly deferring
the actual call:

- **Leading option — protect a fixed list of seeded system addresses**
  (`GATEWAY_ADMIN_EMAIL` and `agent-bootstrap@switch.local` today; anything
  added later in the same category). Refuse to link an OIDC identity into any
  account on that list; those accounts stay on password login only.
  Rationale for: these are the accounts where the IdP's word alone should not
  be sufficient, since either grants broad standing authority (admin, or
  ownership of every bootstrap-registered agent) — and neither is anyone's
  daily-driver account, so excluding them costs almost nothing while leaving
  the ticket's actual use case (password signup, later Google) intact for
  ordinary users.
- **Rejected variant — refuse linking into any `role="admin"` account.**
  Broader, and looks appealing today, but doesn't survive the tenant model
  this Phase 2 work is heading toward: once every workspace has an owner,
  every workspace owner is an `admin` of *something*, and a blanket rule
  would then exclude precisely the people most likely to actually be on
  enterprise SSO. It also wouldn't cover the bootstrap account, which isn't
  an admin at all. The named-list version above has neither problem.
- **Rejected — refuse linking into any account with a password hash.** Would
  close the exposure entirely but also kills the ticket's actual use case
  (password signup, later Google), so it isn't really on the table.

Recommendation: the named-list option, but this is deliberately **not
implemented** here — it's a policy call for humans, not something to decide
unilaterally in this PR. **Whichever of this PR and #399 lands second
inherits the obligation to implement the list** (both PR bodies say so, so
neither side loses track of it).

Related, and also not addressed here: `config.py`'s docstring for
`gateway_oidc_require_email_verified` previously undersold what the flag
controls; updated in round 2 to say plainly what it does and does not affect,
including the legacy sub-only carve-out.

**Also flagged for the tenant work, not this PR:** nothing today binds an
issuer to an email domain, and there's no `UNIQUE(user_id, iss)`. Once a
second IdP exists (or a per-tenant IdP), one tenant's IdP admin could link
into another tenant's user by asserting that user's address. Worth
addressing when multi-tenant IdPs land, out of scope for this change.

## Safety properties and how they're tested

1. **A verified email may link; an unverified one never picks an existing,
   different account.** Exception, stated explicitly rather than implied: a
   pre-existing legacy identity (sub only, no issuer) continues to resolve
   and have its issuer backfilled purely by subject, without consulting
   email or `email_verified` at all — matching main's original behavior for
   that narrow, pre-CHOO-2624 case. Covered by
   `test_unverified_email_collision_with_different_identity_is_refused`, the
   route-level `test_email_collision_still_rejected_when_check_disabled`, and
   (for the legacy exception) `test_legacy_identity_without_issuer_resolves_even_if_email_changed`.
2. **An identity already bound to a different account is never re-bound.**
   Covered by `test_identity_already_bound_elsewhere_is_never_relinked` and
   the route-level `test_bound_identity_is_not_relinked_by_a_different_claimed_email`.
3. **Two subjects from the same issuer can't collapse identities in a way
   that lets one impersonate the other**, and **no two identity rows can
   ever resolve ambiguously** — enforced at the DB level for both the normal
   case (`UNIQUE(iss, sub)`) and the legacy NULL-issuer case
   (`UNIQUE(sub) WHERE iss IS NULL`), not just in application code. Covered
   by `test_two_subjects_same_issuer_can_both_link_to_one_account`,
   `test_iss_sub_unique_constraint_is_enforced_at_the_db_level`, and
   `test_null_issuer_sub_unique_constraint_is_enforced_at_the_db_level`.
4. **Password login is not weakened.** Covered by
   `test_verified_email_links_to_existing_account` and the route-level test
   of the same name.
5. **A pre-CHOO-2624 identity is not locked out or forked into a second
   account**, and **every genuinely ambiguous shape of duplicate `oidc_sub`
   metadata — legacy vs. legacy, full pair vs. identical full pair, or
   legacy vs. full pair — is refused rather than silently resolved by row
   order, while a subject shared only by rows naming distinct, non-null
   issuers (not ambiguous at all, and the shape the tenant work ahead will
   make routine) migrates through untouched.** Covered by the round-1
   legacy tests plus `test_backfill_refuses_when_two_users_share_a_legacy_subject`,
   `test_backfill_refuses_when_two_users_share_an_identical_full_pair`,
   `test_backfill_refuses_when_a_legacy_row_shares_a_subject_with_a_full_pair`,
   and `test_backfill_allows_two_distinct_issuers_sharing_a_subject`.
6. **A race between two logins resolves to one row without a 500, and
   without rolling back the caller's transaction**, and **a race that keeps
   losing fails loudly under its own error type rather than looping or being
   mistaken for a security rejection.** Covered by
   `test_concurrent_creation_of_the_same_identity_resolves_to_the_winner`,
   `test_concurrent_new_email_provisioning_resolves_to_one_account`, and
   `test_race_exhausted_twice_raises_a_distinct_contention_error`.
7. **A pre-existing case-duplicate email resolves the same way every time and
   the ambiguity is disclosed, not silently (or inconsistently) guessed.**
   The pick itself is an arbitrary-but-stable tiebreak (lowest `id`), not a
   claim about which account is "real". Covered by
   `test_pre_existing_case_duplicate_emails_resolve_deterministically_and_log`,
   confirmed non-flaky by running it 12 times after the round-3 fix (12/12
   passing; the pre-fix version had been observed failing about half the
   time).
8. **A raced login returns a usable error, not a generic 500 or a security
   rejection it doesn't deserve.** Covered at the store level by
   `test_race_exhausted_twice_raises_a_distinct_contention_error` and at the
   route level by `test_identity_race_contention_maps_to_503`.

## Test plan

- [x] `just test` (full suite: 2587 passed)
- [x] `just typecheck`
- [x] `just format` / `ruff check`
- [x] The previously-flaky case-duplicate-email test run 12 times in
      isolation after the round-3 fix: 12/12 passing.
- [x] Manual `alembic upgrade` / `downgrade` against throwaway Postgres
      instances, seven separate rehearsals in total across all four review
      rounds: (1) a full pair + a sub-only legacy row, verifying backfill and
      exact downgrade round-trip; (2) a mixed-case email row, verifying the
      case-insensitive index; (3) two users sharing one legacy subject,
      verifying the migration refuses with a clear message, leaves no partial
      schema behind, and — after resolving the collision by hand — succeeds,
      with the partial unique index then independently confirmed to reject a
      direct duplicate insert; (4) two users sharing an identical full
      `(iss, sub)` pair, verifying the widened pre-flight catches it with both
      issuers named in the message; (5) a legacy row and a full-pair row
      sharing one subject — the case that previously migrated silently and
      wrong — verifying the widened pre-flight now catches it too; (6) all
      three shapes seeded in the same database at once (identical full pair,
      legacy-vs-full-pair, and two distinct issuers sharing a subject),
      verifying the error names only the two genuine collisions and migrates
      cleanly once those two are resolved by hand — with the two-distinct-
      issuer rows landing in `oidc_identities` as two independent rows,
      untouched; (7) downgrade of that same database, confirming both
      distinct-issuer rows round-trip back into `users.metadata`
      independently.

