### PR TITLE
fix(agent): scope AGENT_REGISTRATION_TOKEN to a non-admin owner

### DIFF
--- a/core/switch_core/bridges/agent/api/handlers.py
+++ b/core/switch_core/bridges/agent/api/handlers.py
@@ -151,7 +151,10 @@ async def _resolve_registration_user_id(
     key = await api_key_store.get_by_hash(session, token_hash)
     if key is None or key.type not in REGISTRATION_KEY_TYPES:
         raise HTTPException(status_code=401, detail="Invalid registration token")
-    return await resolve_registration_owner_id(session, protocol.user_store, key)
+    try:
+        return await resolve_registration_owner_id(session, protocol.user_store, key)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 # Registration endpoints

--- a/core/switch_core/bridges/agent/api/handlers.py
+++ b/core/switch_core/bridges/agent/api/handlers.py
@@ -90,6 +90,10 @@ from switch_core.bridges.agent.protocol.connections import (
 )
 from switch_core.bridges.agent.protocol.service import AgentExistsError, ProtocolService
 from switch_core.bridges.agent.protocol.stream import event_stream
+from switch_core.bridges.agent.registration_bootstrap import (
+    REGISTRATION_KEY_TYPES,
+    resolve_registration_owner_id,
+)
 from switch_core.db.models import Agent, Task
 from switch_core.db.stores.api_key_store import ApiKeyStore
 from switch_core.db.stores.feature_flag_store import FeatureFlagStore
@@ -130,17 +134,24 @@ async def _resolve_registration_user_id(
     authorization: Annotated[str, Header()],
     session: Annotated[AsyncSession, Depends(get_session)],
     api_key_store: Annotated[ApiKeyStore, Depends(get_api_key_store)],
+    protocol: Annotated[ProtocolService, Depends(get_protocol)],
 ) -> str:
     """Validate the registration token in the Authorization header and
-    return the owning user_id."""
+    return the user_id new agents should be owned by.
+
+    A personal ``"registration"`` key resolves to the user who minted it. The
+    deployment-wide ``"bootstrap"`` key (see ``registration_bootstrap.py``)
+    resolves to a dedicated, non-admin account instead of the admin who
+    seeded it, so holding it never confers admin authority.
+    """
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid authorization header")
     token = authorization[7:]
     token_hash = hashlib.sha256(token.encode()).hexdigest()
     key = await api_key_store.get_by_hash(session, token_hash)
-    if key is None or key.type != "registration":
+    if key is None or key.type not in REGISTRATION_KEY_TYPES:
         raise HTTPException(status_code=401, detail="Invalid registration token")
-    return key.user_id
+    return await resolve_registration_owner_id(session, protocol.user_store, key)
 
 
 # Registration endpoints

--- a/core/switch_core/bridges/agent/api/handlers.py
+++ b/core/switch_core/bridges/agent/api/handlers.py
@@ -154,7 +154,10 @@ async def _resolve_registration_user_id(
     try:
         return await resolve_registration_owner_id(session, protocol.user_store, key)
     except RuntimeError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        logger.error("Agent-registration bootstrap owner resolution failed: %s", exc)
+        raise HTTPException(
+            status_code=503, detail="Agent registration is temporarily unavailable"
+        ) from exc
 
 
 # Registration endpoints

--- a/core/switch_core/bridges/agent/auth.py
+++ b/core/switch_core/bridges/agent/auth.py
@@ -11,6 +11,7 @@ from starlette.responses import Response
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from switch_core.bridges.agent.api_key_cache import ApiKeyCache
+from switch_core.bridges.agent.registration_bootstrap import REGISTRATION_KEY_TYPES
 from switch_core.db.models import Agent, ApiKey
 from switch_core.db.stores.agent_store import AgentStore
 from switch_core.db.stores.api_key_store import ApiKeyStore
@@ -71,8 +72,9 @@ class BearerAuthMiddleware:
        Used by agent-bridge HTTP endpoints and MCP.
     2. OIDC token — validated against the configured issuer, mapped to an
        agent via the ``oauth_client_id`` field on Agent.
-    3. Registration token — an ApiKey row of type ``"registration"`` that
-       has no associated agent. Used by the registration endpoint
+    3. Registration token — an ApiKey row of type ``"registration"`` or
+       ``"bootstrap"`` (see ``registration_bootstrap.py``) that has no
+       associated agent. Used by the registration endpoint
        (``POST /agents``). Sets ``scope["api_key"]`` so downstream
        handlers can validate it again.
 
@@ -137,7 +139,7 @@ class BearerAuthMiddleware:
         # Registration token: pass through (handler validates again). MCP rejects.
         if (
             api_key is not None
-            and api_key.type == "registration"
+            and api_key.type in REGISTRATION_KEY_TYPES
             and not path.startswith("/mcp")
         ):
             scope["api_key"] = api_key

--- a/core/switch_core/bridges/agent/protocol/service.py
+++ b/core/switch_core/bridges/agent/protocol/service.py
@@ -51,6 +51,10 @@ from switch_core.bridges.agent.protocol.types import (
     ToolCallReport,
     ToolSpec,
 )
+from switch_core.bridges.agent.registration_bootstrap import (
+    REGISTRATION_KEY_TYPES,
+    resolve_registration_owner_id,
+)
 from switch_core.bridges.resource.service import ResourceService
 from switch_core.crypto import encrypt_token
 from switch_core.db.models import (
@@ -435,14 +439,18 @@ class ProtocolService:
     ) -> RegistrationResult:
         """Resolve a registration token to its owner, then register the agent.
 
-        Raises PermissionError if the token does not match a stored ApiKey.
+        Raises PermissionError if the token does not match a stored ApiKey of
+        a registration type (see ``registration_bootstrap.REGISTRATION_KEY_TYPES``).
         Raises AgentExistsError if the name is taken and ``overwrite`` is False.
         """
         token_hash = hashlib.sha256(registration_token.encode()).hexdigest()
         async with self.session_factory() as session:
             key = await self.api_key_store.get_by_hash(session, token_hash)
-        if key is None:
-            raise PermissionError("Invalid registration token")
+            if key is None or key.type not in REGISTRATION_KEY_TYPES:
+                raise PermissionError("Invalid registration token")
+            owner_id = await resolve_registration_owner_id(
+                session, self.user_store, key
+            )
 
         return await self.register_agent(
             name=name,
@@ -453,7 +461,7 @@ class ProtocolService:
             tools=tools,
             models=models,
             metadata=metadata,
-            owner_id=key.user_id,
+            owner_id=owner_id,
             overwrite=overwrite,
             addressable_by_agent_ids=addressable_by_agent_ids,
             owner_only=owner_only,

--- a/core/switch_core/bridges/agent/protocol/service.py
+++ b/core/switch_core/bridges/agent/protocol/service.py
@@ -204,6 +204,17 @@ class AgentExistsError(Exception):
     caller did not opt into re-registration via ``overwrite=True``."""
 
 
+class BootstrapOwnerMisconfiguredError(Exception):
+    """Raised when the deployment-wide bootstrap key's owner account cannot
+    be resolved or trusted (see ``registration_bootstrap.py``).
+
+    Deliberately not a ``PermissionError``: the presented token is valid, so
+    this is a deployment misconfiguration, not a bad credential. A caller
+    that catches ``PermissionError`` to mean "bad token" must not also catch
+    this and report the same thing.
+    """
+
+
 def _describe_room(room: Room) -> RoomDescriptor:
     return RoomDescriptor(
         id=room.id,
@@ -440,10 +451,13 @@ class ProtocolService:
         """Resolve a registration token to its owner, then register the agent.
 
         Raises PermissionError if the token does not match a stored ApiKey of
-        a registration type (see ``registration_bootstrap.REGISTRATION_KEY_TYPES``),
-        or if the bootstrap owner cannot be resolved (misconfigured deployment
-        — the detail is logged, not raised, to match the HTTP registration
-        path's handling of the same failure).
+        a registration type (see ``registration_bootstrap.REGISTRATION_KEY_TYPES``).
+        Raises BootstrapOwnerMisconfiguredError if the token is valid but its
+        bootstrap owner cannot be resolved or trusted — a deployment fault,
+        not a bad credential, so callers must not conflate it with the
+        PermissionError above (the detail is logged here, not in the
+        exception, to match the HTTP registration path's handling of the
+        same failure).
         Raises AgentExistsError if the name is taken and ``overwrite`` is False.
         """
         token_hash = hashlib.sha256(registration_token.encode()).hexdigest()
@@ -459,7 +473,7 @@ class ProtocolService:
                 logger.error(
                     "Agent-registration bootstrap owner resolution failed: %s", exc
                 )
-                raise PermissionError(
+                raise BootstrapOwnerMisconfiguredError(
                     "Agent registration is temporarily unavailable"
                 ) from exc
 

--- a/core/switch_core/bridges/agent/protocol/service.py
+++ b/core/switch_core/bridges/agent/protocol/service.py
@@ -440,7 +440,10 @@ class ProtocolService:
         """Resolve a registration token to its owner, then register the agent.
 
         Raises PermissionError if the token does not match a stored ApiKey of
-        a registration type (see ``registration_bootstrap.REGISTRATION_KEY_TYPES``).
+        a registration type (see ``registration_bootstrap.REGISTRATION_KEY_TYPES``),
+        or if the bootstrap owner cannot be resolved (misconfigured deployment
+        — the detail is logged, not raised, to match the HTTP registration
+        path's handling of the same failure).
         Raises AgentExistsError if the name is taken and ``overwrite`` is False.
         """
         token_hash = hashlib.sha256(registration_token.encode()).hexdigest()
@@ -448,9 +451,17 @@ class ProtocolService:
             key = await self.api_key_store.get_by_hash(session, token_hash)
             if key is None or key.type not in REGISTRATION_KEY_TYPES:
                 raise PermissionError("Invalid registration token")
-            owner_id = await resolve_registration_owner_id(
-                session, self.user_store, key
-            )
+            try:
+                owner_id = await resolve_registration_owner_id(
+                    session, self.user_store, key
+                )
+            except RuntimeError as exc:
+                logger.error(
+                    "Agent-registration bootstrap owner resolution failed: %s", exc
+                )
+                raise PermissionError(
+                    "Agent registration is temporarily unavailable"
+                ) from exc
 
         return await self.register_agent(
             name=name,

--- a/core/switch_core/bridges/agent/registration_bootstrap.py
+++ b/core/switch_core/bridges/agent/registration_bootstrap.py
@@ -13,6 +13,13 @@ to a dedicated, non-admin account (see :data:`BOOTSTRAP_OWNER_EMAIL`) instead
 of the seeded admin. Otherwise every holder of that one shared secret would
 register agents that inherit the admin's authority over every room and
 resource in the deployment, not just their own.
+
+That guarantee only holds if the account at :data:`BOOTSTRAP_OWNER_EMAIL` is
+never an admin. Nothing in this codebase reserves that address — a gateway
+admin can `POST /users` with it and an admin role, and an OIDC identity
+provider can assert it as someone's login email — so both entry points here
+verify the resolved account's role and refuse rather than silently adopting
+an admin.
 """
 
 from __future__ import annotations
@@ -38,16 +45,42 @@ BOOTSTRAP_OWNER_NAME = "Agent Bootstrap"
 BOOTSTRAP_KEY_LABEL = "Deployment bootstrap (from AGENT_REGISTRATION_TOKEN)"
 
 # Label of the key this replaces, from before agent-registration bootstrap
-# had its own owner and its own ApiKey type. Startup seeding uses this to
-# find and migrate an existing deployment's old admin-owned key in place
-# rather than leaving it live alongside a new one.
+# had its own owner and its own ApiKey type. Startup seeding uses this,
+# together with a hash match against the configured token, to find and
+# migrate an existing deployment's old admin-owned key in place rather than
+# leaving it live alongside a new one.
 LEGACY_BOOTSTRAP_KEY_LABEL = "Default (from AGENT_REGISTRATION_TOKEN)"
+
+# Persisted on the bootstrap owner's own metadata (never on the admin's): the
+# admin a deployment resolves to is a mutable config value (`GATEWAY_ADMIN_EMAIL`),
+# so a marker filed there stops meaning what it says the moment that value
+# changes. The bootstrap owner's email is a fixed constant, so this survives
+# an admin-email change intact. It records the hash of the token last seeded
+# rather than a bare boolean so a revoked key stays revoked only for the
+# value it was revoked at: rotating AGENT_REGISTRATION_TOKEN to a new value
+# re-establishes bootstrap registration without touching the database by
+# hand, while restarting with the same, already-revoked value does not.
+BOOTSTRAP_LAST_SEEDED_HASH_META_KEY = "agent_bootstrap_key_last_hash"
+
+
+def _raise_if_admin(owner: User) -> None:
+    if owner.role == "admin":
+        raise RuntimeError(
+            f"{BOOTSTRAP_OWNER_EMAIL} is reserved for agent-registration "
+            "bootstrap and must never be an admin, but the account at that "
+            "address currently has the admin role. Demote or remove it "
+            "before agent-registration bootstrap can run."
+        )
 
 
 async def ensure_bootstrap_owner(session: AsyncSession, user_store: UserStore) -> User:
-    """Idempotently create the account bootstrap-registered agents are owned by."""
+    """Idempotently create the account bootstrap-registered agents are owned by.
+
+    Raises if an account already exists at that address with the admin role.
+    """
     owner = await user_store.get_by_email(session, BOOTSTRAP_OWNER_EMAIL)
     if owner is not None:
+        _raise_if_admin(owner)
         return owner
     owner = User(name=BOOTSTRAP_OWNER_NAME, email=BOOTSTRAP_OWNER_EMAIL, role="user")
     await user_store.create(session, owner)
@@ -60,6 +93,9 @@ async def resolve_registration_owner_id(
     """The user new agents should be owned by, given the key used to register them.
 
     ``key`` must already be validated as one of ``REGISTRATION_KEY_TYPES``.
+    Raises if a bootstrap key resolves to an account that has since been
+    promoted to admin — ``ensure_bootstrap_owner`` only runs at startup, so
+    this is the check that catches a later promotion.
     """
     if key.type != BOOTSTRAP_KEY_TYPE:
         return key.user_id
@@ -69,4 +105,5 @@ async def resolve_registration_owner_id(
             f"Agent-registration bootstrap owner ({BOOTSTRAP_OWNER_EMAIL}) is "
             "missing; restart the server to reseed it."
         )
+    _raise_if_admin(owner)
     return owner.id

--- a/core/switch_core/bridges/agent/registration_bootstrap.py
+++ b/core/switch_core/bridges/agent/registration_bootstrap.py
@@ -108,10 +108,15 @@ def _is_genuine(owner: User) -> bool:
 def _raise_unless_genuine(owner: User) -> None:
     if not _is_genuine(owner):
         raise RuntimeError(
-            f"An account already exists at {BOOTSTRAP_OWNER_EMAIL} but was "
-            "not created by agent-registration bootstrap seeding, so it "
-            "cannot be trusted to carry no admin authority now or later. "
-            "There is no gateway endpoint that removes or renames a user: "
+            f"An account already exists at {BOOTSTRAP_OWNER_EMAIL} but "
+            "cannot be proven to have been created by agent-registration "
+            "bootstrap seeding, so it cannot be trusted to carry no admin "
+            "authority now or later. Two things produce this: something "
+            "else claimed the address (a gateway admin, an OIDC login), or "
+            "it was created by an earlier revision of this feature that "
+            "recorded its own state on the admin's account instead of here "
+            "and so left no evidence on this row to check. Either way, "
+            "there is no gateway endpoint that removes or renames a user: "
             "this needs a direct edit to the users table before "
             "agent-registration bootstrap can run."
         )

--- a/core/switch_core/bridges/agent/registration_bootstrap.py
+++ b/core/switch_core/bridges/agent/registration_bootstrap.py
@@ -15,11 +15,15 @@ register agents that inherit the admin's authority over every room and
 resource in the deployment, not just their own.
 
 That guarantee only holds if the account at :data:`BOOTSTRAP_OWNER_EMAIL` is
-never an admin. Nothing in this codebase reserves that address — a gateway
-admin can `POST /users` with it and an admin role, and an OIDC identity
-provider can assert it as someone's login email — so both entry points here
-verify the resolved account's role and refuse rather than silently adopting
-an admin.
+the one this module itself provisioned. Nothing in this codebase reserves
+that address, and an admin role is not the only way to end up controlling
+it: a gateway admin can `POST /users` with that email and an admin role, but
+an OIDC identity provider can also claim it outright by asserting it as a
+login email — JIT provisioning always creates a `role="user"` account, so an
+account's mere existence there proves nothing about who put it there. Both
+entry points here refuse to adopt an existing account at that address unless
+it carries the marker only this module's own creation path sets, and refuse
+an admin role on top of that as a second, independent check.
 """
 
 from __future__ import annotations
@@ -42,6 +46,13 @@ REGISTRATION_KEY_TYPES = ("registration", BOOTSTRAP_KEY_TYPE)
 BOOTSTRAP_OWNER_EMAIL = "agent-bootstrap@switch.local"
 BOOTSTRAP_OWNER_NAME = "Agent Bootstrap"
 
+# Stamped into the bootstrap owner's metadata only at the moment this module
+# creates it. An account found at BOOTSTRAP_OWNER_EMAIL without this marker
+# was put there by something else — a gateway admin, an OIDC login claiming
+# the address before this ever ran — and must not be adopted regardless of
+# its role.
+BOOTSTRAP_OWNER_MARKER_META_KEY = "agent_bootstrap_owner"
+
 BOOTSTRAP_KEY_LABEL = "Deployment bootstrap (from AGENT_REGISTRATION_TOKEN)"
 
 # Label of the key this replaces, from before agent-registration bootstrap
@@ -51,38 +62,61 @@ BOOTSTRAP_KEY_LABEL = "Deployment bootstrap (from AGENT_REGISTRATION_TOKEN)"
 # leaving it live alongside a new one.
 LEGACY_BOOTSTRAP_KEY_LABEL = "Default (from AGENT_REGISTRATION_TOKEN)"
 
-# Persisted on the bootstrap owner's own metadata (never on the admin's): the
-# admin a deployment resolves to is a mutable config value (`GATEWAY_ADMIN_EMAIL`),
-# so a marker filed there stops meaning what it says the moment that value
-# changes. The bootstrap owner's email is a fixed constant, so this survives
-# an admin-email change intact. It records the hash of the token last seeded
-# rather than a bare boolean so a revoked key stays revoked only for the
-# value it was revoked at: rotating AGENT_REGISTRATION_TOKEN to a new value
-# re-establishes bootstrap registration without touching the database by
-# hand, while restarting with the same, already-revoked value does not.
+# Both persisted on the bootstrap owner's own metadata, never on the admin's:
+# the admin a deployment resolves to is a mutable config value
+# (`GATEWAY_ADMIN_EMAIL`), so a marker filed there stops meaning what it says
+# the moment that value changes. The bootstrap owner's email is a fixed
+# constant, so these survive an admin-email change intact.
+#
+# `..._LAST_HASH...` is the hash of the bootstrap key as of the last seed
+# call, used only to notice that a key present last time is now gone (i.e. it
+# was just revoked) so its hash can be recorded below.
+#
+# `..._REVOKED_HASHES...` is every hash ever revoked this way. A hash on this
+# list is refused forever, even if the currently active key or the
+# configured token later returns to it — recording only the single
+# most-recently-revoked value would let one rotation forward and one back
+# silently reinstate a value the operator deliberately killed.
 BOOTSTRAP_LAST_SEEDED_HASH_META_KEY = "agent_bootstrap_key_last_hash"
+BOOTSTRAP_REVOKED_HASHES_META_KEY = "agent_bootstrap_revoked_hashes"
 
 
-def _raise_if_admin(owner: User) -> None:
+def _raise_unless_genuine(owner: User) -> None:
+    if not (owner.metadata_ or {}).get(BOOTSTRAP_OWNER_MARKER_META_KEY):
+        raise RuntimeError(
+            f"An account already exists at {BOOTSTRAP_OWNER_EMAIL} but was "
+            "not created by agent-registration bootstrap seeding, so it "
+            "cannot be trusted to carry no admin authority now or later. "
+            "There is no gateway endpoint that removes or renames a user: "
+            "this needs a direct edit to the users table before "
+            "agent-registration bootstrap can run."
+        )
     if owner.role == "admin":
         raise RuntimeError(
             f"{BOOTSTRAP_OWNER_EMAIL} is reserved for agent-registration "
             "bootstrap and must never be an admin, but the account at that "
-            "address currently has the admin role. Demote or remove it "
-            "before agent-registration bootstrap can run."
+            "address currently has the admin role. There is no gateway "
+            "endpoint that changes a user's role: this needs a direct edit "
+            "to the users table before agent-registration bootstrap can run."
         )
 
 
 async def ensure_bootstrap_owner(session: AsyncSession, user_store: UserStore) -> User:
     """Idempotently create the account bootstrap-registered agents are owned by.
 
-    Raises if an account already exists at that address with the admin role.
+    Raises if an account already exists at that address that this function
+    did not itself create, or that has since been given the admin role.
     """
     owner = await user_store.get_by_email(session, BOOTSTRAP_OWNER_EMAIL)
     if owner is not None:
-        _raise_if_admin(owner)
+        _raise_unless_genuine(owner)
         return owner
-    owner = User(name=BOOTSTRAP_OWNER_NAME, email=BOOTSTRAP_OWNER_EMAIL, role="user")
+    owner = User(
+        name=BOOTSTRAP_OWNER_NAME,
+        email=BOOTSTRAP_OWNER_EMAIL,
+        role="user",
+        metadata_={BOOTSTRAP_OWNER_MARKER_META_KEY: True},
+    )
     await user_store.create(session, owner)
     return owner
 
@@ -93,9 +127,10 @@ async def resolve_registration_owner_id(
     """The user new agents should be owned by, given the key used to register them.
 
     ``key`` must already be validated as one of ``REGISTRATION_KEY_TYPES``.
-    Raises if a bootstrap key resolves to an account that has since been
-    promoted to admin — ``ensure_bootstrap_owner`` only runs at startup, so
-    this is the check that catches a later promotion.
+    Raises if a bootstrap key resolves to an account this module did not
+    provision, or one that has since been given the admin role —
+    ``ensure_bootstrap_owner`` only runs at startup, so this is the check
+    that catches either happening afterward.
     """
     if key.type != BOOTSTRAP_KEY_TYPE:
         return key.user_id
@@ -105,5 +140,5 @@ async def resolve_registration_owner_id(
             f"Agent-registration bootstrap owner ({BOOTSTRAP_OWNER_EMAIL}) is "
             "missing; restart the server to reseed it."
         )
-    _raise_if_admin(owner)
+    _raise_unless_genuine(owner)
     return owner.id

--- a/core/switch_core/bridges/agent/registration_bootstrap.py
+++ b/core/switch_core/bridges/agent/registration_bootstrap.py
@@ -22,8 +22,8 @@ an OIDC identity provider can also claim it outright by asserting it as a
 login email — JIT provisioning always creates a `role="user"` account, so an
 account's mere existence there proves nothing about who put it there. Both
 entry points here refuse to adopt an existing account at that address unless
-it carries the marker only this module's own creation path sets, and refuse
-an admin role on top of that as a second, independent check.
+it is provably genuine, and refuse an admin role on top of that as a second,
+independent check.
 """
 
 from __future__ import annotations
@@ -37,8 +37,19 @@ BOOTSTRAP_KEY_TYPE = "bootstrap"
 
 # Every ApiKey type that may stand in for a registration token at the
 # `POST /agents` family of endpoints. Anything else (in practice, an agent's
-# own `"agent"`-type key) must not be replayed to register more agents.
+# own `"agent"`-type key, or a `RETIRED_KEY_TYPE` row) must not be replayed
+# to register more agents.
 REGISTRATION_KEY_TYPES = ("registration", BOOTSTRAP_KEY_TYPE)
+
+# Assigned to a stale legacy-labeled key at startup instead of deleting it:
+# not in REGISTRATION_KEY_TYPES, so it stops authenticating exactly as
+# deletion would, but the row (and its label, rewritten to say so) stays on
+# the gateway's API Keys page for a human to notice and remove — a deleted
+# row leaves nothing but a startup log line, and the two cases this can be
+# (a stale rotated-out bootstrap key, or an unrelated personal key that
+# happened to share the auto-generated label) are not distinguishable at
+# seed time, so the evidence needs to survive for a human to tell afterward.
+RETIRED_KEY_TYPE = "retired"
 
 # Synthetic account, never logged into (no password), that owns every agent
 # registered through the deployment-wide bootstrap key. Kept distinct from
@@ -46,11 +57,17 @@ REGISTRATION_KEY_TYPES = ("registration", BOOTSTRAP_KEY_TYPE)
 BOOTSTRAP_OWNER_EMAIL = "agent-bootstrap@switch.local"
 BOOTSTRAP_OWNER_NAME = "Agent Bootstrap"
 
-# Stamped into the bootstrap owner's metadata only at the moment this module
-# creates it. An account found at BOOTSTRAP_OWNER_EMAIL without this marker
-# was put there by something else — a gateway admin, an OIDC login claiming
-# the address before this ever ran — and must not be adopted regardless of
-# its role.
+# Stamped into the bootstrap owner's metadata by this module's own creation
+# path. An account found at BOOTSTRAP_OWNER_EMAIL without this marker was put
+# there by something else — a gateway admin, an OIDC login claiming the
+# address before this ever ran — *unless* it already carries
+# BOOTSTRAP_LAST_SEEDED_HASH_META_KEY (below): that key is written only by
+# this module's own seeding step, so its presence on an unmarked row proves
+# the row predates the marker (created by an earlier version of this
+# feature) rather than being squatted — a squatter cannot have written a
+# value only this code ever writes. Backfilled onto such a row rather than
+# refused, so upgrading past the commit that introduced the marker does not
+# brick a database this already ran against.
 BOOTSTRAP_OWNER_MARKER_META_KEY = "agent_bootstrap_owner"
 
 BOOTSTRAP_KEY_LABEL = "Deployment bootstrap (from AGENT_REGISTRATION_TOKEN)"
@@ -81,8 +98,15 @@ BOOTSTRAP_LAST_SEEDED_HASH_META_KEY = "agent_bootstrap_key_last_hash"
 BOOTSTRAP_REVOKED_HASHES_META_KEY = "agent_bootstrap_revoked_hashes"
 
 
+def _is_genuine(owner: User) -> bool:
+    meta = owner.metadata_ or {}
+    if meta.get(BOOTSTRAP_OWNER_MARKER_META_KEY):
+        return True
+    return BOOTSTRAP_LAST_SEEDED_HASH_META_KEY in meta
+
+
 def _raise_unless_genuine(owner: User) -> None:
-    if not (owner.metadata_ or {}).get(BOOTSTRAP_OWNER_MARKER_META_KEY):
+    if not _is_genuine(owner):
         raise RuntimeError(
             f"An account already exists at {BOOTSTRAP_OWNER_EMAIL} but was "
             "not created by agent-registration bootstrap seeding, so it "
@@ -93,23 +117,29 @@ def _raise_unless_genuine(owner: User) -> None:
         )
     if owner.role == "admin":
         raise RuntimeError(
-            f"{BOOTSTRAP_OWNER_EMAIL} is reserved for agent-registration "
-            "bootstrap and must never be an admin, but the account at that "
-            "address currently has the admin role. There is no gateway "
-            "endpoint that changes a user's role: this needs a direct edit "
-            "to the users table before agent-registration bootstrap can run."
+            f"{BOOTSTRAP_OWNER_EMAIL} must never be an admin, but the "
+            "account at that address currently has the admin role. There is "
+            "no gateway endpoint that changes a user's role: this needs a "
+            "direct edit to the users table before agent-registration "
+            "bootstrap can run."
         )
 
 
 async def ensure_bootstrap_owner(session: AsyncSession, user_store: UserStore) -> User:
     """Idempotently create the account bootstrap-registered agents are owned by.
 
-    Raises if an account already exists at that address that this function
-    did not itself create, or that has since been given the admin role.
+    Raises if an account already exists at that address that cannot be
+    proven genuine (see ``_is_genuine``), or that has since been given the
+    admin role. A genuine row created before the marker existed is backfilled
+    with one here rather than refused.
     """
     owner = await user_store.get_by_email(session, BOOTSTRAP_OWNER_EMAIL)
     if owner is not None:
         _raise_unless_genuine(owner)
+        if not (owner.metadata_ or {}).get(BOOTSTRAP_OWNER_MARKER_META_KEY):
+            meta = dict(owner.metadata_ or {})
+            meta[BOOTSTRAP_OWNER_MARKER_META_KEY] = True
+            owner.metadata_ = meta
         return owner
     owner = User(
         name=BOOTSTRAP_OWNER_NAME,
@@ -127,8 +157,8 @@ async def resolve_registration_owner_id(
     """The user new agents should be owned by, given the key used to register them.
 
     ``key`` must already be validated as one of ``REGISTRATION_KEY_TYPES``.
-    Raises if a bootstrap key resolves to an account this module did not
-    provision, or one that has since been given the admin role —
+    Raises if a bootstrap key resolves to an account that cannot be proven
+    genuine, or one that has since been given the admin role —
     ``ensure_bootstrap_owner`` only runs at startup, so this is the check
     that catches either happening afterward.
     """

--- a/core/switch_core/bridges/agent/registration_bootstrap.py
+++ b/core/switch_core/bridges/agent/registration_bootstrap.py
@@ -1,0 +1,72 @@
+"""The deployment-wide agent-registration bootstrap credential.
+
+``AGENT_REGISTRATION_TOKEN`` is seeded once at startup as an ``ApiKey`` of
+type ``"bootstrap"`` (see ``main.py``) so a fresh deployment has *some* way to
+register its first agents before any user has logged into the gateway to mint
+a personal one (``gateway/api_keys.py``, type ``"registration"``).
+
+A ``"registration"`` key is minted by, and owned by, a single user: agents it
+registers are attributed to that user directly. A ``"bootstrap"`` key has no
+such owner in mind — it is handed to whoever needs to bring an agent up
+against a fresh deployment — so agents registered through it are attributed
+to a dedicated, non-admin account (see :data:`BOOTSTRAP_OWNER_EMAIL`) instead
+of the seeded admin. Otherwise every holder of that one shared secret would
+register agents that inherit the admin's authority over every room and
+resource in the deployment, not just their own.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from switch_core.db.models import ApiKey, User
+from switch_core.db.stores.user_store import UserStore
+
+BOOTSTRAP_KEY_TYPE = "bootstrap"
+
+# Every ApiKey type that may stand in for a registration token at the
+# `POST /agents` family of endpoints. Anything else (in practice, an agent's
+# own `"agent"`-type key) must not be replayed to register more agents.
+REGISTRATION_KEY_TYPES = ("registration", BOOTSTRAP_KEY_TYPE)
+
+# Synthetic account, never logged into (no password), that owns every agent
+# registered through the deployment-wide bootstrap key. Kept distinct from
+# the admin user specifically so that key confers no admin authority.
+BOOTSTRAP_OWNER_EMAIL = "agent-bootstrap@switch.local"
+BOOTSTRAP_OWNER_NAME = "Agent Bootstrap"
+
+BOOTSTRAP_KEY_LABEL = "Deployment bootstrap (from AGENT_REGISTRATION_TOKEN)"
+
+# Label of the key this replaces, from before agent-registration bootstrap
+# had its own owner and its own ApiKey type. Startup seeding uses this to
+# find and migrate an existing deployment's old admin-owned key in place
+# rather than leaving it live alongside a new one.
+LEGACY_BOOTSTRAP_KEY_LABEL = "Default (from AGENT_REGISTRATION_TOKEN)"
+
+
+async def ensure_bootstrap_owner(session: AsyncSession, user_store: UserStore) -> User:
+    """Idempotently create the account bootstrap-registered agents are owned by."""
+    owner = await user_store.get_by_email(session, BOOTSTRAP_OWNER_EMAIL)
+    if owner is not None:
+        return owner
+    owner = User(name=BOOTSTRAP_OWNER_NAME, email=BOOTSTRAP_OWNER_EMAIL, role="user")
+    await user_store.create(session, owner)
+    return owner
+
+
+async def resolve_registration_owner_id(
+    session: AsyncSession, user_store: UserStore, key: ApiKey
+) -> str:
+    """The user new agents should be owned by, given the key used to register them.
+
+    ``key`` must already be validated as one of ``REGISTRATION_KEY_TYPES``.
+    """
+    if key.type != BOOTSTRAP_KEY_TYPE:
+        return key.user_id
+    owner = await user_store.get_by_email(session, BOOTSTRAP_OWNER_EMAIL)
+    if owner is None:
+        raise RuntimeError(
+            f"Agent-registration bootstrap owner ({BOOTSTRAP_OWNER_EMAIL}) is "
+            "missing; restart the server to reseed it."
+        )
+    return owner.id

--- a/core/switch_core/db/stores/api_key_store.py
+++ b/core/switch_core/db/stores/api_key_store.py
@@ -60,6 +60,17 @@ class ApiKeyStore:
         result = await session.execute(select(ApiKey).where(ApiKey.type == key_type))
         return list(result.scalars().all())
 
+    async def get_by_label(self, session: AsyncSession, label: str) -> list[ApiKey]:
+        """Every key carrying a given label, regardless of type or owner.
+
+        Labels are free text, so this is a discovery aid, not an identity
+        lookup — a caller matching against a known auto-generated label
+        (never one a user is expected to type) still has to check the type
+        and, ideally, the hash, before treating a match as authoritative.
+        """
+        result = await session.execute(select(ApiKey).where(ApiKey.label == label))
+        return list(result.scalars().all())
+
     async def delete(self, session: AsyncSession, key_id: str) -> None:
         key = await session.get(ApiKey, key_id)
         if key:

--- a/core/switch_core/db/stores/api_key_store.py
+++ b/core/switch_core/db/stores/api_key_store.py
@@ -50,6 +50,16 @@ class ApiKeyStore:
         )
         return list(result.scalars().all())
 
+    async def get_by_type(self, session: AsyncSession, key_type: str) -> list[ApiKey]:
+        """Every key of a given type, regardless of which user owns it.
+
+        Used where a type is meant to be a deployment-wide singleton (the
+        agent-registration bootstrap key) and existence must not depend on
+        which user currently holds it.
+        """
+        result = await session.execute(select(ApiKey).where(ApiKey.type == key_type))
+        return list(result.scalars().all())
+
     async def delete(self, session: AsyncSession, key_id: str) -> None:
         key = await session.get(ApiKey, key_id)
         if key:

--- a/core/switch_core/main.py
+++ b/core/switch_core/main.py
@@ -28,6 +28,7 @@ from switch_core.bridges.agent.registration_bootstrap import (
     BOOTSTRAP_LAST_SEEDED_HASH_META_KEY,
     BOOTSTRAP_REVOKED_HASHES_META_KEY,
     LEGACY_BOOTSTRAP_KEY_LABEL,
+    RETIRED_KEY_TYPE,
     ensure_bootstrap_owner,
 )
 from switch_core.bridges.agent.server_connectors.lifecycle import (
@@ -560,52 +561,19 @@ async def _seed_agent_registration_bootstrap_key(
             )
         bootstrap_key = bootstrap_keys[0] if bootstrap_keys else None
 
-        # Every row carrying the legacy label, not just one matching the
-        # current token: an admin who rotated AGENT_REGISTRATION_TOKEN at or
-        # before this upgrade leaves the old row's hash stale, so a hash-only
-        # lookup for the current token would miss it — and a `type:
-        # "registration"` row at that label is otherwise indistinguishable
-        # from a live credential that still authenticates as the admin.
-        legacy_rows = [
-            row
-            for row in await api_key_store.get_by_label(
-                session, LEGACY_BOOTSTRAP_KEY_LABEL
-            )
-            if row.type == "registration"
-        ]
-        matching_legacy = next(
-            (row for row in legacy_rows if row.key_hash == token_hash), None
-        )
-        if bootstrap_key is None and matching_legacy is not None:
-            matching_legacy.type = BOOTSTRAP_KEY_TYPE
-            matching_legacy.label = BOOTSTRAP_KEY_LABEL
-            matching_legacy.encrypted_key = encrypted_key
-            bootstrap_key = matching_legacy
-            logger.info(
-                "Migrated the legacy admin-owned registration key to a "
-                "scoped agent-registration bootstrap key"
-            )
-        for stale in legacy_rows:
-            if stale is matching_legacy:
-                continue
-            logger.warning(
-                "Removing a stale admin-owned registration key (id %s, "
-                "label %r): its value no longer matches "
-                "AGENT_REGISTRATION_TOKEN, so it predates a token rotation "
-                "and would otherwise keep registering agents with admin "
-                "authority indefinitely.",
-                stale.id,
-                LEGACY_BOOTSTRAP_KEY_LABEL,
-            )
-            await api_key_store.delete(session, stale.id)
-
         last_seeded_hash = (bootstrap_owner.metadata_ or {}).get(
             BOOTSTRAP_LAST_SEEDED_HASH_META_KEY
         )
-        revoked_hashes: list[str] = list(
-            (bootstrap_owner.metadata_ or {}).get(BOOTSTRAP_REVOKED_HASHES_META_KEY)
-            or []
+        raw_revoked_hashes = (bootstrap_owner.metadata_ or {}).get(
+            BOOTSTRAP_REVOKED_HASHES_META_KEY
         )
+        if raw_revoked_hashes is not None and not isinstance(raw_revoked_hashes, list):
+            raise RuntimeError(
+                f"{BOOTSTRAP_REVOKED_HASHES_META_KEY} on the agent-registration "
+                "bootstrap owner is not a list; refusing to guess which "
+                "hashes are revoked. This needs a direct database fix."
+            )
+        revoked_hashes: list[str] = list(raw_revoked_hashes or [])
         meta_dirty = False
 
         if (
@@ -623,6 +591,64 @@ async def _seed_agent_registration_bootstrap_key(
                 "last restart; its value is now permanently refused, even "
                 "if AGENT_REGISTRATION_TOKEN is later set back to it."
             )
+
+        if bootstrap_key is None:
+            # Every row carrying the legacy label, not just one matching the
+            # current token: an admin who rotated AGENT_REGISTRATION_TOKEN at
+            # or before this upgrade leaves the old row's hash stale, so a
+            # hash-only lookup for the current token would miss it — and a
+            # `type: "registration"` row at that label is otherwise
+            # indistinguishable from a live credential that still
+            # authenticates as the admin. Scoped to "no bootstrap key yet":
+            # once one exists, any startup that still finds a legacy-labeled
+            # row here already retired it on an earlier pass.
+            legacy_rows = [
+                row
+                for row in await api_key_store.get_by_label(
+                    session, LEGACY_BOOTSTRAP_KEY_LABEL
+                )
+                if row.type == "registration"
+            ]
+            matching_legacy = next(
+                (row for row in legacy_rows if row.key_hash == token_hash), None
+            )
+            if matching_legacy is not None:
+                matching_legacy.type = BOOTSTRAP_KEY_TYPE
+                matching_legacy.label = BOOTSTRAP_KEY_LABEL
+                matching_legacy.encrypted_key = encrypted_key
+                bootstrap_key = matching_legacy
+                logger.info(
+                    "Migrated the legacy admin-owned registration key to a "
+                    "scoped agent-registration bootstrap key"
+                )
+            for stale in legacy_rows:
+                if stale is matching_legacy:
+                    continue
+                # Retired, not deleted: every consumer already refuses
+                # RETIRED_KEY_TYPE (it is not in REGISTRATION_KEY_TYPES), so
+                # this stops it authenticating exactly as deletion would —
+                # but the row stays on the API Keys page (filtered on type,
+                # not existence) with a label that says why, so an operator
+                # can tell a stale bootstrap key apart from a personal key
+                # that coincidentally shared the label, and delete it
+                # themselves once they have. Its hash is also permanently
+                # revoked: restoring an old .env or values file must not
+                # bring it back to life via the rotation path below.
+                stale.type = RETIRED_KEY_TYPE
+                stale.label = f"{stale.label} (retired: stale, no longer authenticates)"
+                if stale.key_hash not in revoked_hashes:
+                    revoked_hashes.append(stale.key_hash)
+                    meta_dirty = True
+                logger.warning(
+                    "Retired a stale admin-owned registration key (id %s, "
+                    "label %r): its value no longer matches "
+                    "AGENT_REGISTRATION_TOKEN, so it predates a token "
+                    "rotation and would otherwise keep registering agents "
+                    "with admin authority indefinitely. It is now visible "
+                    "on the API Keys page for a human to review and delete.",
+                    stale.id,
+                    LEGACY_BOOTSTRAP_KEY_LABEL,
+                )
 
         if bootstrap_key is not None:
             if bootstrap_key.key_hash != token_hash:

--- a/core/switch_core/main.py
+++ b/core/switch_core/main.py
@@ -26,6 +26,7 @@ from switch_core.bridges.agent.registration_bootstrap import (
     BOOTSTRAP_KEY_LABEL,
     BOOTSTRAP_KEY_TYPE,
     BOOTSTRAP_LAST_SEEDED_HASH_META_KEY,
+    BOOTSTRAP_REVOKED_HASHES_META_KEY,
     LEGACY_BOOTSTRAP_KEY_LABEL,
     ensure_bootstrap_owner,
 )
@@ -552,40 +553,98 @@ async def _seed_agent_registration_bootstrap_key(
         )
 
         bootstrap_keys = await api_key_store.get_by_type(session, BOOTSTRAP_KEY_TYPE)
+        if len(bootstrap_keys) > 1:
+            raise RuntimeError(
+                f"Found {len(bootstrap_keys)} agent-registration bootstrap "
+                "keys; expected at most one. This needs a direct database fix."
+            )
         bootstrap_key = bootstrap_keys[0] if bootstrap_keys else None
 
-        if bootstrap_key is None:
-            legacy_candidate = await api_key_store.get_by_hash(session, token_hash)
-            if (
-                legacy_candidate is not None
-                and legacy_candidate.type == "registration"
-                and legacy_candidate.label == LEGACY_BOOTSTRAP_KEY_LABEL
-            ):
-                legacy_candidate.type = BOOTSTRAP_KEY_TYPE
-                legacy_candidate.label = BOOTSTRAP_KEY_LABEL
-                bootstrap_key = legacy_candidate
-                logger.info(
-                    "Migrated the legacy admin-owned registration key to a "
-                    "scoped agent-registration bootstrap key"
-                )
+        # Every row carrying the legacy label, not just one matching the
+        # current token: an admin who rotated AGENT_REGISTRATION_TOKEN at or
+        # before this upgrade leaves the old row's hash stale, so a hash-only
+        # lookup for the current token would miss it — and a `type:
+        # "registration"` row at that label is otherwise indistinguishable
+        # from a live credential that still authenticates as the admin.
+        legacy_rows = [
+            row
+            for row in await api_key_store.get_by_label(
+                session, LEGACY_BOOTSTRAP_KEY_LABEL
+            )
+            if row.type == "registration"
+        ]
+        matching_legacy = next(
+            (row for row in legacy_rows if row.key_hash == token_hash), None
+        )
+        if bootstrap_key is None and matching_legacy is not None:
+            matching_legacy.type = BOOTSTRAP_KEY_TYPE
+            matching_legacy.label = BOOTSTRAP_KEY_LABEL
+            matching_legacy.encrypted_key = encrypted_key
+            bootstrap_key = matching_legacy
+            logger.info(
+                "Migrated the legacy admin-owned registration key to a "
+                "scoped agent-registration bootstrap key"
+            )
+        for stale in legacy_rows:
+            if stale is matching_legacy:
+                continue
+            logger.warning(
+                "Removing a stale admin-owned registration key (id %s, "
+                "label %r): its value no longer matches "
+                "AGENT_REGISTRATION_TOKEN, so it predates a token rotation "
+                "and would otherwise keep registering agents with admin "
+                "authority indefinitely.",
+                stale.id,
+                LEGACY_BOOTSTRAP_KEY_LABEL,
+            )
+            await api_key_store.delete(session, stale.id)
 
         last_seeded_hash = (bootstrap_owner.metadata_ or {}).get(
             BOOTSTRAP_LAST_SEEDED_HASH_META_KEY
         )
+        revoked_hashes: list[str] = list(
+            (bootstrap_owner.metadata_ or {}).get(BOOTSTRAP_REVOKED_HASHES_META_KEY)
+            or []
+        )
+        meta_dirty = False
+
+        if (
+            bootstrap_key is None
+            and last_seeded_hash is not None
+            and last_seeded_hash not in revoked_hashes
+        ):
+            # A key was active as of the last seed call and is gone now: it
+            # was deleted (revoked) since then. Remember its value forever,
+            # not just until the next rotation — see the constant's docstring.
+            revoked_hashes.append(last_seeded_hash)
+            meta_dirty = True
+            logger.warning(
+                "Agent-registration bootstrap key was deleted since the "
+                "last restart; its value is now permanently refused, even "
+                "if AGENT_REGISTRATION_TOKEN is later set back to it."
+            )
 
         if bootstrap_key is not None:
             if bootstrap_key.key_hash != token_hash:
-                bootstrap_key.key_hash = token_hash
-                bootstrap_key.encrypted_key = encrypted_key
-                logger.info(
-                    "Rotated the agent-registration bootstrap key from "
-                    "AGENT_REGISTRATION_TOKEN"
-                )
-        elif last_seeded_hash == token_hash:
+                if token_hash in revoked_hashes:
+                    logger.warning(
+                        "AGENT_REGISTRATION_TOKEN matches a previously "
+                        "revoked agent-registration bootstrap key; refusing "
+                        "to rotate onto it. Set a new, never-used value to "
+                        "change the active key."
+                    )
+                else:
+                    bootstrap_key.key_hash = token_hash
+                    bootstrap_key.encrypted_key = encrypted_key
+                    logger.info(
+                        "Rotated the agent-registration bootstrap key from "
+                        "AGENT_REGISTRATION_TOKEN"
+                    )
+        elif token_hash in revoked_hashes:
             logger.warning(
                 "Agent-registration bootstrap key was revoked; not "
-                "reseeding it from AGENT_REGISTRATION_TOKEN. Rotate the "
-                "token to a new value to re-enable deployment-wide bootstrap "
+                "reseeding it from AGENT_REGISTRATION_TOKEN. Set a new, "
+                "never-used value to re-enable deployment-wide bootstrap "
                 "registration, or mint per-user registration keys from the "
                 "gateway's API Keys page instead."
             )
@@ -603,9 +662,14 @@ async def _seed_agent_registration_bootstrap_key(
                 "AGENT_REGISTRATION_TOKEN"
             )
 
-        if bootstrap_key is not None and last_seeded_hash != token_hash:
+        new_last_seeded_hash = bootstrap_key.key_hash if bootstrap_key else None
+        if new_last_seeded_hash != last_seeded_hash:
+            meta_dirty = True
+
+        if meta_dirty:
             meta = dict(bootstrap_owner.metadata_ or {})
-            meta[BOOTSTRAP_LAST_SEEDED_HASH_META_KEY] = token_hash
+            meta[BOOTSTRAP_LAST_SEEDED_HASH_META_KEY] = new_last_seeded_hash
+            meta[BOOTSTRAP_REVOKED_HASHES_META_KEY] = revoked_hashes
             bootstrap_owner.metadata_ = meta
 
         await session.commit()

--- a/core/switch_core/main.py
+++ b/core/switch_core/main.py
@@ -549,7 +549,15 @@ async def _seed_agent_registration_bootstrap_key(
         bootstrap_key = next(
             (k for k in admin_keys if k.type == BOOTSTRAP_KEY_TYPE), None
         )
-        already_seeded = bool((admin.metadata_ or {}).get(_BOOTSTRAP_SEEDED_FLAG))
+        # Whether the flag is *already durably recorded* — read-only, used to
+        # decide whether a missing key means "revoked" vs. "never seeded".
+        # Deliberately not reused as a "did something get provisioned this
+        # call" flag: that conflated the migration branch (which provisions a
+        # key without having recorded the flag yet) with a true revocation,
+        # so the flag write below was skipped on the exact call that migrates
+        # a legacy key, leaving a revocation made shortly after unable to
+        # stick past the next restart.
+        flag_already_set = bool((admin.metadata_ or {}).get(_BOOTSTRAP_SEEDED_FLAG))
 
         if legacy_key is not None and bootstrap_key is None:
             legacy_key.type = BOOTSTRAP_KEY_TYPE
@@ -557,7 +565,6 @@ async def _seed_agent_registration_bootstrap_key(
             legacy_key.key_hash = token_hash
             legacy_key.encrypted_key = encrypted_key
             bootstrap_key = legacy_key
-            already_seeded = True
             logger.info(
                 "Migrated the legacy admin-owned registration key to a "
                 "scoped agent-registration bootstrap key"
@@ -571,27 +578,27 @@ async def _seed_agent_registration_bootstrap_key(
                     "Rotated the agent-registration bootstrap key from "
                     "AGENT_REGISTRATION_TOKEN"
                 )
-        elif already_seeded:
+        elif flag_already_set:
             logger.warning(
                 "Agent-registration bootstrap key was revoked; not "
                 "reseeding it from AGENT_REGISTRATION_TOKEN. Mint per-user "
                 "registration keys from the gateway's API Keys page instead."
             )
         else:
-            key = ApiKey(
+            bootstrap_key = ApiKey(
                 user_id=admin.id,
                 key_hash=token_hash,
                 encrypted_key=encrypted_key,
                 label=BOOTSTRAP_KEY_LABEL,
                 type=BOOTSTRAP_KEY_TYPE,
             )
-            await api_key_store.create(session, key)
+            await api_key_store.create(session, bootstrap_key)
             logger.info(
                 "Seeded the agent-registration bootstrap key from "
                 "AGENT_REGISTRATION_TOKEN"
             )
 
-        if not already_seeded:
+        if bootstrap_key is not None and not flag_already_set:
             meta = dict(admin.metadata_ or {})
             meta[_BOOTSTRAP_SEEDED_FLAG] = True
             admin.metadata_ = meta

--- a/core/switch_core/main.py
+++ b/core/switch_core/main.py
@@ -25,6 +25,7 @@ from switch_core.bridges.agent.protocol.service import ProtocolService
 from switch_core.bridges.agent.registration_bootstrap import (
     BOOTSTRAP_KEY_LABEL,
     BOOTSTRAP_KEY_TYPE,
+    BOOTSTRAP_LAST_SEEDED_HASH_META_KEY,
     LEGACY_BOOTSTRAP_KEY_LABEL,
     ensure_bootstrap_owner,
 )
@@ -217,7 +218,7 @@ async def run() -> None:
     # ── Seed admin user + agent-registration bootstrap key ──────────────────
     await _seed_admin_user(session_factory, user_store, config)
     await _seed_agent_registration_bootstrap_key(
-        session_factory, user_store, api_key_store, config
+        session_factory, user_store, api_key_store, agent_store, config
     )
 
     # ── Event queue + request trackers ───────────────────────────────────────
@@ -493,21 +494,11 @@ async def _seed_admin_user(
         logger.info("Seeded admin user: %s", config.gateway_admin_email)
 
 
-# Marker recorded on the admin user's metadata once the agent-registration
-# bootstrap key has been seeded. Independent of the ApiKey row itself so that
-# an operator who deletes the key (revoking it from the gateway's API Keys
-# page) gets a permanent revocation: the next restart sees the flag, finds no
-# bootstrap-type key, and does not silently recreate one from the still-set
-# AGENT_REGISTRATION_TOKEN. Rotating the env var, by contrast, always takes
-# effect immediately: an existing bootstrap key's hash is kept in sync with
-# whatever the config currently holds.
-_BOOTSTRAP_SEEDED_FLAG = "agent_bootstrap_key_seeded"
-
-
 async def _seed_agent_registration_bootstrap_key(
     session_factory: object,
     user_store: UserStore,
     api_key_store: ApiKeyStore,
+    agent_store: AgentStore,
     config: SwitchConfig,
 ) -> None:
     """Seed the deployment-wide agent-registration bootstrap key.
@@ -520,6 +511,14 @@ async def _seed_agent_registration_bootstrap_key(
     row is filed under — the row lives on the admin so it is listed and
     revocable from the admin's own API Keys page, but holding the token
     itself confers no admin authority.
+
+    Existence and rotation are resolved by the key's own hash and type
+    globally, never by which user the configured admin email currently
+    resolves to: an admin row is looked up here only to own a freshly
+    created key, and can be swapped out (``GATEWAY_ADMIN_EMAIL`` changed to a
+    different account) without this re-inserting a duplicate of a key that
+    already exists under the old one, which would collide on the unique
+    ``key_hash`` and fail the whole boot.
     """
     async with session_factory() as session:  # type: ignore[operator]
         admin = await user_store.get_by_email(session, config.gateway_admin_email)
@@ -528,7 +527,22 @@ async def _seed_agent_registration_bootstrap_key(
                 "Cannot seed agent-registration bootstrap key: admin user "
                 f"{config.gateway_admin_email} not found"
             )
-        await ensure_bootstrap_owner(session, user_store)
+        bootstrap_owner = await ensure_bootstrap_owner(session, user_store)
+
+        admin_owned_agents = [
+            a for a in await agent_store.get_all(session) if a.owner_id == admin.id
+        ]
+        if admin_owned_agents:
+            logger.warning(
+                "%d agent(s) are owned by the admin user (%s) and carry "
+                "admin-equivalent authority over every room and resource in "
+                "this deployment, not just their own: %s. If any were "
+                "registered through AGENT_REGISTRATION_TOKEN, reassign or "
+                "re-register them under a non-admin owner.",
+                len(admin_owned_agents),
+                config.gateway_admin_email,
+                ", ".join(a.name for a in admin_owned_agents),
+            )
 
         token_hash = hashlib.sha256(
             config.agent_registration_token.encode()
@@ -537,38 +551,27 @@ async def _seed_agent_registration_bootstrap_key(
             config.agent_registration_token, config.jwt_secret_key
         )
 
-        admin_keys = await api_key_store.get_by_user(session, admin.id)
-        legacy_key = next(
-            (
-                k
-                for k in admin_keys
-                if k.type == "registration" and k.label == LEGACY_BOOTSTRAP_KEY_LABEL
-            ),
-            None,
-        )
-        bootstrap_key = next(
-            (k for k in admin_keys if k.type == BOOTSTRAP_KEY_TYPE), None
-        )
-        # Whether the flag is *already durably recorded* — read-only, used to
-        # decide whether a missing key means "revoked" vs. "never seeded".
-        # Deliberately not reused as a "did something get provisioned this
-        # call" flag: that conflated the migration branch (which provisions a
-        # key without having recorded the flag yet) with a true revocation,
-        # so the flag write below was skipped on the exact call that migrates
-        # a legacy key, leaving a revocation made shortly after unable to
-        # stick past the next restart.
-        flag_already_set = bool((admin.metadata_ or {}).get(_BOOTSTRAP_SEEDED_FLAG))
+        bootstrap_keys = await api_key_store.get_by_type(session, BOOTSTRAP_KEY_TYPE)
+        bootstrap_key = bootstrap_keys[0] if bootstrap_keys else None
 
-        if legacy_key is not None and bootstrap_key is None:
-            legacy_key.type = BOOTSTRAP_KEY_TYPE
-            legacy_key.label = BOOTSTRAP_KEY_LABEL
-            legacy_key.key_hash = token_hash
-            legacy_key.encrypted_key = encrypted_key
-            bootstrap_key = legacy_key
-            logger.info(
-                "Migrated the legacy admin-owned registration key to a "
-                "scoped agent-registration bootstrap key"
-            )
+        if bootstrap_key is None:
+            legacy_candidate = await api_key_store.get_by_hash(session, token_hash)
+            if (
+                legacy_candidate is not None
+                and legacy_candidate.type == "registration"
+                and legacy_candidate.label == LEGACY_BOOTSTRAP_KEY_LABEL
+            ):
+                legacy_candidate.type = BOOTSTRAP_KEY_TYPE
+                legacy_candidate.label = BOOTSTRAP_KEY_LABEL
+                bootstrap_key = legacy_candidate
+                logger.info(
+                    "Migrated the legacy admin-owned registration key to a "
+                    "scoped agent-registration bootstrap key"
+                )
+
+        last_seeded_hash = (bootstrap_owner.metadata_ or {}).get(
+            BOOTSTRAP_LAST_SEEDED_HASH_META_KEY
+        )
 
         if bootstrap_key is not None:
             if bootstrap_key.key_hash != token_hash:
@@ -578,11 +581,13 @@ async def _seed_agent_registration_bootstrap_key(
                     "Rotated the agent-registration bootstrap key from "
                     "AGENT_REGISTRATION_TOKEN"
                 )
-        elif flag_already_set:
+        elif last_seeded_hash == token_hash:
             logger.warning(
                 "Agent-registration bootstrap key was revoked; not "
-                "reseeding it from AGENT_REGISTRATION_TOKEN. Mint per-user "
-                "registration keys from the gateway's API Keys page instead."
+                "reseeding it from AGENT_REGISTRATION_TOKEN. Rotate the "
+                "token to a new value to re-enable deployment-wide bootstrap "
+                "registration, or mint per-user registration keys from the "
+                "gateway's API Keys page instead."
             )
         else:
             bootstrap_key = ApiKey(
@@ -598,10 +603,10 @@ async def _seed_agent_registration_bootstrap_key(
                 "AGENT_REGISTRATION_TOKEN"
             )
 
-        if bootstrap_key is not None and not flag_already_set:
-            meta = dict(admin.metadata_ or {})
-            meta[_BOOTSTRAP_SEEDED_FLAG] = True
-            admin.metadata_ = meta
+        if bootstrap_key is not None and last_seeded_hash != token_hash:
+            meta = dict(bootstrap_owner.metadata_ or {})
+            meta[BOOTSTRAP_LAST_SEEDED_HASH_META_KEY] = token_hash
+            bootstrap_owner.metadata_ = meta
 
         await session.commit()
 

--- a/core/switch_core/main.py
+++ b/core/switch_core/main.py
@@ -22,6 +22,12 @@ from switch_core.bridges.agent.protocol.connections import (
 )
 from switch_core.bridges.agent.protocol.event_buffer import EventBuffer
 from switch_core.bridges.agent.protocol.service import ProtocolService
+from switch_core.bridges.agent.registration_bootstrap import (
+    BOOTSTRAP_KEY_LABEL,
+    BOOTSTRAP_KEY_TYPE,
+    LEGACY_BOOTSTRAP_KEY_LABEL,
+    ensure_bootstrap_owner,
+)
 from switch_core.bridges.agent.server_connectors.lifecycle import (
     ServerSideConnectorLifecycleService,
 )
@@ -208,9 +214,9 @@ async def run() -> None:
     message_store = MessageStore()
     media_store = MediaStore()
 
-    # ── Seed admin user + registration key ──────────────────────────────────
+    # ── Seed admin user + agent-registration bootstrap key ──────────────────
     await _seed_admin_user(session_factory, user_store, config)
-    await _seed_admin_registration_key(
+    await _seed_agent_registration_bootstrap_key(
         session_factory, user_store, api_key_store, config
     )
 
@@ -487,41 +493,110 @@ async def _seed_admin_user(
         logger.info("Seeded admin user: %s", config.gateway_admin_email)
 
 
-async def _seed_admin_registration_key(
+# Marker recorded on the admin user's metadata once the agent-registration
+# bootstrap key has been seeded. Independent of the ApiKey row itself so that
+# an operator who deletes the key (revoking it from the gateway's API Keys
+# page) gets a permanent revocation: the next restart sees the flag, finds no
+# bootstrap-type key, and does not silently recreate one from the still-set
+# AGENT_REGISTRATION_TOKEN. Rotating the env var, by contrast, always takes
+# effect immediately: an existing bootstrap key's hash is kept in sync with
+# whatever the config currently holds.
+_BOOTSTRAP_SEEDED_FLAG = "agent_bootstrap_key_seeded"
+
+
+async def _seed_agent_registration_bootstrap_key(
     session_factory: object,
     user_store: UserStore,
     api_key_store: ApiKeyStore,
     config: SwitchConfig,
 ) -> None:
+    """Seed the deployment-wide agent-registration bootstrap key.
+
+    Unlike a personal registration key (minted by, and owned by, a single
+    gateway user), this key is handed out to bring up the first agents
+    against a fresh deployment before anyone has logged in. Agents it
+    registers are attributed to a dedicated, non-admin account (see
+    ``registration_bootstrap.py``), not to the admin user this key's ApiKey
+    row is filed under — the row lives on the admin so it is listed and
+    revocable from the admin's own API Keys page, but holding the token
+    itself confers no admin authority.
+    """
     async with session_factory() as session:  # type: ignore[operator]
         admin = await user_store.get_by_email(session, config.gateway_admin_email)
         if admin is None:
-            logger.error(
-                "Cannot seed registration key: admin user %s not found",
-                config.gateway_admin_email,
+            raise RuntimeError(
+                "Cannot seed agent-registration bootstrap key: admin user "
+                f"{config.gateway_admin_email} not found"
             )
-            return
+        await ensure_bootstrap_owner(session, user_store)
 
         token_hash = hashlib.sha256(
             config.agent_registration_token.encode()
         ).hexdigest()
-        existing = await api_key_store.get_by_hash(session, token_hash)
-        if existing is not None:
-            logger.info("Admin registration key already seeded")
-            return
-
-        key = ApiKey(
-            user_id=admin.id,
-            key_hash=token_hash,
-            encrypted_key=encrypt_token(
-                config.agent_registration_token, config.jwt_secret_key
-            ),
-            label="Default (from AGENT_REGISTRATION_TOKEN)",
-            type="registration",
+        encrypted_key = encrypt_token(
+            config.agent_registration_token, config.jwt_secret_key
         )
-        await api_key_store.create(session, key)
+
+        admin_keys = await api_key_store.get_by_user(session, admin.id)
+        legacy_key = next(
+            (
+                k
+                for k in admin_keys
+                if k.type == "registration" and k.label == LEGACY_BOOTSTRAP_KEY_LABEL
+            ),
+            None,
+        )
+        bootstrap_key = next(
+            (k for k in admin_keys if k.type == BOOTSTRAP_KEY_TYPE), None
+        )
+        already_seeded = bool((admin.metadata_ or {}).get(_BOOTSTRAP_SEEDED_FLAG))
+
+        if legacy_key is not None and bootstrap_key is None:
+            legacy_key.type = BOOTSTRAP_KEY_TYPE
+            legacy_key.label = BOOTSTRAP_KEY_LABEL
+            legacy_key.key_hash = token_hash
+            legacy_key.encrypted_key = encrypted_key
+            bootstrap_key = legacy_key
+            already_seeded = True
+            logger.info(
+                "Migrated the legacy admin-owned registration key to a "
+                "scoped agent-registration bootstrap key"
+            )
+
+        if bootstrap_key is not None:
+            if bootstrap_key.key_hash != token_hash:
+                bootstrap_key.key_hash = token_hash
+                bootstrap_key.encrypted_key = encrypted_key
+                logger.info(
+                    "Rotated the agent-registration bootstrap key from "
+                    "AGENT_REGISTRATION_TOKEN"
+                )
+        elif already_seeded:
+            logger.warning(
+                "Agent-registration bootstrap key was revoked; not "
+                "reseeding it from AGENT_REGISTRATION_TOKEN. Mint per-user "
+                "registration keys from the gateway's API Keys page instead."
+            )
+        else:
+            key = ApiKey(
+                user_id=admin.id,
+                key_hash=token_hash,
+                encrypted_key=encrypted_key,
+                label=BOOTSTRAP_KEY_LABEL,
+                type=BOOTSTRAP_KEY_TYPE,
+            )
+            await api_key_store.create(session, key)
+            logger.info(
+                "Seeded the agent-registration bootstrap key from "
+                "AGENT_REGISTRATION_TOKEN"
+            )
+
+        if not already_seeded:
+            meta = dict(admin.metadata_ or {})
+            meta[_BOOTSTRAP_SEEDED_FLAG] = True
+            admin.metadata_ = meta
+
         await session.commit()
-        logger.info("Seeded admin registration key from AGENT_REGISTRATION_TOKEN")
 
 
 async def _shutdown(

--- a/core/tests/integration/conftest.py
+++ b/core/tests/integration/conftest.py
@@ -398,7 +398,11 @@ async def harness(session_env: SessionEnv) -> AsyncIterator[Harness]:
     # boot, so a test can register through REGISTRATION_TOKEN exactly as a
     # standalone agent does, without duplicating that seeding logic here.
     await _seed_agent_registration_bootstrap_key(
-        session_factory, session_env.user_store, session_env.api_key_store, config
+        session_factory,
+        session_env.user_store,
+        session_env.api_key_store,
+        session_env.agent_store,
+        config,
     )
 
     # Per-test in-memory wiring: a fresh EventBuffer / client registry so queued

--- a/core/tests/integration/conftest.py
+++ b/core/tests/integration/conftest.py
@@ -75,6 +75,7 @@ from switch_core.db.stores.room_role_store import RoomRoleStore
 from switch_core.db.stores.room_store import RoomStore
 from switch_core.db.stores.task_store import TaskStore
 from switch_core.db.stores.user_store import UserStore
+from switch_core.main import _seed_agent_registration_bootstrap_key
 from switch_core.messages.notify import MessageListener
 from switch_core.provisioning import Provisioning
 from switch_core.provisioning.postgres import PostgresProvisioning
@@ -248,6 +249,24 @@ class Harness:
         self._registered.append(result.agent_id)
         return result
 
+    async def register_agent_via_registration_token(
+        self, name: str, token: str
+    ) -> RegistrationResult:
+        """Register the way a standalone agent does: with a bearer token
+        presented to `POST /agents`, resolved here directly against the
+        protocol service rather than over real HTTP."""
+        result = await self.protocol.register_agent_with_token(
+            registration_token=token,
+            name=name,
+            description=f"integration test agent {name}",
+            connector_type="test",
+            integration_profile=_PROFILE,
+            overwrite=True,
+            owner_only=False,
+        )
+        self._registered.append(result.agent_id)
+        return result
+
     async def start_clients(self, timeout: float = 20.0) -> None:
         """Start every registered agent's client and await readiness.
 
@@ -374,6 +393,13 @@ async def harness(session_env: SessionEnv) -> AsyncIterator[Harness]:
         await session_env.user_store.create(session, owner)
         await session.commit()
     owner_id = owner.id
+
+    # Seeds the same deployment-wide bootstrap key `main.py` would on a real
+    # boot, so a test can register through REGISTRATION_TOKEN exactly as a
+    # standalone agent does, without duplicating that seeding logic here.
+    await _seed_agent_registration_bootstrap_key(
+        session_factory, session_env.user_store, session_env.api_key_store, config
+    )
 
     # Per-test in-memory wiring: a fresh EventBuffer / client registry so queued
     # events and client registrations never leak across tests.

--- a/core/tests/integration/test_registration_bootstrap_scope.py
+++ b/core/tests/integration/test_registration_bootstrap_scope.py
@@ -1,0 +1,65 @@
+"""The deployment-wide AGENT_REGISTRATION_TOKEN must not grant admin authority.
+
+Before this fix, any holder of that one shared secret registered agents owned
+by the seeded admin user. Since room/resource authorization treats "owned by
+an admin" as "acts with admin authority" (`ProtocolService._resolve_acting_identity`),
+that made the token a privilege-escalation vector: a colleague given the
+deployment secret to bring up their own agent got an agent that could bypass
+`read_visibility`/`write_visibility` on every room and resource in the
+deployment, not just their own.
+
+This test registers an agent the same way a standalone agent does — presenting
+REGISTRATION_TOKEN to `register_agent_with_token` — and proves the resulting
+agent is owned by a dedicated, non-admin account instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.conftest import REGISTRATION_TOKEN, Harness, SessionEnv
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
+
+
+async def test_bootstrap_token_registration_does_not_own_as_admin(
+    harness: Harness, session_env: SessionEnv
+) -> None:
+    result = await harness.register_agent_via_registration_token(
+        "colleague-agent", REGISTRATION_TOKEN
+    )
+
+    async with session_env.session_factory() as session:  # type: ignore[operator]
+        agent = await harness.protocol.agent_store.get(session, result.agent_id)
+        assert agent is not None
+        assert agent.owner_id is not None
+        assert agent.owner_id != harness.owner_id, (
+            "agent registered through the deployment-wide bootstrap token "
+            "must not be owned by the admin user"
+        )
+
+        owner = await session_env.user_store.get(session, agent.owner_id)
+        assert owner is not None
+        assert owner.role != "admin", (
+            "agent registered through the deployment-wide bootstrap token "
+            "must not inherit admin authority"
+        )
+
+
+async def test_bootstrap_token_registration_is_repeatable_and_stable(
+    harness: Harness, session_env: SessionEnv
+) -> None:
+    """Two different colleagues sharing the same bootstrap token land on the
+    same non-admin owner, rather than each minting a new one."""
+    first = await harness.register_agent_via_registration_token(
+        "colleague-one", REGISTRATION_TOKEN
+    )
+    second = await harness.register_agent_via_registration_token(
+        "colleague-two", REGISTRATION_TOKEN
+    )
+
+    async with session_env.session_factory() as session:  # type: ignore[operator]
+        agent_one = await harness.protocol.agent_store.get(session, first.agent_id)
+        agent_two = await harness.protocol.agent_store.get(session, second.agent_id)
+        assert agent_one is not None and agent_two is not None
+        assert agent_one.owner_id == agent_two.owner_id

--- a/core/tests/integration/test_registration_bootstrap_scope.py
+++ b/core/tests/integration/test_registration_bootstrap_scope.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import pytest
 
+from switch_core.room_service import RoomCreateConfig
 from tests.integration.conftest import REGISTRATION_TOKEN, Harness, SessionEnv
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio(loop_scope="session")]
@@ -63,3 +64,40 @@ async def test_bootstrap_token_registration_is_repeatable_and_stable(
         agent_two = await harness.protocol.agent_store.get(session, second.agent_id)
         assert agent_one is not None and agent_two is not None
         assert agent_one.owner_id == agent_two.owner_id
+
+
+async def test_bootstrap_owned_agent_cannot_write_a_private_room_it_does_not_own(
+    harness: Harness, session_env: SessionEnv
+) -> None:
+    """Drives the actual authorization decision this fix closes, not just
+    the ownership attribute: before this fix, a bootstrap-registered agent's
+    owner was the admin, and `_resolve_acting_identity` would have resolved
+    it as `owner_is_admin=True` — an admin-equivalent bypass on every
+    private room in the deployment, including this one."""
+    bootstrap_result = await harness.register_agent_via_registration_token(
+        "colleague-agent", REGISTRATION_TOKEN
+    )
+    admin_owned = await harness.register_agent("admin-owned-agent")
+
+    private_room = await harness.room_service.create_room(
+        RoomCreateConfig(
+            name="admins-private-room",
+            description="owned by the admin, not the bootstrap account",
+            agent_ids=[admin_owned.agent_id],
+            owner_id=harness.owner_id,
+            created_by=harness.owner_id,
+            read_visibility="private",
+            write_visibility="private",
+        )
+    )
+
+    async with session_env.session_factory() as session:  # type: ignore[operator]
+        # Control: the admin's own agent is the room's owner and must pass.
+        await harness.protocol._require_room_action(
+            session, admin_owned.agent_id, private_room.room.id, "write"
+        )
+
+        with pytest.raises(PermissionError):
+            await harness.protocol._require_room_action(
+                session, bootstrap_result.agent_id, private_room.room.id, "write"
+            )

--- a/core/tests/switch_core/bridges/agent/protocol/registration_harness.py
+++ b/core/tests/switch_core/bridges/agent/protocol/registration_harness.py
@@ -20,6 +20,7 @@ from switch_core.bridges.agent.protocol.types import (
 from switch_core.db.models import Client, User
 from switch_core.db.stores.agent_store import AgentStore
 from switch_core.db.stores.api_key_store import ApiKeyStore
+from switch_core.db.stores.user_store import UserStore
 
 PROFILE = IntegrationProfile(
     connection_model="session_passive",
@@ -69,6 +70,7 @@ def make_service(
     svc.session_factory = session_factory  # type: ignore[attr-defined]
     svc.agent_store = AgentStore()  # type: ignore[attr-defined]
     svc.api_key_store = ApiKeyStore()  # type: ignore[attr-defined]
+    svc.user_store = UserStore()  # type: ignore[attr-defined]
     svc.api_key_cache = ApiKeyCache(ttl_seconds=5.0, max_entries=8)  # type: ignore[attr-defined]
     svc.client_lifecycle = FakeClientLifecycle(session_factory)  # type: ignore[attr-defined]
     svc.collab_lifecycle = NoBridges()  # type: ignore[attr-defined]

--- a/core/tests/switch_core/bridges/agent/protocol/test_register_with_token_bootstrap.py
+++ b/core/tests/switch_core/bridges/agent/protocol/test_register_with_token_bootstrap.py
@@ -1,0 +1,135 @@
+"""`register_agent_with_token` must not let a shared secret act as admin.
+
+Before this fix, the deployment-wide AGENT_REGISTRATION_TOKEN was seeded as a
+`"registration"`-type key owned by the admin user, so every agent registered
+through it inherited the admin's authority (`_resolve_acting_identity` reads
+the owner's `role` straight off the `User` row). A `"bootstrap"`-type key now
+resolves to a dedicated, non-admin owner instead — this proves it, and that
+a non-registration key (an agent's own) can no longer be replayed as one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.bridges.agent.registration_bootstrap import (
+    BOOTSTRAP_KEY_TYPE,
+    ensure_bootstrap_owner,
+)
+from switch_core.db.models import ApiKey, User
+from switch_core.db.stores.user_store import UserStore
+from tests.switch_core.bridges.agent.protocol.registration_harness import (
+    PROFILE,
+    make_service,
+)
+
+
+async def _make_admin(session_factory: async_sessionmaker[AsyncSession]) -> str:
+    async with session_factory() as session:
+        admin = User(name="Admin", email="admin@test", role="admin")
+        session.add(admin)
+        await session.commit()
+        return admin.id
+
+
+async def _make_key(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    user_id: str,
+    token: str,
+    key_type: str,
+) -> None:
+    async with session_factory() as session:
+        session.add(
+            ApiKey(
+                user_id=user_id,
+                key_hash=hashlib.sha256(token.encode()).hexdigest(),
+                encrypted_key="irrelevant",
+                label="test key",
+                type=key_type,
+            )
+        )
+        await session.commit()
+
+
+class TestBootstrapTokenRegistration:
+    async def test_bootstrap_token_owns_the_agent_as_the_bootstrap_account(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        svc = make_service(session_factory)
+        admin_id = await _make_admin(session_factory)
+        async with session_factory() as session:
+            bootstrap_owner = await ensure_bootstrap_owner(session, UserStore())
+            await session.commit()
+        await _make_key(
+            session_factory,
+            user_id=admin_id,
+            token="shared-secret",
+            key_type=BOOTSTRAP_KEY_TYPE,
+        )
+
+        result = await svc.register_agent_with_token(
+            registration_token="shared-secret",
+            name="colleague-agent",
+            description="d",
+            connector_type="test",
+            integration_profile=PROFILE,
+            owner_only=False,
+        )
+
+        async with session_factory() as session:
+            agent = await svc.agent_store.get(session, result.agent_id)
+        assert agent is not None
+        assert agent.owner_id == bootstrap_owner.id
+        assert agent.owner_id != admin_id
+
+    async def test_a_plain_registration_key_still_owns_as_itself(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        svc = make_service(session_factory)
+        async with session_factory() as session:
+            owner = User(name="owner", email="owner2@test", role="user")
+            session.add(owner)
+            await session.commit()
+            owner_id = owner.id
+        await _make_key(
+            session_factory, user_id=owner_id, token="personal", key_type="registration"
+        )
+
+        result = await svc.register_agent_with_token(
+            registration_token="personal",
+            name="personal-agent",
+            description="d",
+            connector_type="test",
+            integration_profile=PROFILE,
+            owner_only=False,
+        )
+
+        async with session_factory() as session:
+            agent = await svc.agent_store.get(session, result.agent_id)
+        assert agent is not None
+        assert agent.owner_id == owner_id
+
+    async def test_an_agent_key_cannot_be_replayed_as_a_registration_token(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        svc = make_service(session_factory)
+        admin_id = await _make_admin(session_factory)
+        await _make_key(
+            session_factory,
+            user_id=admin_id,
+            token="leaked-agent-key",
+            key_type="agent",
+        )
+
+        with pytest.raises(PermissionError):
+            await svc.register_agent_with_token(
+                registration_token="leaked-agent-key",
+                name="should-not-exist",
+                description="d",
+                connector_type="test",
+                integration_profile=PROFILE,
+            )

--- a/core/tests/switch_core/bridges/agent/test_bearer_auth_registration_pass_through.py
+++ b/core/tests/switch_core/bridges/agent/test_bearer_auth_registration_pass_through.py
@@ -1,0 +1,112 @@
+"""BearerAuthMiddleware's registration-token pass-through gate.
+
+Both `"registration"` (personal, self-serve) and `"bootstrap"` (the
+deployment-wide AGENT_REGISTRATION_TOKEN) keys must reach the registration
+handlers on ordinary paths, and neither may reach `/mcp` — a registration
+token opens no MCP session, bootstrap included.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.bridges.agent.api_key_cache import ApiKeyCache
+from switch_core.bridges.agent.auth import BearerAuthMiddleware
+from switch_core.db.models import ApiKey, User
+from switch_core.db.stores.agent_store import AgentStore
+from switch_core.db.stores.api_key_store import ApiKeyStore
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+async def _seed_key(
+    session_factory: async_sessionmaker[AsyncSession], token: str, key_type: str
+) -> None:
+    async with session_factory() as session:
+        user = User(name="u", email="u@test", role="user", password_hash="x")
+        session.add(user)
+        await session.flush()
+        session.add(
+            ApiKey(
+                user_id=user.id,
+                key_hash=_hash(token),
+                encrypted_key="enc",
+                label="k",
+                type=key_type,
+            )
+        )
+        await session.commit()
+
+
+def _middleware(session_factory: Any) -> tuple[BearerAuthMiddleware, dict]:
+    called: dict[str, Any] = {}
+
+    async def _app(scope: Any, receive: Any, send: Any) -> None:
+        called["scope"] = scope
+
+    mw = BearerAuthMiddleware(
+        _app,
+        agent_store=AgentStore(),
+        api_key_store=ApiKeyStore(),
+        api_key_cache=ApiKeyCache(ttl_seconds=5, max_entries=8),
+        session_factory=session_factory,
+    )
+    return mw, called
+
+
+async def _dispatch(mw: BearerAuthMiddleware, path: str, token: str) -> list[dict]:
+    async def receive() -> dict:
+        return {"type": "http.request"}
+
+    sent: list[dict] = []
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "path": path,
+        "headers": [(b"authorization", f"Bearer {token}".encode())],
+    }
+    await mw(scope, receive, send)
+    return sent
+
+
+class TestRegistrationPassThrough:
+    async def test_a_bootstrap_key_reaches_a_registration_path(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_key(session_factory, "tok", "bootstrap")
+        mw, called = _middleware(session_factory)
+
+        sent = await _dispatch(mw, "/agents", "tok")
+
+        assert sent == []
+        assert called["scope"]["api_key"].type == "bootstrap"
+
+    async def test_a_bootstrap_key_is_rejected_on_mcp(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_key(session_factory, "tok", "bootstrap")
+        mw, called = _middleware(session_factory)
+
+        sent = await _dispatch(mw, "/mcp", "tok")
+
+        assert "scope" not in called
+        assert sent[0]["status"] == 401
+
+    async def test_a_registration_key_reaches_a_registration_path(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_key(session_factory, "tok", "registration")
+        mw, called = _middleware(session_factory)
+
+        sent = await _dispatch(mw, "/agents", "tok")
+
+        assert sent == []
+        assert called["scope"]["api_key"].type == "registration"

--- a/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
+++ b/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.bridges.agent.registration_bootstrap import (
+    BOOTSTRAP_KEY_TYPE,
+    BOOTSTRAP_OWNER_EMAIL,
+    ensure_bootstrap_owner,
+    resolve_registration_owner_id,
+)
+from switch_core.db.models import ApiKey, User
+from switch_core.db.stores.user_store import UserStore
+
+
+async def _make_user(
+    session_factory: async_sessionmaker[AsyncSession], *, role: str
+) -> str:
+    async with session_factory() as session:
+        user = User(name=role, email=f"{role}@test", role=role, password_hash="x")
+        session.add(user)
+        await session.commit()
+        return user.id
+
+
+class TestEnsureBootstrapOwner:
+    async def test_creates_a_non_admin_user_once(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store = UserStore()
+        async with session_factory() as session:
+            owner = await ensure_bootstrap_owner(session, user_store)
+            await session.commit()
+            assert owner.email == BOOTSTRAP_OWNER_EMAIL
+            assert owner.role != "admin"
+
+        async with session_factory() as session:
+            again = await ensure_bootstrap_owner(session, user_store)
+            await session.commit()
+            assert again.id == owner.id
+
+
+class TestResolveRegistrationOwnerId:
+    async def test_registration_key_resolves_to_its_own_user(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store = UserStore()
+        user_id = await _make_user(session_factory, role="user")
+        key = ApiKey(
+            user_id=user_id,
+            key_hash="h",
+            encrypted_key="e",
+            label="mine",
+            type="registration",
+        )
+        async with session_factory() as session:
+            owner_id = await resolve_registration_owner_id(session, user_store, key)
+        assert owner_id == user_id
+
+    async def test_bootstrap_key_resolves_to_the_bootstrap_owner_not_its_user_id(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store = UserStore()
+        admin_id = await _make_user(session_factory, role="admin")
+        async with session_factory() as session:
+            bootstrap_owner = await ensure_bootstrap_owner(session, user_store)
+            await session.commit()
+
+        key = ApiKey(
+            user_id=admin_id,
+            key_hash="h",
+            encrypted_key="e",
+            label="deployment bootstrap",
+            type=BOOTSTRAP_KEY_TYPE,
+        )
+        async with session_factory() as session:
+            owner_id = await resolve_registration_owner_id(session, user_store, key)
+
+        assert owner_id == bootstrap_owner.id
+        assert owner_id != admin_id
+
+    async def test_bootstrap_key_without_a_seeded_owner_fails_loud(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store = UserStore()
+        admin_id = await _make_user(session_factory, role="admin")
+        key = ApiKey(
+            user_id=admin_id,
+            key_hash="h",
+            encrypted_key="e",
+            label="deployment bootstrap",
+            type=BOOTSTRAP_KEY_TYPE,
+        )
+        async with session_factory() as session:
+            with pytest.raises(RuntimeError):
+                await resolve_registration_owner_id(session, user_store, key)

--- a/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
+++ b/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from switch_core.bridges.agent.registration_bootstrap import (
     BOOTSTRAP_KEY_TYPE,
     BOOTSTRAP_OWNER_EMAIL,
+    BOOTSTRAP_OWNER_MARKER_META_KEY,
     ensure_bootstrap_owner,
     resolve_registration_owner_id,
 )
@@ -24,7 +25,7 @@ async def _make_user(
 
 
 class TestEnsureBootstrapOwner:
-    async def test_creates_a_non_admin_user_once(
+    async def test_creates_a_marked_non_admin_user_once(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
         user_store = UserStore()
@@ -33,19 +34,37 @@ class TestEnsureBootstrapOwner:
             await session.commit()
             assert owner.email == BOOTSTRAP_OWNER_EMAIL
             assert owner.role != "admin"
+            assert (owner.metadata_ or {}).get(BOOTSTRAP_OWNER_MARKER_META_KEY) is True
 
         async with session_factory() as session:
             again = await ensure_bootstrap_owner(session, user_store)
             await session.commit()
             assert again.id == owner.id
 
+    async def test_refuses_a_role_user_account_squatting_the_address(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The realistic squatter: an identity claimed this address — via
+        OIDC JIT provisioning, or any other path — before bootstrap seeding
+        ever ran. JIT provisioning always creates `role="user"`, so a role
+        check alone would silently adopt it; only the creation marker this
+        module stamps distinguishes a genuine bootstrap owner from one."""
+        user_store = UserStore()
+        async with session_factory() as session:
+            session.add(User(name="squatter", email=BOOTSTRAP_OWNER_EMAIL, role="user"))
+            await session.commit()
+
+        async with session_factory() as session:
+            with pytest.raises(RuntimeError, match="not created by"):
+                await ensure_bootstrap_owner(session, user_store)
+
     async def test_refuses_an_existing_account_with_the_admin_role(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        """Nothing reserves this address: a gateway admin can `POST /users`
-        with it and an admin role, or an OIDC provider can hand it to any
-        identity that asserts it. Adopting that account would silently
-        restore the exact escalation this module exists to close."""
+        """A gateway admin can `POST /users` with this exact email and an
+        admin role. Adopting that account would silently restore the exact
+        escalation this module exists to close — caught here as a second,
+        independent check even though the missing marker already refuses it."""
         user_store = UserStore()
         async with session_factory() as session:
             session.add(
@@ -141,4 +160,27 @@ class TestResolveRegistrationOwnerId:
         )
         async with session_factory() as session:
             with pytest.raises(RuntimeError, match="admin"):
+                await resolve_registration_owner_id(session, user_store, key)
+
+    async def test_role_user_squatter_at_the_bootstrap_address_fails_loud(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Registration-time counterpart of the squatter case above: even
+        without ever having run `ensure_bootstrap_owner`, a bootstrap-type
+        key must not resolve to an unmarked account at that address."""
+        user_store = UserStore()
+        admin_id = await _make_user(session_factory, role="admin")
+        async with session_factory() as session:
+            session.add(User(name="squatter", email=BOOTSTRAP_OWNER_EMAIL, role="user"))
+            await session.commit()
+
+        key = ApiKey(
+            user_id=admin_id,
+            key_hash="h",
+            encrypted_key="e",
+            label="deployment bootstrap",
+            type=BOOTSTRAP_KEY_TYPE,
+        )
+        async with session_factory() as session:
+            with pytest.raises(RuntimeError, match="not created by"):
                 await resolve_registration_owner_id(session, user_store, key)

--- a/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
+++ b/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
@@ -39,6 +39,24 @@ class TestEnsureBootstrapOwner:
             await session.commit()
             assert again.id == owner.id
 
+    async def test_refuses_an_existing_account_with_the_admin_role(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Nothing reserves this address: a gateway admin can `POST /users`
+        with it and an admin role, or an OIDC provider can hand it to any
+        identity that asserts it. Adopting that account would silently
+        restore the exact escalation this module exists to close."""
+        user_store = UserStore()
+        async with session_factory() as session:
+            session.add(
+                User(name="squatter", email=BOOTSTRAP_OWNER_EMAIL, role="admin")
+            )
+            await session.commit()
+
+        async with session_factory() as session:
+            with pytest.raises(RuntimeError, match="admin"):
+                await ensure_bootstrap_owner(session, user_store)
+
 
 class TestResolveRegistrationOwnerId:
     async def test_registration_key_resolves_to_its_own_user(
@@ -93,4 +111,34 @@ class TestResolveRegistrationOwnerId:
         )
         async with session_factory() as session:
             with pytest.raises(RuntimeError):
+                await resolve_registration_owner_id(session, user_store, key)
+
+    async def test_bootstrap_owner_promoted_to_admin_after_startup_fails_loud(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """`ensure_bootstrap_owner` only runs once at startup, so a later
+        promotion of the bootstrap owner to admin (e.g. by a gateway admin
+        editing the account, or an OIDC identity being linked to it after
+        #397) must still be caught here, at registration time."""
+        user_store = UserStore()
+        admin_id = await _make_user(session_factory, role="admin")
+        async with session_factory() as session:
+            bootstrap_owner = await ensure_bootstrap_owner(session, user_store)
+            await session.commit()
+
+        async with session_factory() as session:
+            promoted = await session.get(User, bootstrap_owner.id)
+            assert promoted is not None
+            promoted.role = "admin"
+            await session.commit()
+
+        key = ApiKey(
+            user_id=admin_id,
+            key_hash="h",
+            encrypted_key="e",
+            label="deployment bootstrap",
+            type=BOOTSTRAP_KEY_TYPE,
+        )
+        async with session_factory() as session:
+            with pytest.raises(RuntimeError, match="admin"):
                 await resolve_registration_owner_id(session, user_store, key)

--- a/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
+++ b/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
@@ -56,7 +56,7 @@ class TestEnsureBootstrapOwner:
             await session.commit()
 
         async with session_factory() as session:
-            with pytest.raises(RuntimeError, match="not created by"):
+            with pytest.raises(RuntimeError, match="cannot be proven"):
                 await ensure_bootstrap_owner(session, user_store)
 
     async def test_backfills_the_marker_onto_a_row_created_before_it_existed(
@@ -225,5 +225,5 @@ class TestResolveRegistrationOwnerId:
             type=BOOTSTRAP_KEY_TYPE,
         )
         async with session_factory() as session:
-            with pytest.raises(RuntimeError, match="not created by"):
+            with pytest.raises(RuntimeError, match="cannot be proven"):
                 await resolve_registration_owner_id(session, user_store, key)

--- a/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
+++ b/core/tests/switch_core/bridges/agent/test_registration_bootstrap.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from switch_core.bridges.agent.registration_bootstrap import (
     BOOTSTRAP_KEY_TYPE,
+    BOOTSTRAP_LAST_SEEDED_HASH_META_KEY,
     BOOTSTRAP_OWNER_EMAIL,
     BOOTSTRAP_OWNER_MARKER_META_KEY,
     ensure_bootstrap_owner,
@@ -58,22 +59,64 @@ class TestEnsureBootstrapOwner:
             with pytest.raises(RuntimeError, match="not created by"):
                 await ensure_bootstrap_owner(session, user_store)
 
-    async def test_refuses_an_existing_account_with_the_admin_role(
+    async def test_backfills_the_marker_onto_a_row_created_before_it_existed(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        """A gateway admin can `POST /users` with this exact email and an
-        admin role. Adopting that account would silently restore the exact
-        escalation this module exists to close — caught here as a second,
-        independent check even though the missing marker already refuses it."""
+        """Upgrade path: a bootstrap owner created by an earlier commit of
+        this same feature, before the marker existed, has no marker but does
+        carry the last-seeded-hash key — a value only this module's own
+        seeding step ever writes, so a squatter cannot have it. Must be
+        healed in place, not refused, or upgrading past the commit that
+        introduced the marker bricks every database that already ran this."""
         user_store = UserStore()
         async with session_factory() as session:
             session.add(
-                User(name="squatter", email=BOOTSTRAP_OWNER_EMAIL, role="admin")
+                User(
+                    name=BOOTSTRAP_OWNER_EMAIL,
+                    email=BOOTSTRAP_OWNER_EMAIL,
+                    role="user",
+                    metadata_={BOOTSTRAP_LAST_SEEDED_HASH_META_KEY: "some-hash"},
+                )
             )
             await session.commit()
 
         async with session_factory() as session:
-            with pytest.raises(RuntimeError, match="admin"):
+            owner = await ensure_bootstrap_owner(session, user_store)
+            await session.commit()
+
+        assert (owner.metadata_ or {}).get(BOOTSTRAP_OWNER_MARKER_META_KEY) is True
+        assert (owner.metadata_ or {}).get(BOOTSTRAP_LAST_SEEDED_HASH_META_KEY) == (
+            "some-hash"
+        )
+
+        async with session_factory() as session:
+            persisted = await session.get(User, owner.id)
+        assert persisted is not None
+        assert (persisted.metadata_ or {}).get(BOOTSTRAP_OWNER_MARKER_META_KEY) is True
+
+    async def test_refuses_a_marked_account_promoted_to_the_admin_role(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The role check as its own, independently-exercised guard: an
+        otherwise-genuine account (it carries the marker) that has been
+        given the admin role — e.g. a gateway admin editing it directly —
+        must still be refused. Deliberately marked so this hits the role
+        check specifically rather than the (already separately tested)
+        missing-marker check."""
+        user_store = UserStore()
+        async with session_factory() as session:
+            session.add(
+                User(
+                    name="promoted",
+                    email=BOOTSTRAP_OWNER_EMAIL,
+                    role="admin",
+                    metadata_={BOOTSTRAP_OWNER_MARKER_META_KEY: True},
+                )
+            )
+            await session.commit()
+
+        async with session_factory() as session:
+            with pytest.raises(RuntimeError, match="must never be an admin"):
                 await ensure_bootstrap_owner(session, user_store)
 
 

--- a/core/tests/switch_core/test_main.py
+++ b/core/tests/switch_core/test_main.py
@@ -2,9 +2,9 @@
 
 See `bridges/agent/test_registration_bootstrap.py` for what the key resolves
 to; this covers the seeding lifecycle itself: fresh install, in-place
-rotation, and that a deliberate revocation (deleting the key from the
-gateway's API Keys page) survives a restart instead of being silently
-recreated.
+rotation, legacy migration, and that a deliberate revocation (deleting the
+key from the gateway's API Keys page) survives a restart instead of being
+silently recreated — including when the admin email changes underneath it.
 """
 
 from __future__ import annotations
@@ -17,21 +17,20 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from switch_core.bridges.agent.registration_bootstrap import (
     BOOTSTRAP_KEY_LABEL,
     BOOTSTRAP_KEY_TYPE,
+    BOOTSTRAP_OWNER_EMAIL,
     LEGACY_BOOTSTRAP_KEY_LABEL,
 )
 from switch_core.config import SwitchConfig
-from switch_core.db.models import ApiKey, User
+from switch_core.db.models import Agent, ApiKey, Client, User
+from switch_core.db.stores.agent_store import AgentStore
 from switch_core.db.stores.api_key_store import ApiKeyStore
 from switch_core.db.stores.user_store import UserStore
-from switch_core.main import (
-    _BOOTSTRAP_SEEDED_FLAG,
-    _seed_agent_registration_bootstrap_key,
-)
+from switch_core.main import _seed_agent_registration_bootstrap_key
 
 ADMIN_EMAIL = "admin@switch.local"
 
 
-def _config(token: str) -> SwitchConfig:
+def _config(token: str, *, admin_email: str = ADMIN_EMAIL) -> SwitchConfig:
     return SwitchConfig(
         db_host="unused",
         db_port="5432",
@@ -41,17 +40,65 @@ def _config(token: str) -> SwitchConfig:
         matrix_server_name="test",
         agent_registration_token=token,
         jwt_secret_key="test-jwt-secret",
-        gateway_admin_email=ADMIN_EMAIL,
+        gateway_admin_email=admin_email,
         gateway_admin_password="unused",
     )
 
 
-async def _make_admin(session_factory: async_sessionmaker[AsyncSession]) -> str:
+async def _make_user(
+    session_factory: async_sessionmaker[AsyncSession], *, email: str, role: str
+) -> str:
     async with session_factory() as session:
-        admin = User(name="Admin", email=ADMIN_EMAIL, role="admin")
-        session.add(admin)
+        user = User(name=role, email=email, role=role)
+        session.add(user)
         await session.commit()
-        return admin.id
+        return user.id
+
+
+async def _make_admin(session_factory: async_sessionmaker[AsyncSession]) -> str:
+    return await _make_user(session_factory, email=ADMIN_EMAIL, role="admin")
+
+
+async def _make_agent_owned_by(
+    session_factory: async_sessionmaker[AsyncSession], *, owner_id: str, name: str
+) -> None:
+    async with session_factory() as session:
+        client = Client(matrix_user_id=f"@{name}:test", display_name=name, type="agent")
+        session.add(client)
+        await session.flush()
+        key = ApiKey(
+            user_id=owner_id,
+            key_hash=_hash(f"agent-key-{name}"),
+            encrypted_key="irrelevant",
+            label=name,
+            type="agent",
+        )
+        session.add(key)
+        await session.flush()
+        session.add(
+            Agent(
+                name=name,
+                description="d",
+                agent_type="session_addressable",
+                connector_type="claude_code",
+                integration_profile={},
+                client_id=client.id,
+                api_key_id=key.id,
+                owner_id=owner_id,
+            )
+        )
+        await session.commit()
+
+
+async def _seed(
+    session_factory: async_sessionmaker[AsyncSession],
+    user_store: UserStore,
+    api_key_store: ApiKeyStore,
+    config: SwitchConfig,
+) -> None:
+    await _seed_agent_registration_bootstrap_key(
+        session_factory, user_store, api_key_store, AgentStore(), config
+    )
 
 
 def _hash(token: str) -> str:
@@ -66,20 +113,15 @@ class TestSeedAgentRegistrationBootstrapKey:
         admin_id = await _make_admin(session_factory)
         config = _config("dev-test-token")
 
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, config
-        )
+        await _seed(session_factory, user_store, api_key_store, config)
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
-            admin = await user_store.get(session, admin_id)
 
         bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
         assert len(bootstrap_keys) == 1
         assert bootstrap_keys[0].key_hash == _hash("dev-test-token")
         assert bootstrap_keys[0].label == BOOTSTRAP_KEY_LABEL
-        assert admin is not None
-        assert (admin.metadata_ or {}).get(_BOOTSTRAP_SEEDED_FLAG) is True
 
     async def test_rerunning_with_the_same_token_is_a_no_op(
         self, session_factory: async_sessionmaker[AsyncSession]
@@ -88,12 +130,8 @@ class TestSeedAgentRegistrationBootstrapKey:
         admin_id = await _make_admin(session_factory)
         config = _config("dev-test-token")
 
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, config
-        )
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, config
-        )
+        await _seed(session_factory, user_store, api_key_store, config)
+        await _seed(session_factory, user_store, api_key_store, config)
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
@@ -118,9 +156,7 @@ class TestSeedAgentRegistrationBootstrapKey:
             await session.commit()
             legacy_id = legacy.id
 
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, config
-        )
+        await _seed(session_factory, user_store, api_key_store, config)
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
@@ -130,13 +166,43 @@ class TestSeedAgentRegistrationBootstrapKey:
         assert bootstrap_keys[0].label == BOOTSTRAP_KEY_LABEL
         assert not any(k.type == "registration" for k in keys)
 
+    async def test_a_personal_key_sharing_the_legacy_label_but_not_the_hash_is_untouched(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """A label is free text an admin could reuse by coincidence; only a
+        matching hash proves a row really is the historical bootstrap key."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+        config = _config("dev-test-token")
+
+        async with session_factory() as session:
+            personal = ApiKey(
+                user_id=admin_id,
+                key_hash=_hash("some-unrelated-personal-secret"),
+                encrypted_key="irrelevant",
+                label=LEGACY_BOOTSTRAP_KEY_LABEL,
+                type="registration",
+            )
+            session.add(personal)
+            await session.commit()
+            personal_id = personal.id
+
+        await _seed(session_factory, user_store, api_key_store, config)
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        by_id = {k.id: k for k in keys}
+        assert by_id[personal_id].type == "registration"
+        assert by_id[personal_id].key_hash == _hash("some-unrelated-personal-secret")
+        assert len([k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]) == 1
+
     async def test_revoking_a_migrated_legacy_key_survives_a_restart(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        """The durable-seeded flag must be recorded on the very call that
-        migrates a legacy key, not only on a later, unrelated call — an
-        operator can revoke (delete) the freshly migrated key immediately,
-        with no intervening restart to have backfilled the flag."""
+        """The durable marker must be recorded on the very call that migrates
+        a legacy key, not only on a later, unrelated call — an operator can
+        revoke (delete) the freshly migrated key immediately, with no
+        intervening restart to have backfilled it."""
         user_store, api_key_store = UserStore(), ApiKeyStore()
         admin_id = await _make_admin(session_factory)
         config = _config("dev-test-token")
@@ -152,9 +218,7 @@ class TestSeedAgentRegistrationBootstrapKey:
             session.add(legacy)
             await session.commit()
 
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, config
-        )
+        await _seed(session_factory, user_store, api_key_store, config)
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
@@ -162,9 +226,7 @@ class TestSeedAgentRegistrationBootstrapKey:
             await api_key_store.delete(session, bootstrap_key.id)
             await session.commit()
 
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, config
-        )
+        await _seed(session_factory, user_store, api_key_store, config)
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
@@ -176,12 +238,8 @@ class TestSeedAgentRegistrationBootstrapKey:
         user_store, api_key_store = UserStore(), ApiKeyStore()
         admin_id = await _make_admin(session_factory)
 
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, _config("old-token")
-        )
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, _config("new-token")
-        )
+        await _seed(session_factory, user_store, api_key_store, _config("old-token"))
+        await _seed(session_factory, user_store, api_key_store, _config("new-token"))
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
@@ -200,22 +258,48 @@ class TestSeedAgentRegistrationBootstrapKey:
         admin_id = await _make_admin(session_factory)
         config = _config("dev-test-token")
 
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, config
-        )
+        await _seed(session_factory, user_store, api_key_store, config)
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
             (bootstrap_key,) = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
             await api_key_store.delete(session, bootstrap_key.id)
             await session.commit()
 
-        await _seed_agent_registration_bootstrap_key(
-            session_factory, user_store, api_key_store, config
-        )
+        await _seed(session_factory, user_store, api_key_store, config)
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
         assert not any(k.type == BOOTSTRAP_KEY_TYPE for k in keys)
+
+    async def test_rotating_to_a_new_value_after_revocation_re_enables_it(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """A revoked key stays revoked only for the value it was revoked at.
+        An operator with no database access can re-enable deployment-wide
+        bootstrap registration by rotating to a new secret."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+
+        await _seed(session_factory, user_store, api_key_store, _config("old-token"))
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+            (bootstrap_key,) = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+            await api_key_store.delete(session, bootstrap_key.id)
+            await session.commit()
+
+        # Same value: stays revoked.
+        await _seed(session_factory, user_store, api_key_store, _config("old-token"))
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        assert not any(k.type == BOOTSTRAP_KEY_TYPE for k in keys)
+
+        # New value: re-enabled.
+        await _seed(session_factory, user_store, api_key_store, _config("new-token"))
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("new-token")
 
     async def test_missing_admin_user_fails_loud(
         self, session_factory: async_sessionmaker[AsyncSession]
@@ -224,6 +308,89 @@ class TestSeedAgentRegistrationBootstrapKey:
         config = _config("dev-test-token")
 
         with pytest.raises(RuntimeError):
-            await _seed_agent_registration_bootstrap_key(
-                session_factory, user_store, api_key_store, config
+            await _seed(session_factory, user_store, api_key_store, config)
+
+    async def test_bootstrap_owner_promoted_to_admin_blocks_seeding(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Adversarial: something (a gateway admin via POST /users, or an
+        OIDC identity provider on an upgrading deployment) has already
+        claimed the bootstrap owner's reserved address with the admin role.
+        Seeding must refuse rather than adopt it — that account would confer
+        admin authority on every agent registered through the shared token,
+        exactly the escalation this fix closes."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        await _make_admin(session_factory)
+        await _make_user(session_factory, email=BOOTSTRAP_OWNER_EMAIL, role="admin")
+        config = _config("dev-test-token")
+
+        with pytest.raises(RuntimeError, match="admin"):
+            await _seed(session_factory, user_store, api_key_store, config)
+
+    async def test_admin_owned_agents_are_logged_as_a_warning(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+        await _make_agent_owned_by(
+            session_factory, owner_id=admin_id, name="admin-owned-agent"
+        )
+        config = _config("dev-test-token")
+
+        with caplog.at_level("WARNING", logger="switch_core.main"):
+            await _seed(session_factory, user_store, api_key_store, config)
+
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("admin-owned-agent" in w for w in warnings)
+
+    async def test_changing_the_admin_email_does_not_crash_or_duplicate_the_key(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The seed check must not be scoped to whichever user the currently
+        configured admin email resolves to: an admin-email change must not
+        cause a duplicate insert of a key that already exists (and collides
+        on the unique key_hash) under the previous admin."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        await _make_admin(session_factory)
+        config = _config("dev-test-token")
+        await _seed(session_factory, user_store, api_key_store, config)
+
+        new_admin_email = "new-admin@switch.local"
+        await _make_user(session_factory, email=new_admin_email, role="admin")
+        new_config = _config("dev-test-token", admin_email=new_admin_email)
+
+        # Must not raise (would previously fail the unique constraint on
+        # api_keys.key_hash by trying to insert a second row for the same
+        # token under the new admin).
+        await _seed(session_factory, user_store, api_key_store, new_config)
+
+        async with session_factory() as session:
+            all_keys_by_hash = await api_key_store.get_by_hash(
+                session, _hash("dev-test-token")
             )
+        assert all_keys_by_hash is not None
+
+    async def test_changing_the_admin_email_after_revocation_does_not_resurrect_it(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+        config = _config("dev-test-token")
+        await _seed(session_factory, user_store, api_key_store, config)
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+            (bootstrap_key,) = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+            await api_key_store.delete(session, bootstrap_key.id)
+            await session.commit()
+
+        new_admin_email = "new-admin@switch.local"
+        await _make_user(session_factory, email=new_admin_email, role="admin")
+        new_config = _config("dev-test-token", admin_email=new_admin_email)
+        await _seed(session_factory, user_store, api_key_store, new_config)
+
+        async with session_factory() as session:
+            found = await api_key_store.get_by_hash(session, _hash("dev-test-token"))
+        assert found is None

--- a/core/tests/switch_core/test_main.py
+++ b/core/tests/switch_core/test_main.py
@@ -226,6 +226,52 @@ class TestSeedAgentRegistrationBootstrapKey:
         assert len(bootstrap_keys) == 1
         assert bootstrap_keys[0].key_hash == _hash("new-token")
 
+    async def test_deleting_the_retired_row_then_restoring_the_old_token_stays_blocked(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The case with no constraint to fall back on. Above, restoring the
+        old token while the retired row is still present is blocked twice
+        over: the revoked-hashes check, and (if that ever failed) the unique
+        constraint on key_hash, since the retired row still holds the old
+        value. Once an operator deletes that retired row from the API Keys
+        page — exactly what the warning invites them to do — that row is
+        gone and the constraint can no longer save a bug here. Only the
+        revoked-hashes list, recorded at retirement time, stands between the
+        old token and reinstating admin-authority registration."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+
+        async with session_factory() as session:
+            legacy = ApiKey(
+                user_id=admin_id,
+                key_hash=_hash("old-token"),
+                encrypted_key="irrelevant",
+                label=LEGACY_BOOTSTRAP_KEY_LABEL,
+                type="registration",
+            )
+            session.add(legacy)
+            await session.commit()
+
+        await _seed(session_factory, user_store, api_key_store, _config("new-token"))
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+            (retired,) = [k for k in keys if k.type == RETIRED_KEY_TYPE]
+            await api_key_store.delete(session, retired.id)
+            await session.commit()
+
+        # No row anywhere holds H(old-token) now. If this were still guarded
+        # only by the unique constraint, this call would succeed and rotate
+        # the active key back onto the revoked value.
+        await _seed(session_factory, user_store, api_key_store, _config("old-token"))
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("new-token")
+        assert not any(k.key_hash == _hash("old-token") for k in keys)
+
     async def test_a_hash_mismatched_legacy_labeled_key_is_retired_and_warned_about(
         self,
         session_factory: async_sessionmaker[AsyncSession],
@@ -500,7 +546,7 @@ class TestSeedAgentRegistrationBootstrapKey:
         await _make_user(session_factory, email=BOOTSTRAP_OWNER_EMAIL, role="user")
         config = _config("dev-test-token")
 
-        with pytest.raises(RuntimeError, match="not created by"):
+        with pytest.raises(RuntimeError, match="cannot be proven"):
             await _seed(session_factory, user_store, api_key_store, config)
 
     async def test_admin_owned_agents_are_logged_as_a_warning(

--- a/core/tests/switch_core/test_main.py
+++ b/core/tests/switch_core/test_main.py
@@ -130,6 +130,46 @@ class TestSeedAgentRegistrationBootstrapKey:
         assert bootstrap_keys[0].label == BOOTSTRAP_KEY_LABEL
         assert not any(k.type == "registration" for k in keys)
 
+    async def test_revoking_a_migrated_legacy_key_survives_a_restart(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The durable-seeded flag must be recorded on the very call that
+        migrates a legacy key, not only on a later, unrelated call — an
+        operator can revoke (delete) the freshly migrated key immediately,
+        with no intervening restart to have backfilled the flag."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+        config = _config("dev-test-token")
+
+        async with session_factory() as session:
+            legacy = ApiKey(
+                user_id=admin_id,
+                key_hash=_hash("dev-test-token"),
+                encrypted_key="irrelevant",
+                label=LEGACY_BOOTSTRAP_KEY_LABEL,
+                type="registration",
+            )
+            session.add(legacy)
+            await session.commit()
+
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, config
+        )
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+            (bootstrap_key,) = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+            await api_key_store.delete(session, bootstrap_key.id)
+            await session.commit()
+
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, config
+        )
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        assert not any(k.type == BOOTSTRAP_KEY_TYPE for k in keys)
+
     async def test_rotating_the_token_updates_the_existing_key_in_place(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:

--- a/core/tests/switch_core/test_main.py
+++ b/core/tests/switch_core/test_main.py
@@ -1,0 +1,189 @@
+"""Seeding the deployment-wide agent-registration bootstrap key.
+
+See `bridges/agent/test_registration_bootstrap.py` for what the key resolves
+to; this covers the seeding lifecycle itself: fresh install, in-place
+rotation, and that a deliberate revocation (deleting the key from the
+gateway's API Keys page) survives a restart instead of being silently
+recreated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.bridges.agent.registration_bootstrap import (
+    BOOTSTRAP_KEY_LABEL,
+    BOOTSTRAP_KEY_TYPE,
+    LEGACY_BOOTSTRAP_KEY_LABEL,
+)
+from switch_core.config import SwitchConfig
+from switch_core.db.models import ApiKey, User
+from switch_core.db.stores.api_key_store import ApiKeyStore
+from switch_core.db.stores.user_store import UserStore
+from switch_core.main import (
+    _BOOTSTRAP_SEEDED_FLAG,
+    _seed_agent_registration_bootstrap_key,
+)
+
+ADMIN_EMAIL = "admin@switch.local"
+
+
+def _config(token: str) -> SwitchConfig:
+    return SwitchConfig(
+        db_host="unused",
+        db_port="5432",
+        db_user="unused",
+        db_password="unused",
+        db_name="unused",
+        matrix_server_name="test",
+        agent_registration_token=token,
+        jwt_secret_key="test-jwt-secret",
+        gateway_admin_email=ADMIN_EMAIL,
+        gateway_admin_password="unused",
+    )
+
+
+async def _make_admin(session_factory: async_sessionmaker[AsyncSession]) -> str:
+    async with session_factory() as session:
+        admin = User(name="Admin", email=ADMIN_EMAIL, role="admin")
+        session.add(admin)
+        await session.commit()
+        return admin.id
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+class TestSeedAgentRegistrationBootstrapKey:
+    async def test_fresh_install_seeds_one_bootstrap_key_owned_by_admin(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+        config = _config("dev-test-token")
+
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, config
+        )
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+            admin = await user_store.get(session, admin_id)
+
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("dev-test-token")
+        assert bootstrap_keys[0].label == BOOTSTRAP_KEY_LABEL
+        assert admin is not None
+        assert (admin.metadata_ or {}).get(_BOOTSTRAP_SEEDED_FLAG) is True
+
+    async def test_rerunning_with_the_same_token_is_a_no_op(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+        config = _config("dev-test-token")
+
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, config
+        )
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, config
+        )
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        assert len([k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]) == 1
+
+    async def test_migrates_a_legacy_admin_owned_registration_key_in_place(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+        config = _config("dev-test-token")
+
+        async with session_factory() as session:
+            legacy = ApiKey(
+                user_id=admin_id,
+                key_hash=_hash("dev-test-token"),
+                encrypted_key="irrelevant",
+                label=LEGACY_BOOTSTRAP_KEY_LABEL,
+                type="registration",
+            )
+            session.add(legacy)
+            await session.commit()
+            legacy_id = legacy.id
+
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, config
+        )
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].id == legacy_id
+        assert bootstrap_keys[0].label == BOOTSTRAP_KEY_LABEL
+        assert not any(k.type == "registration" for k in keys)
+
+    async def test_rotating_the_token_updates_the_existing_key_in_place(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, _config("old-token")
+        )
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, _config("new-token")
+        )
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("new-token")
+
+    async def test_revoking_the_key_survives_a_restart_with_the_same_token(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Deleting the seeded key (as an operator would from the gateway's
+        API Keys page) must be a durable revocation: restarting the server
+        with the same, unchanged AGENT_REGISTRATION_TOKEN must not bring it
+        back — the old failure this guards against is exactly that."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+        config = _config("dev-test-token")
+
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, config
+        )
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+            (bootstrap_key,) = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+            await api_key_store.delete(session, bootstrap_key.id)
+            await session.commit()
+
+        await _seed_agent_registration_bootstrap_key(
+            session_factory, user_store, api_key_store, config
+        )
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        assert not any(k.type == BOOTSTRAP_KEY_TYPE for k in keys)
+
+    async def test_missing_admin_user_fails_loud(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        config = _config("dev-test-token")
+
+        with pytest.raises(RuntimeError):
+            await _seed_agent_registration_bootstrap_key(
+                session_factory, user_store, api_key_store, config
+            )

--- a/core/tests/switch_core/test_main.py
+++ b/core/tests/switch_core/test_main.py
@@ -17,8 +17,13 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from switch_core.bridges.agent.registration_bootstrap import (
     BOOTSTRAP_KEY_LABEL,
     BOOTSTRAP_KEY_TYPE,
+    BOOTSTRAP_LAST_SEEDED_HASH_META_KEY,
     BOOTSTRAP_OWNER_EMAIL,
+    BOOTSTRAP_OWNER_MARKER_META_KEY,
+    BOOTSTRAP_OWNER_NAME,
+    BOOTSTRAP_REVOKED_HASHES_META_KEY,
     LEGACY_BOOTSTRAP_KEY_LABEL,
+    RETIRED_KEY_TYPE,
 )
 from switch_core.config import SwitchConfig
 from switch_core.db.models import Agent, ApiKey, Client, User
@@ -46,10 +51,14 @@ def _config(token: str, *, admin_email: str = ADMIN_EMAIL) -> SwitchConfig:
 
 
 async def _make_user(
-    session_factory: async_sessionmaker[AsyncSession], *, email: str, role: str
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    email: str,
+    role: str,
+    metadata: dict | None = None,
 ) -> str:
     async with session_factory() as session:
-        user = User(name=role, email=email, role=role)
+        user = User(name=role, email=email, role=role, metadata_=metadata)
         session.add(user)
         await session.commit()
         return user.id
@@ -175,7 +184,11 @@ class TestSeedAgentRegistrationBootstrapKey:
         migrate. Left alone, that row keeps authenticating as
         `type="registration"`, owned by the admin — exactly the escalation
         this PR exists to close, and permanently, since a bootstrap key
-        exists after this run and later runs never look for it again."""
+        exists after this run and later runs never look for it again.
+
+        Retired, not deleted: the row must stop authenticating but stay
+        visible (and its old value permanently revoked, so restoring an old
+        .env or values file can't bring it back either)."""
         user_store, api_key_store = UserStore(), ApiKeyStore()
         admin_id = await _make_admin(session_factory)
 
@@ -189,19 +202,29 @@ class TestSeedAgentRegistrationBootstrapKey:
             )
             session.add(legacy)
             await session.commit()
+            legacy_id = legacy.id
 
         await _seed(session_factory, user_store, api_key_store, _config("new-token"))
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
+        by_id = {k.id: k for k in keys}
         bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
         assert len(bootstrap_keys) == 1
         assert bootstrap_keys[0].key_hash == _hash("new-token")
-        # The stale row must not still be live as a registration credential
-        # under the old value.
-        assert not any(
-            k.type == "registration" and k.key_hash == _hash("old-token") for k in keys
-        )
+        # Still visible, no longer live: retired, not gone.
+        assert legacy_id in by_id
+        assert by_id[legacy_id].type == RETIRED_KEY_TYPE
+        assert by_id[legacy_id].type not in ("registration", BOOTSTRAP_KEY_TYPE)
+
+        # Restoring the old .env (or a stale values file) must not resurrect
+        # it: its hash is permanently revoked, not just retyped away.
+        await _seed(session_factory, user_store, api_key_store, _config("old-token"))
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("new-token")
 
     async def test_a_hash_mismatched_legacy_labeled_key_is_retired_and_warned_about(
         self,
@@ -214,9 +237,10 @@ class TestSeedAgentRegistrationBootstrapKey:
         label identically (finding 5's contrived scenario). Nothing in the
         schema distinguishes them once the hash no longer matches, so this
         favours closing the real, silent escalation: retire the row (so it
-        can no longer register anything) and name it loudly in a warning, so
-        the rare coincidental case is at least visible and cheap to recover
-        from (recreate a personal key) rather than a permanent, silent hole."""
+        can no longer register anything, but stays visible on the API Keys
+        page instead of vanishing) and name it loudly in a warning, so the
+        rare coincidental case is at least visible and recoverable rather
+        than a permanent, silent hole."""
         user_store, api_key_store = UserStore(), ApiKeyStore()
         admin_id = await _make_admin(session_factory)
         config = _config("dev-test-token")
@@ -238,7 +262,10 @@ class TestSeedAgentRegistrationBootstrapKey:
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
-        assert not any(k.id == stale_id for k in keys)
+        by_id = {k.id: k for k in keys}
+        assert stale_id in by_id, "the retired row must still be visible"
+        assert by_id[stale_id].type == RETIRED_KEY_TYPE
+        assert "retired" in by_id[stale_id].label.lower()
         assert len([k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]) == 1
         warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
         assert any(stale_id in w for w in warnings)
@@ -390,21 +417,75 @@ class TestSeedAgentRegistrationBootstrapKey:
         with pytest.raises(RuntimeError):
             await _seed(session_factory, user_store, api_key_store, config)
 
-    async def test_bootstrap_owner_promoted_to_admin_blocks_seeding(
+    async def test_malformed_revoked_hashes_fails_loud(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        """Adversarial: a gateway admin has already claimed the bootstrap
-        owner's reserved address with the admin role via `POST /users`.
-        Seeding must refuse rather than adopt it — that account would confer
-        admin authority on every agent registered through the shared token,
-        exactly the escalation this fix closes."""
+        """A hand-edited, non-list value must not be silently coerced (`list("a
+        string")` iterates its characters) into "nothing is revoked"."""
         user_store, api_key_store = UserStore(), ApiKeyStore()
         await _make_admin(session_factory)
-        await _make_user(session_factory, email=BOOTSTRAP_OWNER_EMAIL, role="admin")
+        async with session_factory() as session:
+            session.add(
+                User(
+                    name=BOOTSTRAP_OWNER_NAME,
+                    email=BOOTSTRAP_OWNER_EMAIL,
+                    role="user",
+                    metadata_={
+                        BOOTSTRAP_OWNER_MARKER_META_KEY: True,
+                        BOOTSTRAP_REVOKED_HASHES_META_KEY: "not-a-list",
+                    },
+                )
+            )
+            await session.commit()
         config = _config("dev-test-token")
 
-        with pytest.raises(RuntimeError, match="admin"):
+        with pytest.raises(RuntimeError, match="not a list"):
             await _seed(session_factory, user_store, api_key_store, config)
+
+    async def test_promoted_bootstrap_owner_blocks_seeding(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The role check exercised on its own: an otherwise-genuine account
+        (carries the marker) that was given the admin role directly — e.g. a
+        gateway admin editing it — must still block seeding. Marked so this
+        hits the role check rather than the separately-tested missing-marker
+        one."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        await _make_admin(session_factory)
+        await _make_user(
+            session_factory,
+            email=BOOTSTRAP_OWNER_EMAIL,
+            role="admin",
+            metadata={BOOTSTRAP_OWNER_MARKER_META_KEY: True},
+        )
+        config = _config("dev-test-token")
+
+        with pytest.raises(RuntimeError, match="must never be an admin"):
+            await _seed(session_factory, user_store, api_key_store, config)
+
+    async def test_upgrading_past_the_marker_commit_does_not_brick_seeding(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """A bootstrap owner created by an earlier commit of this same
+        feature (before the marker existed) has no marker but does carry the
+        last-seeded-hash key, which only this module's own seeding ever
+        writes. Seeding must heal it in place rather than refuse to start."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        await _make_admin(session_factory)
+        await _make_user(
+            session_factory,
+            email=BOOTSTRAP_OWNER_EMAIL,
+            role="user",
+            metadata={BOOTSTRAP_LAST_SEEDED_HASH_META_KEY: "old-hash"},
+        )
+        config = _config("dev-test-token")
+
+        await _seed(session_factory, user_store, api_key_store, config)
+
+        async with session_factory() as session:
+            owner = await user_store.get_by_email(session, BOOTSTRAP_OWNER_EMAIL)
+        assert owner is not None
+        assert (owner.metadata_ or {}).get(BOOTSTRAP_OWNER_MARKER_META_KEY) is True
 
     async def test_role_user_squatter_at_bootstrap_address_blocks_seeding(
         self, session_factory: async_sessionmaker[AsyncSession]

--- a/core/tests/switch_core/test_main.py
+++ b/core/tests/switch_core/test_main.py
@@ -166,35 +166,82 @@ class TestSeedAgentRegistrationBootstrapKey:
         assert bootstrap_keys[0].label == BOOTSTRAP_KEY_LABEL
         assert not any(k.type == "registration" for k in keys)
 
-    async def test_a_personal_key_sharing_the_legacy_label_but_not_the_hash_is_untouched(
+    async def test_a_legacy_key_rotated_before_the_upgrade_is_retired_not_left_live(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        """A label is free text an admin could reuse by coincidence; only a
-        matching hash proves a row really is the historical bootstrap key."""
+        """An operator who rotates AGENT_REGISTRATION_TOKEN at or before the
+        upgrade (ordinary practice) leaves the legacy row's hash stale, so a
+        hash-only lookup for the *current* token would never find it to
+        migrate. Left alone, that row keeps authenticating as
+        `type="registration"`, owned by the admin — exactly the escalation
+        this PR exists to close, and permanently, since a bootstrap key
+        exists after this run and later runs never look for it again."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+
+        async with session_factory() as session:
+            legacy = ApiKey(
+                user_id=admin_id,
+                key_hash=_hash("old-token"),
+                encrypted_key="irrelevant",
+                label=LEGACY_BOOTSTRAP_KEY_LABEL,
+                type="registration",
+            )
+            session.add(legacy)
+            await session.commit()
+
+        await _seed(session_factory, user_store, api_key_store, _config("new-token"))
+
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("new-token")
+        # The stale row must not still be live as a registration credential
+        # under the old value.
+        assert not any(
+            k.type == "registration" and k.key_hash == _hash("old-token") for k in keys
+        )
+
+    async def test_a_hash_mismatched_legacy_labeled_key_is_retired_and_warned_about(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The label alone cannot tell a stale, rotated-out bootstrap key
+        (finding 1: dangerous — admin-owned, still registers agents with
+        admin authority) apart from a personal key an admin happened to
+        label identically (finding 5's contrived scenario). Nothing in the
+        schema distinguishes them once the hash no longer matches, so this
+        favours closing the real, silent escalation: retire the row (so it
+        can no longer register anything) and name it loudly in a warning, so
+        the rare coincidental case is at least visible and cheap to recover
+        from (recreate a personal key) rather than a permanent, silent hole."""
         user_store, api_key_store = UserStore(), ApiKeyStore()
         admin_id = await _make_admin(session_factory)
         config = _config("dev-test-token")
 
         async with session_factory() as session:
-            personal = ApiKey(
+            stale = ApiKey(
                 user_id=admin_id,
-                key_hash=_hash("some-unrelated-personal-secret"),
+                key_hash=_hash("some-other-value"),
                 encrypted_key="irrelevant",
                 label=LEGACY_BOOTSTRAP_KEY_LABEL,
                 type="registration",
             )
-            session.add(personal)
+            session.add(stale)
             await session.commit()
-            personal_id = personal.id
+            stale_id = stale.id
 
-        await _seed(session_factory, user_store, api_key_store, config)
+        with caplog.at_level("WARNING", logger="switch_core.main"):
+            await _seed(session_factory, user_store, api_key_store, config)
 
         async with session_factory() as session:
             keys = await api_key_store.get_by_user(session, admin_id)
-        by_id = {k.id: k for k in keys}
-        assert by_id[personal_id].type == "registration"
-        assert by_id[personal_id].key_hash == _hash("some-unrelated-personal-secret")
+        assert not any(k.id == stale_id for k in keys)
         assert len([k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]) == 1
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any(stale_id in w for w in warnings)
 
     async def test_revoking_a_migrated_legacy_key_survives_a_restart(
         self, session_factory: async_sessionmaker[AsyncSession]
@@ -301,6 +348,39 @@ class TestSeedAgentRegistrationBootstrapKey:
         assert len(bootstrap_keys) == 1
         assert bootstrap_keys[0].key_hash == _hash("new-token")
 
+    async def test_rotating_back_to_a_revoked_value_does_not_reinstate_it(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Revoke X, rotate to Y and restart, rotate back to X and restart:
+        the deployment must keep serving Y (or nothing), never X again — a
+        revoked value is refused forever, not just until the next rotation."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        admin_id = await _make_admin(session_factory)
+
+        await _seed(session_factory, user_store, api_key_store, _config("x-token"))
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+            (bootstrap_key,) = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+            await api_key_store.delete(session, bootstrap_key.id)
+            await session.commit()
+
+        # Rotate forward to Y: re-enabled at the new value.
+        await _seed(session_factory, user_store, api_key_store, _config("y-token"))
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("y-token")
+
+        # Rotate back to X: must not reinstate the revoked value. Y stays active.
+        await _seed(session_factory, user_store, api_key_store, _config("x-token"))
+        async with session_factory() as session:
+            keys = await api_key_store.get_by_user(session, admin_id)
+        bootstrap_keys = [k for k in keys if k.type == BOOTSTRAP_KEY_TYPE]
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("y-token")
+        assert not any(k.key_hash == _hash("x-token") for k in keys)
+
     async def test_missing_admin_user_fails_loud(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
@@ -313,9 +393,8 @@ class TestSeedAgentRegistrationBootstrapKey:
     async def test_bootstrap_owner_promoted_to_admin_blocks_seeding(
         self, session_factory: async_sessionmaker[AsyncSession]
     ) -> None:
-        """Adversarial: something (a gateway admin via POST /users, or an
-        OIDC identity provider on an upgrading deployment) has already
-        claimed the bootstrap owner's reserved address with the admin role.
+        """Adversarial: a gateway admin has already claimed the bootstrap
+        owner's reserved address with the admin role via `POST /users`.
         Seeding must refuse rather than adopt it — that account would confer
         admin authority on every agent registered through the shared token,
         exactly the escalation this fix closes."""
@@ -325,6 +404,22 @@ class TestSeedAgentRegistrationBootstrapKey:
         config = _config("dev-test-token")
 
         with pytest.raises(RuntimeError, match="admin"):
+            await _seed(session_factory, user_store, api_key_store, config)
+
+    async def test_role_user_squatter_at_bootstrap_address_blocks_seeding(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The realistic squatter: an identity claimed the bootstrap owner's
+        address (e.g. an OIDC login, which always provisions `role="user"`)
+        before agent-registration bootstrap ever ran. A role check alone
+        would silently adopt this account; only the creation marker this
+        module stamps on its own account catches it."""
+        user_store, api_key_store = UserStore(), ApiKeyStore()
+        await _make_admin(session_factory)
+        await _make_user(session_factory, email=BOOTSTRAP_OWNER_EMAIL, role="user")
+        config = _config("dev-test-token")
+
+        with pytest.raises(RuntimeError, match="not created by"):
             await _seed(session_factory, user_store, api_key_store, config)
 
     async def test_admin_owned_agents_are_logged_as_a_warning(
@@ -367,10 +462,11 @@ class TestSeedAgentRegistrationBootstrapKey:
         await _seed(session_factory, user_store, api_key_store, new_config)
 
         async with session_factory() as session:
-            all_keys_by_hash = await api_key_store.get_by_hash(
-                session, _hash("dev-test-token")
+            bootstrap_keys = await api_key_store.get_by_type(
+                session, BOOTSTRAP_KEY_TYPE
             )
-        assert all_keys_by_hash is not None
+        assert len(bootstrap_keys) == 1
+        assert bootstrap_keys[0].key_hash == _hash("dev-test-token")
 
     async def test_changing_the_admin_email_after_revocation_does_not_resurrect_it(
         self, session_factory: async_sessionmaker[AsyncSession]

--- a/docs/old/ARCHITECTURE.md
+++ b/docs/old/ARCHITECTURE.md
@@ -124,7 +124,12 @@ The relational schema is defined in
   presentation only and falls back to `name`. An agent inherits exactly its
   owner's permissions. **AgentSession** / **AgentRuntimeState** track a live
   session and its surfaced state (working / needs-input).
-- **ApiKey** — a hashed credential, of type `"agent"` or `"registration"`.
+- **ApiKey** — a hashed credential, of type `"agent"`, `"registration"`
+  (minted by, and owned by, a single user), or `"bootstrap"` (the
+  deployment-wide key seeded from `AGENT_REGISTRATION_TOKEN`; agents it
+  registers are owned by a dedicated non-admin account rather than the admin
+  it is filed under — see
+  [`bridges/agent/registration_bootstrap.py`](../core/switch_core/bridges/agent/registration_bootstrap.py)).
 - **Client** / **ClientRoom** — the Matrix client backing each participant and
   its room memberships.
 - **Room** — a Matrix room plus Switch metadata (channel type, bridge link,
@@ -156,7 +161,8 @@ The relational schema is defined in
 ### 4.1 Agent registration & connection
 
 1. An agent calls `POST /agents` with a **registration token** (an `ApiKey` of
-   type `"registration"`) and receives its own `{id, api_key}`
+   type `"registration"` or `"bootstrap"`) and receives its own `{id,
+   api_key}`
    ([`bridges/agent/api/handlers.py`](../core/switch_core/bridges/agent/api/handlers.py)).
    Known-agent types (e.g. `claude-code`) register via `POST /agents/register-known`.
 2. All later calls present the agent API key as a `Bearer` token. The

--- a/gateway/src/pages/registration-keys/RegistrationKeysPage.tsx
+++ b/gateway/src/pages/registration-keys/RegistrationKeysPage.tsx
@@ -67,7 +67,10 @@ export default function RegistrationKeysPage() {
   }, []);
 
   const registrationKeys = useMemo(
-    () => keys?.filter((k) => k.type === "registration") ?? [],
+    // Everything that isn't an agent's own key is a way to register more
+    // agents — a personal "registration" key or the deployment-wide
+    // "bootstrap" key seeded from AGENT_REGISTRATION_TOKEN.
+    () => keys?.filter((k) => k.type !== "agent") ?? [],
     [keys],
   );
 


### PR DESCRIPTION
## The attack this closes

`AGENT_REGISTRATION_TOKEN` is seeded once at startup as an `ApiKey` of type
`"registration"`, owned by the seeded admin user. Every agent registered
through `POST /agents` with that token gets `owner_id = <admin's id>`.

Room and resource authorization (`ProtocolService._resolve_acting_identity`,
used by room creation, roster changes, and reference/package attachment)
looks up the agent's owner and treats `owner.role == "admin"` as acting with
full admin authority — the same global bypass `authz.can`/`can_manage` give a
human admin. So an agent registered through the shared deployment token
doesn't just get an owner; it gets **admin authority over every room and
resource in the deployment**, not just ones it's a member of.

This token is explicitly meant to be shared: `docs/official/deploy/self-host.md`
says "Set `AGENT_REGISTRATION_TOKEN` before the first start... which is what
your colleagues' agents register against." So the documented, intended
workflow — hand the one deployment secret to each colleague so they can
bring up their own agent — was itself the privilege-escalation path: any
colleague who registers an agent this way ends up with an agent that can
bypass every room's `read_visibility`/`write_visibility`, change any room's
membership, and manage any reference/document/package, because it is
"owned" by an admin.

A secondary, related gap in the same code path: `ProtocolService.
register_agent_with_token` (used by server-side connectors) never checked
the presented key's `type`, so a leaked **agent** API key — far more widely
distributed than a registration token, since every live connection uses one
— could also be replayed to register more agents under that agent owner's
identity.

## The fix

`AGENT_REGISTRATION_TOKEN` remains (a fresh deployment still needs some way
to register its first agents before anyone has logged into the gateway), but
it is seeded as a new, distinct `ApiKey` type, `"bootstrap"`, rather than
`"registration"`. Agents registered through a bootstrap-type key are owned by
a dedicated, non-admin account (`agent-bootstrap@switch.local`, seeded
alongside it) instead of the admin — so holding the shared secret no longer
confers admin authority, while the resulting agent still has a real owner and
can still create rooms, own them, and attach references, same as before.

The `ApiKey` row itself stays filed under the admin user, so it keeps showing
up (and can be deleted) on the existing gateway "API Keys" page — no new UI
plumbing, just a one-line filter update so a `"bootstrap"`- or `"retired"`-
type key (see "Round 4" below) isn't hidden. Two things that page's existing
delete button did not previously guarantee, now hold:

- **Revocation is durable.** Before this change, deleting the seeded key from
  the API Keys page didn't stick — the next restart matched the current
  `AGENT_REGISTRATION_TOKEN` value against existing hashes, found none, and
  silently reseeded the exact same key. A revocation now persists across a
  restart with the same token, and forever — even through a later rotation
  away and back (see "Round 3" below); rotating the token to a *different,
  never-used* value re-establishes bootstrap registration.
- **A leaked agent key can't be replayed as a registration token** — both
  `register_agent_with_token` and the HTTP registration dependency now
  reject any key whose type isn't `"registration"` or `"bootstrap"`.

An existing deployment's already-seeded legacy key (type `"registration"`,
label `"Default (from AGENT_REGISTRATION_TOKEN)"`) is migrated onto the new
type automatically on the next restart if its hash still matches the
configured token, and retired in place (see "Round 4") if it doesn't — no
operator action required either way.

Per-user registration keys minted from the gateway (`POST /gateway/api-keys`)
are untouched — they already scope to the minting user's own id, which is
exactly the "per-tenant credential" shape CHOO-2624 asks for; `owner_id` was
already the field a future tenant model would replace this with, so nothing
here stands in the way of that later change.

## Adversarial review, round 2

An independent pass found five real gaps in the first version of this fix,
plus a comment that narrated the change instead of documenting behavior:

1. **Changing `GATEWAY_ADMIN_EMAIL` on a running deployment either crashed
   startup or silently un-revoked a revoked key.** The first version decided
   "does a bootstrap key already exist" and stored the revocation marker
   scoped to whichever user the *currently configured* admin email resolves
   to. Point that config at a different account (token unchanged) and the
   seeder found no key under the "new" admin and tried to insert one with a
   hash the old admin's row already held — `api_keys.key_hash` is unique, so
   this failed the whole boot. The same scenario with a previously revoked
   key silently recreated the deployment-wide credential instead, logged at
   `info`. Both existence and rotation are now resolved by the key's own
   hash/type **globally**, never by which admin the config currently names —
   an admin row is only looked up to own a freshly *created* key.
2. **The bootstrap owner's identity was adopted, not verified** (superseded
   by round 3, then round 4, below).
3. **Interaction with #397, and this needs resolving between the two PRs.**
   #397 changes OIDC login so a *verified* email match to an existing account
   links to it instead of refusing. Today, the refusal is what protects
   `agent-bootstrap@switch.local` (and the seeded admin address) from being
   claimed by an external IdP identity. Once #397 lands, an IdP identity
   asserting a verified `agent-bootstrap@switch.local` would be linked to the
   account this PR seeds — handing an external party control of the shared
   identity every bootstrap-registered agent is owned by. #397's own
   write-up discusses the seeded *admin* address and does not mention this
   one. **Whichever of the two PRs lands second must add a not-linkable list
   covering both seeded addresses** (admin and bootstrap-owner) before OIDC
   linking-on-verified-email is safe to ship alongside this.
4. **Legacy-key migration matched on a free-text label alone** (refined by
   round 3, then round 4, below).
5. **Revocation was a one-way boolean** (superseded by round 3, below).
6. **Admin-owned agents predating this fix were mentioned only in this PR
   body.** Seeding now logs a `logger.warning` naming every agent still owned
   by the admin, on every startup for as long as any exist.

## Adversarial review, round 3

A second independent pass found that two of round 2's own fixes reopened
real gaps, one that round 2 explicitly protected against, plus four smaller
issues:

1. **The round-2 hash-match requirement for legacy migration orphaned a live
   admin-authority key on an ordinary upgrade path.** An admin who rotates
   `AGENT_REGISTRATION_TOKEN` at or before the upgrade — normal practice, and
   what re-running `just init-env` does — leaves the legacy row's hash stale.
   A hash-only lookup for the *current* token never finds it, so a fresh
   bootstrap key gets created at the new value while the old row is left
   completely untouched: still `type="registration"`, still owned by the
   admin, still authenticating anyone holding the old token as the admin.
   This is permanent (later restarts stop looking once a bootstrap key
   exists) and was invisible (the round-2 startup warning enumerates
   admin-owned *agents*, not stale admin-owned registration *keys*). Every
   row carrying the legacy label is now inspected regardless of hash: one
   matching the current token still migrates in place (keeping round 2's
   protection against clobbering an unrelated personal key that happens to
   share the label into becoming the live singleton); every other one is
   neutralized (deleted at the time — refined to *retired in place* by round
   4, below) with a `logger.warning` naming it, since a hash mismatch on this
   auto-generated label means the row is stale and must stop authenticating.
2. **The role check was the wrong shape and missed the realistic threat.** It
   refused only `role == "admin"`, but OIDC JIT provisioning always creates
   `role="user"` (hardcoded in `user_store.py`) — so an identity that
   squatted `agent-bootstrap@switch.local` on an older deployment, before
   this ever ran, would be silently adopted exactly as before, and could log
   in and manage every bootstrap-registered agent. The account this module
   creates is now stamped with a marker in its own `metadata_` at creation
   time; both `ensure_bootstrap_owner` (startup) and
   `resolve_registration_owner_id` (every bootstrap-token registration) now
   refuse to adopt an existing account that lacks it, regardless of role —
   this subsumes the admin-role case, which stays as a second, independent
   check (refined by round 4, below, to also accept a *genuine* pre-marker
   account rather than refusing it).
3. **Changing the revocation marker from a boolean to "last seeded hash"
   reopened the case the boolean covered.** Revoke at X (marker becomes
   `H(X)`), rotate to Y and restart (marker overwritten to `H(Y)`), rotate
   back to X and restart: the marker no longer remembers X was ever revoked,
   so the deployment silently starts serving the exact value the operator
   deliberately killed. A permanent list of every revoked hash is now kept
   instead of just the last one, and any of them is refused forever — as a
   fresh seed target and as a rotation target — no matter how many rotations
   happen in between.
4. **The startup refusal named a remedy that does not exist.** "Demote or
   remove it" implied a gateway action; there is no update-role or
   delete-user endpoint, and the gateway is down at startup regardless. Both
   messages now say plainly that the fix is a direct edit to the `users`
   table.
5. Four smaller ones, all fixed: a `get_by_type` lookup whose docstring
   asserted a system-wide singleton nothing enforced now raises if more than
   one row is ever found; a missing/malformed bootstrap owner surfaced as a
   bare 500 on the HTTP registration path with the reason only in the log
   (refined by round 4, below, to a generic 503); legacy migration skipped
   refreshing the encrypted blob, so a `JWT_SECRET_KEY` rotation alongside a
   migrated key would have broken the reveal button; and a test asserting
   only that *some* key existed after an admin-email change now asserts
   exactly one bootstrap key exists with the expected hash.

## Adversarial review, round 4

A third independent pass found that two of round 3's own fixes had gaps,
plus one that the round-2/3 admin-role tests weren't actually exercising,
plus three smaller issues:

1. **The marker check (round 3, point 2) bricked any database seeded by an
   earlier commit of this branch.** `_raise_unless_genuine` tested the
   marker before the role, so a bootstrap owner created by any earlier
   commit of this same feature has no marker, and the next boot refused to
   start — telling the operator (in practice: a reviewer, or whoever had
   already run the branch) the account "was not created by agent-
   registration bootstrap seeding", which is false. An unmarked row is now
   accepted, and backfilled with the marker, if it carries the
   last-seeded-hash key — a value only this module's own seeding step ever
   writes, so a squatter cannot have it, which is what makes "predates the
   marker" distinguishable from "put there by something else" without
   weakening the check.
2. **A retired stale key's hash was never added to the revoked list** — one
   line missing from the round-3 deletion loop. Reproduces, inside the code
   meant to prevent it, the exact bug the revoked-hashes list exists to
   close: delete the stale row at `H(old)`, then an operator restores an old
   `.env` or redeploys a stale values file setting the token back to `old`,
   and the rotation path accepts it because `H(old)` was never recorded (in
   testing, it instead crashed the boot on the `key_hash` unique constraint,
   colliding with the still-present retired row — worse, not better). Its
   hash is now added to the permanently-revoked list at the moment it is
   retired.
3. **Retiring a stale legacy key should retire it, not delete it (round 3,
   point 1).** The row must stop authenticating, but deletion isn't the
   minimal way to achieve that: every consumer already refuses any type
   outside `REGISTRATION_KEY_TYPES`, so retyping it to a new, excluded
   `"retired"` type 401s it exactly as deletion would. Deletion cost three
   things retyping doesn't: the API Keys page filters on type, so a retired
   row stays visible and hand-deletable where a deleted one leaves nothing
   but a startup log line; there is no `updated_at` and no audit table, so
   nothing else records a deleted row ever existed; and `get_by_label` is
   global while any authenticated user can create a registration key with a
   free-text label, so a colleague who happened to reuse the legacy label
   had their key destroyed at the next restart with no notification besides
   a log line the operator may never read. Because the two cases (a stale
   bootstrap key vs. a coincidentally-labeled personal key) still can't be
   told apart at seed time, the fix now preserves the evidence that lets a
   human tell them apart afterward: retype to `"retired"`, rewrite the label
   to say so, keep the warning, leave the row for the operator to review and
   delete themselves.
4. **Two tests exercising the admin-role squatter used an unmarked fixture**,
   so both actually hit the (separately tested) missing-marker check and
   never reached the role check — they passed only because `match="admin"`
   happened to match "admin authority" in the missing-marker message too.
   Both fixtures now carry the marker, so they exercise the role check they
   claim to, and match a message unique to it.
5. **The HTTP registration path returned the internal `RuntimeError` text
   verbatim** — the account name and the remediation procedure, and
   confirmation to a squatter that their squat was detected. It now logs the
   detail and returns a generic 503 (a misconfigured deployment, not a
   client error). The service-layer registration path
   (`register_agent_with_token`, used by server-side connectors) gets the
   same log-detail-return-generic treatment for consistency between the two
   registration surfaces.
6. Two smaller ones: the revoked-hashes metadata value was read with a bare
   `list(...)`, so a hand-edited non-list value (e.g. a string) would be
   silently iterated character-by-character into "nothing is revoked" —
   guarded with an `isinstance` check that raises instead; and the
   legacy-migration and stale-retirement logic are now scoped identically
   (both only run while no bootstrap key exists yet) rather than the
   deletion loop being reachable slightly more broadly than the migration
   check for no functional reason.

## Adversarial review, round 5

A fourth independent pass, focused on attacking the retention-vs-revocation
design from round 4, confirmed it holds — the revoked-hashes list lives on
the bootstrap owner's row rather than being derived from the key table, so
it survives both the retired row's own later deletion and the constraint
that happens to also guard the case where that row is still present — and
found three small gaps:

1. **No test covered the case with no constraint to fall back on.** There
   was a test for restoring the old token while the retired row is still
   present (blocked twice over: revoked-hashes, and the unique constraint on
   `key_hash`, since the retired row still holds the old value). There was
   none for deleting that retired row first — exactly what its own warning
   invites an operator to do — and *then* restoring the old token, the one
   path where the revoked-hashes list is the only thing standing in the way,
   with nothing left to collide with. Added.
2. **The missing-genuine-account message claimed more than it knows.** The
   backfill (round 4) rescues a database seeded by the third commit of this
   branch, because that commit wrote the last-seeded-hash to the bootstrap
   owner's own row. The first two commits wrote their state to the *admin's*
   row instead, so their bootstrap owner has no evidence on it and is
   correctly left unrescued — but the refusal said the account "was not
   created by agent-registration bootstrap seeding", which is not something
   this code can actually tell apart from "created by an earlier revision
   that recorded its state elsewhere." The message now names both
   possibilities instead of asserting the first as fact.
3. **`register_agent_with_token` reused `PermissionError` for a
   configuration fault.** A caller reasonably reads `PermissionError` as
   "bad token," so a server-side connector would report an authentication
   failure when the real cause is a misconfigured bootstrap owner. It now
   raises a dedicated `BootstrapOwnerMisconfiguredError`; the generic 503 on
   the HTTP registration path was already right and is unchanged.

Two smaller things worth calling out rather than changing here:

- Filing the bootstrap `ApiKey` under the admin (for visibility/revocation on
  the existing page) but attributing agents it registers to the bootstrap
  owner means a bootstrap-registered agent's *own* `"agent"`-type key is now
  filed under a login-less account. The admin can still delete the whole
  agent (and its key with it) from the Agents page, but can no longer reveal
  or delete just that key from the API Keys page the way they could when it
  was filed under their own account. This is a real, if narrow, behavior
  change from before this PR.
- The Registration Keys page shows no `type` column and no distinction
  between an ordinary key, the deployment bootstrap key, and a retired one.
  A retired key's rewritten label explains why it stopped working, which is
  adequate, but its Copy button still hands an operator a credential that no
  longer authenticates, and there's no visual cue that it's now safe to
  delete. A `type` column, or suppressing Copy for a non-`"registration"`
  type, would finish the job properly — frontend work, and belongs in its
  own change.

## Left for the tenant ticket (CHOO-2623)

- No `tenants` table or `tenant_id` column was added, per the ticket scope.
  `owner_id` (on `Agent`, `Room`, `Reference`, `Document`, `Package`) remains
  the scoping field; swapping it for a tenant id later is a single-column
  change plus updating `registration_bootstrap.py`'s one owner-resolution
  function, not a redesign.
- Agents **already registered** under the admin's real account before this
  fix retain admin-equivalent authority — this closes the vulnerability going
  forward, migrates or retires the credential, and now warns on every startup
  naming both the affected agents and any stale legacy key, but it can't
  safely distinguish "registered via the shared token" from "the admin's own
  legitimate agent" after the fact to auto-reassign existing rows. An
  operator who has shared the deployment token needs to reassign or
  re-register any agent named in that warning that shouldn't have admin
  authority.
- `docs/official/deploy/self-host.md` is generated from a separate docs repo
  (per this repo's `docs/README.md`) and still says the token is "what your
  colleagues' agents register against" implying admin ownership — that
  wording needs a follow-up fix at the source now that colleague-registered
  agents land on a dedicated non-admin account instead.
- The #397 not-linkable-list coordination described above.

## Testing

- `core/tests/switch_core/bridges/agent/test_registration_bootstrap.py` —
  the owner-resolution helper (registration vs. bootstrap vs. missing owner);
  the adversarial cases (an admin account, and separately a `role="user"`
  account, squatting the bootstrap owner's address; a bootstrap owner
  promoted to admin after the fact; a marker-less row backfilled rather than
  refused on the upgrade path).
- `core/tests/switch_core/test_main.py` — the seeding lifecycle: fresh
  install, idempotent rerun, legacy-key migration, a legacy-labeled key
  rotated before the upgrade (retired in place, still visible, no longer
  authenticates, and its old value can't be resurrected by restoring an old
  `.env`), a personal key sharing the legacy label but not its hash (retired
  and warned about, deliberately), revocation surviving a restart with the
  same token (including right after a legacy migration), rotation after
  revocation re-enabling the key, rotating *back* to a revoked value *not*
  reinstating it, the admin-owned-agents warning, a `role="user"` squatter at
  the bootstrap address blocking seeding (and, separately, an admin-role one
  that carries the marker so it actually exercises the role check), a
  marker-less-but-genuine row healed rather than refused, a malformed
  revoked-hashes value failing loud, deleting a retired key and then
  restoring its old value staying blocked with no unique-constraint backstop
  to lean on, and — the round-2 merge-blocking finding — an admin-email
  change neither crashing startup nor un-revoking a previously revoked key.
- `core/tests/switch_core/bridges/agent/protocol/test_register_with_token_bootstrap.py`
  — proves a bootstrap-token registration lands on the non-admin owner (not
  admin), that a personal registration key is unaffected, and that an agent
  key can no longer be replayed as a registration token.
- `core/tests/switch_core/bridges/agent/test_bearer_auth_registration_pass_through.py`
  — the bearer-middleware gate accepts both key types on ordinary paths and
  rejects both on `/mcp`.
- `core/tests/integration/test_registration_bootstrap_scope.py` — end-to-end
  through real Postgres: registering through `AGENT_REGISTRATION_TOKEN` (via
  the same seeding path `main.py` uses) never lands on the admin owner, and a
  bootstrap-owned agent is actually denied (`PermissionError` from
  `_require_room_action`) write access to a private room owned by the admin
  that an admin-owned agent can access — the real authorization decision this
  PR closes, not just an attribute check.
- Every new test in rounds 2 through 5 was checked against a regression: the
  fix it targets was reverted locally, the test was confirmed to fail
  (concretely, not just "some exception"), and the fix was restored.
- `just test` (2600 passed), `just typecheck`, and `just format` are clean.
  `just test-integration` passes aside from a pre-existing, unrelated flake
  in `test_agent_greeting_e2e.py` (room-join delivery timing under this
  sandbox's colima + testcontainers setup) reproduced on unmodified `main`.

No Alembic migration: `ApiKey.type` is a free-text column with no `CHECK`
constraint, so the new `"bootstrap"`/`"retired"` values need no schema change.

