### PR TITLE
fix(console): manual refresh re-checks sign-in options

### DIFF
--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/server-sign-in.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/server-sign-in.tsx
@@ -1,3 +1,4 @@
+import { TriangleAlert } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useEffect, useState } from 'react';
 import { Button } from '@renderer/lib/ui/button';
@@ -18,6 +19,11 @@ import { switchServersStore } from './switch-servers-store';
 export type ServerSignIn = {
   /** Which methods the server offers, or null while that is still unknown. */
   config: SwitchAuthConfig | null;
+  /** Whether the last attempt to read sign-in options failed. The page never
+   * lets this evict a reachable server (see `isUnreachable` on the store), so
+   * this is the only place that failure is visible — `config` may be a stale
+   * answer from before the endpoint broke, or null if it never succeeded. */
+  configCheckFailed: boolean;
   email: string;
   password: string;
   setEmail: (value: string) => void;
@@ -56,6 +62,7 @@ export function useServerSignIn(serverId: string): ServerSignIn {
 
   return {
     config: switchServersStore.authConfigFor(serverId),
+    configCheckFailed: switchServersStore.authConfigCheckFailed(serverId),
     email,
     password,
     setEmail,
@@ -107,11 +114,24 @@ export const ServerSignInFields = observer(function ServerSignInFields({
   };
 
   if (!config) {
-    return <p className="text-sm text-foreground-muted">Checking sign-in options…</p>;
+    return (
+      <p className="text-sm text-foreground-muted">
+        {signIn.configCheckFailed
+          ? 'Could not check sign-in options.'
+          : 'Checking sign-in options…'}
+      </p>
+    );
   }
 
   return (
     <div className="flex flex-col gap-4">
+      {signIn.configCheckFailed && (
+        <p className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500">
+          <TriangleAlert className="size-3 shrink-0" />
+          Could not check for updated sign-in options — showing what was last known.
+        </p>
+      )}
+
       {config.passwordLoginEnabled && (
         <div className="flex flex-col gap-3">
           <div className="space-y-1.5">

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/server-sign-in.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/server-sign-in.tsx
@@ -24,6 +24,10 @@ export type ServerSignIn = {
    * this is the only place that failure is visible — `config` may be a stale
    * answer from before the endpoint broke, or null if it never succeeded. */
   configCheckFailed: boolean;
+  /** Whether a sign-in-options read is in flight right now — checked before
+   * `configCheckFailed` so a fresh retry after a failure is not reported as
+   * still failing while it is still running. */
+  configChecking: boolean;
   email: string;
   password: string;
   setEmail: (value: string) => void;
@@ -63,6 +67,7 @@ export function useServerSignIn(serverId: string): ServerSignIn {
   return {
     config: switchServersStore.authConfigFor(serverId),
     configCheckFailed: switchServersStore.authConfigCheckFailed(serverId),
+    configChecking: switchServersStore.authConfigChecking(serverId),
     email,
     password,
     setEmail,
@@ -116,7 +121,7 @@ export const ServerSignInFields = observer(function ServerSignInFields({
   if (!config) {
     return (
       <p className="text-sm text-foreground-muted">
-        {signIn.configCheckFailed
+        {signIn.configCheckFailed && !signIn.configChecking
           ? 'Could not check sign-in options.'
           : 'Checking sign-in options…'}
       </p>

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
@@ -305,6 +305,42 @@ describe('the reachability flag under concurrent checks', () => {
   });
 });
 
+describe('a persistently broken sign-in-options endpoint', () => {
+  it('stays disclosed to the sign-in panel without evicting an otherwise reachable server', async () => {
+    // The durable case, as opposed to the transient one above: the
+    // sign-in-options endpoint never recovers while the server itself stays
+    // fine. isUnreachable must not flip true — once a status read has ever
+    // landed, it is the sole authority, so this failure can never reach it
+    // again — but the failure must still be visible *somewhere*, or the panel
+    // would silently keep showing a stale answer as if it were current,
+    // forever, for the rest of the session.
+    const store = newStore([server('srv-a')]);
+    await store.ensureAuthConfig('srv-a');
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+    getAuthConfig.mockRejectedValue(new Error('fetch failed'));
+
+    await store.refreshServer('srv-a');
+    await store.refreshServer('srv-a');
+    await store.refreshServer('srv-a');
+
+    expect(store.isUnreachable('srv-a')).toBe(false);
+    expect(store.authConfigCheckFailed('srv-a')).toBe(true);
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+  });
+
+  it('clears once the endpoint answers again', async () => {
+    const store = newStore([server('srv-a')]);
+    await store.ensureAuthConfig('srv-a');
+    getAuthConfig.mockRejectedValueOnce(new Error('fetch failed'));
+    await store.refreshServer('srv-a');
+    expect(store.authConfigCheckFailed('srv-a')).toBe(true);
+
+    await store.refreshServer('srv-a');
+
+    expect(store.authConfigCheckFailed('srv-a')).toBe(false);
+  });
+});
+
 describe('a server that cannot be reached', () => {
   it('is flagged when the sign-in read fails', async () => {
     const store = newStore([server('srv-a')]);

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
@@ -131,6 +131,30 @@ describe('fetching sign-in options', () => {
     expect(getAuthConfig).toHaveBeenCalledTimes(1);
     expect(store.authConfigFor('srv-a')).toEqual(authConfig);
   });
+
+  it('reports a retry as checking rather than still failed while it runs', async () => {
+    // The panel picks its message from configCheckFailed and configChecking
+    // together: without this signal, a retry after a failure would claim the
+    // check failed right up until the moment it actually succeeds or fails
+    // again, even while it is genuinely in flight.
+    const store = newStore([server('srv-a')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('fetch failed'));
+    await store.ensureAuthConfig('srv-a');
+    expect(store.authConfigCheckFailed('srv-a')).toBe(true);
+    expect(store.authConfigChecking('srv-a')).toBe(false);
+
+    const retryPending = deferred<typeof authConfig>();
+    getAuthConfig.mockReturnValueOnce(retryPending.promise);
+    const retrying = store.ensureAuthConfig('srv-a');
+    await flush();
+    expect(store.authConfigChecking('srv-a')).toBe(true);
+
+    retryPending.resolve(authConfig);
+    await retrying;
+
+    expect(store.authConfigChecking('srv-a')).toBe(false);
+    expect(store.authConfigCheckFailed('srv-a')).toBe(false);
+  });
 });
 
 describe('recovering when connectivity returns', () => {
@@ -230,6 +254,23 @@ describe('a server on an unreachable host', () => {
     await store.ensureAuthConfig('srv-a');
 
     expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+  });
+
+  it('does not carry a pre-outage sign-in-options failure past the skip', async () => {
+    // The failure recorded before the host went down belongs to a check that
+    // is no longer running — the skip must not let it sit there as if it
+    // were still current, or unblocking would show it "once more" for a
+    // check that never actually happened during the outage.
+    const store = newStore([remoteServer('srv-a', 'host-1')]);
+    getAuthConfig.mockRejectedValueOnce(new Error('fetch failed'));
+    await store.ensureAuthConfig('srv-a');
+    expect(store.authConfigCheckFailed('srv-a')).toBe(true);
+
+    blockedHosts.add('host-1');
+    await store.ensureAuthConfig('srv-a');
+
+    expect(store.authConfigCheckFailed('srv-a')).toBe(false);
+    expect(getAuthConfig).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
@@ -235,6 +235,36 @@ describe('the manual refresh button', () => {
     expect(getConnectionStatus).toHaveBeenCalledWith('srv-a');
     expect(store.authConfigFor('srv-a')).toEqual(authConfig);
   });
+
+  it('re-fetches sign-in options even when a config is already cached', async () => {
+    // The bug: once cached, ensureAuthConfig's short-circuit meant Refresh
+    // never asked again — a server that gained OIDC after Console cached
+    // password-only kept showing password-only until the app restarted.
+    const store = newStore([server('srv-a')]);
+    await store.ensureAuthConfig('srv-a');
+    expect(store.authConfigFor('srv-a')).toEqual(authConfig);
+
+    const updatedConfig = {
+      passwordLoginEnabled: true,
+      oidcEnabled: true,
+      oidcProviderLabel: 'WorkOS',
+    };
+    getAuthConfig.mockResolvedValueOnce(updatedConfig);
+
+    await store.refreshServer('srv-a');
+
+    expect(store.authConfigFor('srv-a')).toEqual(updatedConfig);
+  });
+
+  it('does not make the mount path re-fetch a cached config', async () => {
+    const store = newStore([server('srv-a')]);
+    await store.ensureAuthConfig('srv-a');
+    getAuthConfig.mockClear();
+
+    await store.ensureAuthConfig('srv-a');
+
+    expect(getAuthConfig).not.toHaveBeenCalled();
+  });
 });
 
 describe('a server that cannot be reached', () => {

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.test.ts
@@ -62,13 +62,22 @@ function newStore(servers: SwitchServer[]) {
   return store;
 }
 
-/** A promise the test resolves by hand, to hold a fetch in flight. */
+/** A promise the test settles by hand, to hold a fetch in flight and control
+ * exactly when — and in what order relative to another fetch — it lands. */
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((r) => {
-    resolve = r;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
+}
+
+/** Flushes pending timers and microtasks so an in-flight fetch's `.then`
+ * chain (including its `runInAction` writes) has fully landed. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 beforeEach(() => {
@@ -255,15 +264,44 @@ describe('the manual refresh button', () => {
 
     expect(store.authConfigFor('srv-a')).toEqual(updatedConfig);
   });
+});
 
-  it('does not make the mount path re-fetch a cached config', async () => {
+describe("the unreachable card's automatic retry", () => {
+  it('does not re-fetch sign-in options once they are already known', async () => {
+    // Before the manual-refresh fix, the auto-retry's call to refreshServer
+    // would have started re-fetching sign-in options on every tick forever.
+    // The retry loop exists to re-probe connectivity, not to hammer an
+    // endpoint whose answer rarely changes.
     const store = newStore([server('srv-a')]);
     await store.ensureAuthConfig('srv-a');
     getAuthConfig.mockClear();
 
-    await store.ensureAuthConfig('srv-a');
+    await store.retryConnection('srv-a');
 
     expect(getAuthConfig).not.toHaveBeenCalled();
+    expect(getConnectionStatus).toHaveBeenCalledWith('srv-a');
+  });
+});
+
+describe('the reachability flag under concurrent checks', () => {
+  it('does not evict a reachable server over a later-landing sign-in-options failure', async () => {
+    // refreshServer runs the connection check and the sign-in-options check
+    // concurrently. If the connection check lands first and succeeds, a
+    // sign-in-options fetch that fails afterward must not overwrite that with
+    // "unreachable" — that would throw a perfectly signed-in user onto the
+    // cannot-reach screen over an unrelated endpoint's hiccup.
+    const store = newStore([server('srv-a')]);
+    const authPending = deferred<typeof authConfig>();
+    getAuthConfig.mockReturnValueOnce(authPending.promise);
+
+    const refreshing = store.refreshServer('srv-a');
+    await flush();
+    expect(store.isUnreachable('srv-a')).toBe(false);
+
+    authPending.reject(new Error('fetch failed'));
+    await refreshing;
+
+    expect(store.isUnreachable('srv-a')).toBe(false);
   });
 });
 

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -165,7 +165,7 @@ export class SwitchServersStore {
    * that never got its auth config stuck on "Checking sign-in options…".
    */
   async refreshServer(serverId: string): Promise<void> {
-    await Promise.all([this.refreshStatus(serverId), this.ensureAuthConfig(serverId)]);
+    await Promise.all([this.refreshStatus(serverId), this.refreshAuthConfig(serverId)]);
   }
 
   async refreshStatus(serverId: string): Promise<void> {
@@ -209,6 +209,26 @@ export class SwitchServersStore {
       this.authConfigWanted.add(serverId);
     });
     if (this.authConfigs.has(serverId)) return;
+    await this.fetchAuthConfig(serverId);
+  }
+
+  /**
+   * Re-fetch a server's login methods even though one is already cached — for
+   * the manual refresh path, where the cached answer is exactly what might be
+   * wrong (an operator turning on OIDC after Console cached password-only). A
+   * failed refresh leaves the stale config in place rather than clearing it:
+   * `unreachable` is the disclosed signal that the answer might be out of
+   * date, so dropping the cache would only trade one indefinite state for
+   * another.
+   */
+  async refreshAuthConfig(serverId: string): Promise<void> {
+    runInAction(() => {
+      this.authConfigWanted.add(serverId);
+    });
+    await this.fetchAuthConfig(serverId);
+  }
+
+  private async fetchAuthConfig(serverId: string): Promise<void> {
     if (this.authConfigInFlight.has(serverId)) return;
     // The gateway of a server on an unreachable host cannot answer, and the
     // host-unreachable surface already states why — don't paint the global

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -33,10 +33,17 @@ export class SwitchServersStore {
   /** Server ids with an auth-config fetch in flight, so several recovery
    * signals arriving at once collapse into a single request. */
   private readonly authConfigInFlight = new Set<string>();
-  /** Server ids whose last gateway read failed. The page shows a single
-   * "cannot reach" state for these: with the gateway down there is nothing to
-   * sign into, so a sign-in form would be a dead end dressed up as a choice. */
-  readonly unreachable = new Set<string>();
+  /** Server ids whose last connection-status read failed. Authoritative for
+   * page-level reachability whenever a status read has ever run for that
+   * server: {@link isUnreachable} defers to this over
+   * {@link authConfigUnreachable} so a hiccup on the sign-in-options endpoint
+   * cannot evict a server whose status just came back fine. */
+  readonly statusUnreachable = new Set<string>();
+  /** Server ids whose last auth-config read failed. Only decisive before any
+   * status read has ever run for that server — the mount-time window where
+   * status is still unknown but a totally unreachable gateway has already
+   * failed the auth-config call. */
+  readonly authConfigUnreachable = new Set<string>();
 
   loadingServers = false;
   /** Whether the list has been read at least once. Until it has, an empty
@@ -85,9 +92,16 @@ export class SwitchServersStore {
     return this.statuses.get(serverId)?.connected ?? false;
   }
 
-  /** Whether the last read of this server's gateway failed to reach it. */
+  /**
+   * Whether this server counts as unreachable for the page. Once a status
+   * read has ever run for it, status is the sole authority — a signed-in
+   * server whose sign-in-options endpoint hiccups must not lose its signed-in
+   * view over that. Before status has ever answered, an auth-config failure
+   * is the only signal available, so it decides instead.
+   */
   isUnreachable(serverId: string): boolean {
-    return this.unreachable.has(serverId);
+    if (this.statuses.has(serverId)) return this.statusUnreachable.has(serverId);
+    return this.authConfigUnreachable.has(serverId);
   }
 
   async init(): Promise<void> {
@@ -168,6 +182,17 @@ export class SwitchServersStore {
     await Promise.all([this.refreshStatus(serverId), this.refreshAuthConfig(serverId)]);
   }
 
+  /**
+   * The unreachable card's probe, on its 10-second timer and its own Retry
+   * button alike. Only connectivity is worth re-checking on a fixed interval;
+   * sign-in options keep the once-cached behavior of {@link ensureAuthConfig}
+   * so a genuine outage does not turn into two doomed round trips forever —
+   * only one, until either succeeds.
+   */
+  async retryConnection(serverId: string): Promise<void> {
+    await Promise.all([this.refreshStatus(serverId), this.ensureAuthConfig(serverId)]);
+  }
+
   async refreshStatus(serverId: string): Promise<void> {
     runInAction(() => {
       this.refreshing.add(serverId);
@@ -176,7 +201,7 @@ export class SwitchServersStore {
       const status = await rpc.switchServers.getConnectionStatus(serverId);
       runInAction(() => {
         this.statuses.set(serverId, status);
-        this.unreachable.delete(serverId);
+        this.statusUnreachable.delete(serverId);
       });
     } catch (cause) {
       // An unreachable server is a real, displayable state — record it as
@@ -187,7 +212,7 @@ export class SwitchServersStore {
       console.warn(`[switch-servers] could not read status for ${serverId}`, cause);
       runInAction(() => {
         this.statuses.set(serverId, { serverId, connected: false, user: null });
-        this.unreachable.add(serverId);
+        this.statusUnreachable.add(serverId);
       });
     } finally {
       runInAction(() => {
@@ -217,9 +242,9 @@ export class SwitchServersStore {
    * the manual refresh path, where the cached answer is exactly what might be
    * wrong (an operator turning on OIDC after Console cached password-only). A
    * failed refresh leaves the stale config in place rather than clearing it:
-   * `unreachable` is the disclosed signal that the answer might be out of
-   * date, so dropping the cache would only trade one indefinite state for
-   * another.
+   * a server that is otherwise reachable keeps working on what it already
+   * knew, and {@link isUnreachable} does not let this failure alone evict a
+   * server whose connection status is fine (see {@link authConfigUnreachable}).
    */
   async refreshAuthConfig(serverId: string): Promise<void> {
     runInAction(() => {
@@ -242,7 +267,7 @@ export class SwitchServersStore {
       const config = await rpc.switchServers.getAuthConfig(serverId);
       runInAction(() => {
         this.authConfigs.set(serverId, config);
-        this.unreachable.delete(serverId);
+        this.authConfigUnreachable.delete(serverId);
       });
     } catch (cause) {
       // Not the error banner: the raw text is our own IPC method name wrapped
@@ -251,7 +276,7 @@ export class SwitchServersStore {
       // reached, and the detail stays in the console for us.
       console.warn(`[switch-servers] could not read auth config for ${serverId}`, cause);
       runInAction(() => {
-        this.unreachable.add(serverId);
+        this.authConfigUnreachable.add(serverId);
       });
     } finally {
       runInAction(() => {
@@ -359,7 +384,8 @@ export class SwitchServersStore {
         this.statuses.delete(serverId);
         this.authConfigs.delete(serverId);
         this.authConfigWanted.delete(serverId);
-        this.unreachable.delete(serverId);
+        this.statusUnreachable.delete(serverId);
+        this.authConfigUnreachable.delete(serverId);
       });
       // The removed id also sits in the server view's saved params, where it
       // outlives the record and would be read back — as a page for a server

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -39,10 +39,16 @@ export class SwitchServersStore {
    * {@link authConfigUnreachable} so a hiccup on the sign-in-options endpoint
    * cannot evict a server whose status just came back fine. */
   readonly statusUnreachable = new Set<string>();
-  /** Server ids whose last auth-config read failed. Only decisive before any
-   * status read has ever run for that server — the mount-time window where
-   * status is still unknown but a totally unreachable gateway has already
-   * failed the auth-config call. */
+  /**
+   * Server ids whose last auth-config read failed. Decisive for page-level
+   * reachability only before any status read has ever run for that server —
+   * once one has, {@link isUnreachable} never looks at this again, since a
+   * server can be perfectly reachable while only its sign-in-options endpoint
+   * stays broken. It does not stop mattering there: {@link
+   * authConfigCheckFailed} exposes it separately so the sign-in panel can
+   * disclose a persistently failing check instead of silently reusing a
+   * cached answer forever.
+   */
   readonly authConfigUnreachable = new Set<string>();
 
   loadingServers = false;
@@ -101,6 +107,19 @@ export class SwitchServersStore {
    */
   isUnreachable(serverId: string): boolean {
     if (this.statuses.has(serverId)) return this.statusUnreachable.has(serverId);
+    return this.authConfigUnreachable.has(serverId);
+  }
+
+  /**
+   * Whether the last sign-in-options read failed, regardless of what
+   * {@link isUnreachable} says. A server can be fully reachable — status
+   * fine, maybe even signed in — while its sign-in-options endpoint stays
+   * persistently broken; that failure never gates the page, so this is the
+   * only place it is visible. The sign-in panel reads it to disclose that the
+   * options on screen might be out of date rather than silently offering a
+   * cached answer forever.
+   */
+  authConfigCheckFailed(serverId: string): boolean {
     return this.authConfigUnreachable.has(serverId);
   }
 
@@ -174,20 +193,25 @@ export class SwitchServersStore {
   }
 
   /**
-   * The server page's manual re-check. Covers both what the status card reads
-   * and what the sign-in panel needs — refreshing only the status leaves a page
-   * that never got its auth config stuck on "Checking sign-in options…".
+   * A manual, explicit re-check: the server page's header button and the
+   * unreachable card's own Retry click. Covers both what the status card
+   * reads and what the sign-in panel needs — refreshing only the status
+   * leaves a page that never got its auth config stuck on "Checking sign-in
+   * options…", and a click is a single bounded request, so it can afford the
+   * full check even where the automatic probe below cannot.
    */
   async refreshServer(serverId: string): Promise<void> {
     await Promise.all([this.refreshStatus(serverId), this.refreshAuthConfig(serverId)]);
   }
 
   /**
-   * The unreachable card's probe, on its 10-second timer and its own Retry
-   * button alike. Only connectivity is worth re-checking on a fixed interval;
-   * sign-in options keep the once-cached behavior of {@link ensureAuthConfig}
-   * so a genuine outage does not turn into two doomed round trips forever —
-   * only one, until either succeeds.
+   * The unreachable card's automatic 10-second timer. Only connectivity is
+   * worth re-checking on a fixed interval; sign-in options keep the
+   * once-cached behavior of {@link ensureAuthConfig} so a genuine outage does
+   * not turn into two doomed round trips on every tick, forever — the panel's
+   * own {@link authConfigCheckFailed} disclosure, plus the card's manual
+   * Retry button, are what re-drive a persistently broken sign-in-options
+   * endpoint instead.
    */
   async retryConnection(serverId: string): Promise<void> {
     await Promise.all([this.refreshStatus(serverId), this.ensureAuthConfig(serverId)]);
@@ -241,10 +265,11 @@ export class SwitchServersStore {
    * Re-fetch a server's login methods even though one is already cached — for
    * the manual refresh path, where the cached answer is exactly what might be
    * wrong (an operator turning on OIDC after Console cached password-only). A
-   * failed refresh leaves the stale config in place rather than clearing it:
-   * a server that is otherwise reachable keeps working on what it already
-   * knew, and {@link isUnreachable} does not let this failure alone evict a
-   * server whose connection status is fine (see {@link authConfigUnreachable}).
+   * failed refresh leaves the stale config in place rather than clearing it,
+   * and {@link isUnreachable} does not let this failure alone evict a server
+   * whose connection status is fine — but the staleness itself is not
+   * silent: {@link authConfigCheckFailed} discloses it to the sign-in panel,
+   * which is the one place still showing what this fetch returned.
    */
   async refreshAuthConfig(serverId: string): Promise<void> {
     runInAction(() => {

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/switch-servers-store.ts
@@ -123,6 +123,13 @@ export class SwitchServersStore {
     return this.authConfigUnreachable.has(serverId);
   }
 
+  /** Whether a sign-in-options read is in flight right now. The sign-in panel
+   * reads this alongside {@link authConfigCheckFailed} so a fresh retry does
+   * not get reported as a failure while it is still running. */
+  authConfigChecking(serverId: string): boolean {
+    return this.authConfigInFlight.has(serverId);
+  }
+
   async init(): Promise<void> {
     runInAction(() => {
       this.loadingServers = true;
@@ -283,8 +290,15 @@ export class SwitchServersStore {
     // The gateway of a server on an unreachable host cannot answer, and the
     // host-unreachable surface already states why — don't paint the global
     // error banner with a doomed fetch (CHOO-1780). The host un-blocking is
-    // itself a recovery signal, so this is a skip, not a giving up.
-    if (this.isHostBlocked(serverId)) return;
+    // itself a recovery signal, so this is a skip, not a giving up — and a
+    // failure recorded before the host went down does not belong to this
+    // skip, so it does not survive it either.
+    if (this.isHostBlocked(serverId)) {
+      runInAction(() => {
+        this.authConfigUnreachable.delete(serverId);
+      });
+      return;
+    }
     runInAction(() => {
       this.authConfigInFlight.add(serverId);
     });

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/view.tsx
@@ -417,7 +417,8 @@ const ServerUnreachableCard = observer(function ServerUnreachableCard({
   // something would leave a server that recovered looking down. This only
   // re-checks connectivity, not sign-in options: those keep their once-cached
   // behavior so a real outage does not turn into two doomed round trips on
-  // every tick, forever.
+  // every tick, forever. A single explicit click is a different budget — see
+  // the Retry button below, which pays for the full check.
   useEffect(() => {
     const timer = setInterval(() => {
       if (!document.hidden) void store.retryConnection(serverId);
@@ -438,7 +439,11 @@ const ServerUnreachableCard = observer(function ServerUnreachableCard({
         variant="outline"
         size="sm"
         disabled={retrying}
-        onClick={() => void store.retryConnection(serverId)}
+        // A full refreshServer, not the lighter retryConnection the timer
+        // above uses: a click is one bounded request, not a forever-repeating
+        // one, so it can afford to also re-check sign-in options — the one
+        // way a persistently broken sign-in-options endpoint gets re-driven.
+        onClick={() => void store.refreshServer(serverId)}
       >
         <RefreshCw className={retrying ? 'size-4 animate-spin' : 'size-4'} />
         Retry

--- a/console/apps/switch-console-desktop/src/renderer/features/switch-servers/view.tsx
+++ b/console/apps/switch-console-desktop/src/renderer/features/switch-servers/view.tsx
@@ -414,10 +414,13 @@ const ServerUnreachableCard = observer(function ServerUnreachableCard({
   const retrying = store.refreshing.has(serverId);
 
   // Keep probing while this is on screen. Waiting for the user to press
-  // something would leave a server that recovered looking down.
+  // something would leave a server that recovered looking down. This only
+  // re-checks connectivity, not sign-in options: those keep their once-cached
+  // behavior so a real outage does not turn into two doomed round trips on
+  // every tick, forever.
   useEffect(() => {
     const timer = setInterval(() => {
-      if (!document.hidden) void store.refreshServer(serverId);
+      if (!document.hidden) void store.retryConnection(serverId);
     }, UNREACHABLE_RETRY_MS);
     return () => clearInterval(timer);
   }, [serverId, store]);
@@ -435,7 +438,7 @@ const ServerUnreachableCard = observer(function ServerUnreachableCard({
         variant="outline"
         size="sm"
         disabled={retrying}
-        onClick={() => void store.refreshServer(serverId)}
+        onClick={() => void store.retryConnection(serverId)}
       >
         <RefreshCw className={retrying ? 'size-4 animate-spin' : 'size-4'} />
         Retry


### PR DESCRIPTION
## What the user saw

A Switch server that gained OIDC sign-in (operator configures an IdP and
restarts the gateway) kept showing password-only in Switch Console until the
whole app was restarted. Clicking Refresh on the server page did not help —
verified live against a server returning
`{"password_login_enabled":true,"oidc_enabled":true,"oidc_provider_label":"WorkOS"}`
while Console kept offering only email/password.

## Why Refresh didn't work

`refreshServer` — the server page's manual re-check — called `refreshStatus`
and `ensureAuthConfig`. `ensureAuthConfig` fetches a server's login methods
once and caches them for the life of the process
(`if (this.authConfigs.has(serverId)) return;`), which is right for its
other callers (mount, recovery sweeps) but meant the explicit user-initiated
refresh could never see a config change after the first successful fetch.

## The fix

Split the actual fetch (in-flight collapsing, host-blocked skip, the
try/catch that marks a server unreachable without raising the global error
banner) into a private `fetchAuthConfig`. `ensureAuthConfig` keeps its
cache-once behavior; a new `refreshAuthConfig` skips the cache check, and
`refreshServer` calls it. Every other caller of `ensureAuthConfig`
(`useServerSignIn`'s mount effect, the fan-out around `view.tsx`) stays
exactly as cheap as before.

## Round 2: a race in the reachability flag

`refreshServer` runs the connection-status check and the sign-in-options
check concurrently. The first version of this fix had both write the same
`unreachable` `Set` with no coordination, so whichever settled last decided
the page's reachability regardless of what the other found — a signed-in
server whose sign-in-options endpoint blipped could get thrown onto the
"cannot reach the server" screen even though its session was fine, and this
now recurred on every Refresh click and every 10-second auto-retry tick
instead of the narrow mount-time window it used to be confined to.

Fixed by tracking the two checks in separate sets, `statusUnreachable` and
`authConfigUnreachable`, with `isUnreachable` deferring to status once a
status read has ever run for a server.

That version also introduced `retryConnection`, used by the unreachable
card's 10-second timer, which re-checks connectivity but keeps sign-in
options at their once-cached read — so an outage does not turn into an
unbounded repeated sign-in-options fetch.

## Round 3: the fix above deleted a signal instead of separating it

Review caught that `refreshStatus` writes `statuses` on both success and
failure, and `init()`/`addServer` populate it for every server within the
first tick of the app's life — so `isUnreachable`'s fallback to
`authConfigUnreachable` was live for a fraction of a second and dead for the
rest of the session. The consequence was not the transient hiccup this PR
set out to fix but the durable one: if the sign-in-options endpoint stayed
persistently broken, there was no signal at all — no unreachable card,
since status was fine, and no error banner by design — so the panel kept
rendering the last cached options as current, forever, silently.

Fixed by adding `authConfigCheckFailed(serverId)`, a signal kept separate
from page-level reachability (`isUnreachable` still defers to status alone,
unchanged from round 2). The sign-in panel (`server-sign-in.tsx`) reads it
and shows "Could not check for updated sign-in options — showing what was
last known" alongside the (possibly stale) cached fields, or "Could not
check sign-in options." if nothing was ever cached — disclosure at the
point the stale data is actually shown, not at the page level.

The same review flagged that the header's "Refresh" button and the
unreachable card's "Retry" button looked identical but behaved differently
(only the header forced a fresh sign-in-options check). Resolved by
collapsing the distinction rather than making it legible: both buttons are
single, bounded, explicit clicks, so both now call the full `refreshServer`.
Only the card's own repeating 10-second timer keeps the cheaper
`retryConnection`, since it is the one thing here that fires without a
click and must stay cheap forever.

## Round 4: two edges in the disclosure itself

1. **The failure text could show while a retry was in flight.** The panel
   chose its "Checking sign-in options…" vs "Could not check sign-in
   options." text from `configCheckFailed` alone. A first attempt failing
   with nothing cached, followed by a remount that starts a fresh fetch,
   would claim the check had failed right up until that fetch actually
   settled — true only briefly, but false while it lasted. Added
   `authConfigChecking(serverId)`, exposed the same way as
   `authConfigCheckFailed`, and the panel now prefers the checking state
   whenever a fetch is genuinely running.
2. **A host-blocked skip left a stale failure flag behind.**
   `fetchAuthConfig`'s host-blocked early return exited without touching
   `authConfigUnreachable` — correct in that it didn't fabricate a new
   failure, but a failure recorded just before the host went down would
   survive the outage and reappear once unblocked, since the recovering
   `ensureAuthConfig` call no-ops on a config that doesn't need fetching and
   never clears it. Now the skip clears `authConfigUnreachable`: a failure
   from before the block belongs to a check that isn't running, so it
   shouldn't outlive it.

## The stale-config trade-off

On a failed re-fetch, the fix leaves the previously cached config in place
rather than dropping it, and now discloses the failure in the one place
that matters (the sign-in panel) rather than at the page level, so a
reachable server never gets evicted over its own sign-in-options endpoint
having a bad day — durably or transiently.

## Test plan

- [x] Added a test that caches a config, has the RPC return a different one,
      calls `refreshServer`, and asserts the store now exposes the new
      config.
- [x] Added a test asserting `retryConnection` does not re-fetch a cached
      config, only connectivity.
- [x] Added a test asserting a sign-in-options failure that lands after a
      successful status check does not flip `isUnreachable` to true (the
      round-2 race).
- [x] Added tests for the round-3 defect: a persistently failing
      sign-in-options check stays disclosed via `authConfigCheckFailed`
      without evicting an otherwise-reachable server, and the disclosure
      clears once the endpoint answers again.
- [x] Added tests for the round-4 edges: a retry in flight reports
      `authConfigChecking` true and is not simultaneously reported as
      failed; a stale failure recorded before a host-blocked skip is
      cleared by that skip rather than surviving it. Both fail against the
      prior commit.
- [x] `pnpm vitest run --project node src/renderer/features/switch-servers/switch-servers-store.test.ts` — 31 passed
- [x] `pnpm vitest run --project node --project main-db` — full suite passed except one pre-existing failure in `src/sidecar/session-spawner.test.ts` unrelated to this change (reproduces identically on unmodified `main`)
- [x] `pnpm run typecheck` (workspace) — passed
- [x] `pnpm run lint` (workspace) — passed, one pre-existing unrelated warning
- [x] `pnpm run format:check` (workspace) — passed