### PR TITLE
fix(gateway): require GATEWAY_OIDC_SCOPES with openid, and stop a userinfo hiccup from 500ing

### DIFF
--- a/core/switch_core/config.py
+++ b/core/switch_core/config.py
@@ -38,11 +38,16 @@ class SwitchConfig(BaseSettings):
     # Gateway OIDC login (optional — bring-your-own identity provider for the
     # gateway browser login, e.g. Okta). Distinct from the agent oauth_*
     # settings above, which gate the MCP/agent bridge and may point at a
-    # different IdP. Active only when issuer + client id + secret are all
-    # set; the provider's endpoints are read from OIDC discovery.
+    # different IdP. Active only when issuer + client id + secret + scopes
+    # are all set; the provider's endpoints are read from OIDC discovery.
     gateway_oidc_issuer_url: str | None = None
     gateway_oidc_client_id: str | None = None
     gateway_oidc_client_secret: str | None = None
+    # Must include "openid": authlib omits the scope parameter entirely when
+    # this is unset, so the provider applies its own default scope, which may
+    # not include "openid" — the provider then issues no id_token, and the
+    # callback falls back to the provider's userinfo endpoint, which may not
+    # answer.
     gateway_oidc_scopes: str | None = None
     gateway_oidc_provider_label: str | None = None
     # Absolute callback URL registered with the IdP. Must exactly match the
@@ -208,13 +213,24 @@ class SwitchConfig(BaseSettings):
             self.gateway_oidc_issuer_url,
             self.gateway_oidc_client_id,
             self.gateway_oidc_client_secret,
+            self.gateway_oidc_scopes,
         )
         set_count = sum(1 for value in required if value)
         if 0 < set_count < len(required):
             raise ValueError(
                 "Partial gateway OIDC config: set all of "
                 "GATEWAY_OIDC_ISSUER_URL / GATEWAY_OIDC_CLIENT_ID / "
-                "GATEWAY_OIDC_CLIENT_SECRET, or none of them."
+                "GATEWAY_OIDC_CLIENT_SECRET / GATEWAY_OIDC_SCOPES, or none "
+                "of them."
+            )
+        if self.gateway_oidc_scopes and "openid" not in (
+            self.gateway_oidc_scopes.split()
+        ):
+            raise ValueError(
+                "GATEWAY_OIDC_SCOPES must include 'openid': without it the "
+                "provider issues no id_token, and the callback falls back "
+                "to the provider's userinfo endpoint, which may not answer. "
+                f"Got {self.gateway_oidc_scopes!r}."
             )
         return self
 

--- a/core/switch_core/gateway/oidc_routes.py
+++ b/core/switch_core/gateway/oidc_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Any
 
+import httpx
 from authlib.integrations.starlette_client import OAuth, OAuthError
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -89,7 +90,13 @@ async def oidc_callback(
 
     claims = token.get("userinfo")
     if not claims:
-        claims = await client.userinfo(token=token)
+        try:
+            claims = await client.userinfo(token=token)
+        except httpx.HTTPError as exc:
+            logger.error("OIDC userinfo request failed: %s", exc)
+            raise HTTPException(
+                status_code=502, detail="OIDC provider did not respond"
+            ) from exc
     email = claims.get("email")
     sub = claims.get("sub")
     if not email or not sub:

--- a/core/switch_core/gateway/oidc_routes.py
+++ b/core/switch_core/gateway/oidc_routes.py
@@ -95,21 +95,28 @@ async def oidc_callback(
             claims = await client.userinfo(token=token)
         except KeyError as exc:
             # authlib's userinfo() looks up metadata["userinfo_endpoint"],
-            # which OIDC discovery makes optional. A provider that omits it
-            # while also not returning an id_token leaves no way to read
-            # claims at all — a configuration mistake (the wrong issuer for
-            # this deployment), not a transient upstream fault, so retrying
-            # won't help. Not a 500: that's for something unanticipated, and
-            # this is diagnosed precisely enough to name.
+            # which OIDC discovery makes optional. We only reach this call
+            # because token["userinfo"] was falsy, which authlib sets only
+            # when both an id_token and the stored nonce were present — so
+            # that can mean no id_token came back, or one did but the nonce
+            # didn't match. Either way, a provider that also has no
+            # userinfo_endpoint leaves no way to read claims at all — a
+            # configuration mistake (the wrong issuer for this deployment),
+            # not a transient upstream fault, so retrying won't help. Not a
+            # 500: that's for something unanticipated, and this is diagnosed
+            # precisely enough to name.
             logger.error(
                 "OIDC callback failed: the provider published no "
-                "userinfo_endpoint and no id_token was returned, so there "
-                "is nowhere to read claims from (%s)",
+                "userinfo_endpoint and no claims were available from the "
+                "token, so there is nowhere to read claims from (%s)",
                 exc,
             )
             raise HTTPException(
                 status_code=503,
-                detail="OIDC provider has no userinfo endpoint and issued no id_token",
+                detail=(
+                    "OIDC provider has no userinfo endpoint and no claims "
+                    "were available from the token"
+                ),
             ) from exc
         except (httpx.HTTPError, json.JSONDecodeError) as exc:
             # A non-2xx response, a transport failure (timeout, connection

--- a/core/switch_core/gateway/oidc_routes.py
+++ b/core/switch_core/gateway/oidc_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Annotated, Any
 
@@ -92,7 +93,28 @@ async def oidc_callback(
     if not claims:
         try:
             claims = await client.userinfo(token=token)
-        except httpx.HTTPError as exc:
+        except KeyError as exc:
+            # authlib's userinfo() looks up metadata["userinfo_endpoint"],
+            # which OIDC discovery makes optional. A provider that omits it
+            # while also not returning an id_token leaves no way to read
+            # claims at all — a configuration mistake (the wrong issuer for
+            # this deployment), not a transient upstream fault, so retrying
+            # won't help.
+            logger.error(
+                "OIDC callback failed: the provider published no "
+                "userinfo_endpoint and no id_token was returned, so there "
+                "is nowhere to read claims from (%s)",
+                exc,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="OIDC provider has no userinfo endpoint and issued no id_token",
+            ) from exc
+        except (httpx.HTTPError, json.JSONDecodeError) as exc:
+            # A non-2xx response, a transport failure (timeout, connection
+            # refused), or a 200 whose body isn't JSON (a proxy or captive
+            # portal in front of the provider) — the provider's fault, not
+            # the caller's.
             logger.error("OIDC userinfo request failed: %s", exc)
             raise HTTPException(
                 status_code=502, detail="OIDC provider did not respond"

--- a/core/switch_core/gateway/oidc_routes.py
+++ b/core/switch_core/gateway/oidc_routes.py
@@ -99,7 +99,8 @@ async def oidc_callback(
             # while also not returning an id_token leaves no way to read
             # claims at all — a configuration mistake (the wrong issuer for
             # this deployment), not a transient upstream fault, so retrying
-            # won't help.
+            # won't help. Not a 500: that's for something unanticipated, and
+            # this is diagnosed precisely enough to name.
             logger.error(
                 "OIDC callback failed: the provider published no "
                 "userinfo_endpoint and no id_token was returned, so there "
@@ -107,7 +108,7 @@ async def oidc_callback(
                 exc,
             )
             raise HTTPException(
-                status_code=500,
+                status_code=503,
                 detail="OIDC provider has no userinfo endpoint and issued no id_token",
             ) from exc
         except (httpx.HTTPError, json.JSONDecodeError) as exc:

--- a/core/tests/switch_core/gateway/test_oidc_config.py
+++ b/core/tests/switch_core/gateway/test_oidc_config.py
@@ -27,6 +27,7 @@ def _kwargs(**overrides: object) -> dict[str, object]:
         gateway_oidc_issuer_url=None,
         gateway_oidc_client_id=None,
         gateway_oidc_client_secret=None,
+        gateway_oidc_scopes=None,
     )
     base.update(overrides)
     return base
@@ -41,12 +42,13 @@ class TestGatewayOidcConfig:
         # Opting out of the verified-email check must be deliberate.
         assert config.gateway_oidc_require_email_verified is True
 
-    def test_enabled_when_all_three_set(self) -> None:
+    def test_enabled_when_all_required_set(self) -> None:
         config = SwitchConfig(
             **_kwargs(
                 gateway_oidc_issuer_url="https://idp.example/realms/x",
                 gateway_oidc_client_id="cid",
                 gateway_oidc_client_secret="secret",
+                gateway_oidc_scopes="openid email profile",
             )  # type: ignore[arg-type]
         )
         assert config.gateway_oidc_enabled is True
@@ -55,11 +57,36 @@ class TestGatewayOidcConfig:
         )
 
     def test_partial_config_fails_loud(self) -> None:
-        # Issuer set but client id/secret missing must raise at construction,
-        # not silently disable OIDC.
+        # Issuer set but client id/secret/scopes missing must raise at
+        # construction, not silently disable OIDC.
         with pytest.raises(ValidationError):
             SwitchConfig(
                 **_kwargs(gateway_oidc_issuer_url="https://idp.example")  # type: ignore[arg-type]
+            )
+
+    def test_scopes_required_alongside_the_others(self) -> None:
+        # A deployment that set issuer/client id/secret but not scopes used to
+        # come up with OIDC "on" and authlib silently omitting the scope
+        # parameter, so the provider applied its own default (which may not
+        # include openid, or omit an id_token). Now it must fail to start.
+        with pytest.raises(ValidationError):
+            SwitchConfig(
+                **_kwargs(
+                    gateway_oidc_issuer_url="https://idp.example",
+                    gateway_oidc_client_id="cid",
+                    gateway_oidc_client_secret="secret",
+                )  # type: ignore[arg-type]
+            )
+
+    def test_scopes_must_include_openid(self) -> None:
+        with pytest.raises(ValidationError):
+            SwitchConfig(
+                **_kwargs(
+                    gateway_oidc_issuer_url="https://idp.example",
+                    gateway_oidc_client_id="cid",
+                    gateway_oidc_client_secret="secret",
+                    gateway_oidc_scopes="email profile",
+                )  # type: ignore[arg-type]
             )
 
 

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import httpx
@@ -451,6 +452,59 @@ class TestOidcCallback:
                     user_store=UserStore(),
                 )
             assert exc.value.status_code == 502
+
+    async def test_userinfo_non_json_response_maps_to_502(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A 200 whose body isn't JSON (a proxy or captive portal sitting in
+        # front of the provider) fails in resp.json(), not raise_for_status()
+        # — still the provider's fault, so still a 502.
+        monkeypatch.setattr(
+            oidc_routes,
+            "_client",
+            lambda: _FakeClientNoUserinfoInToken(
+                json.JSONDecodeError("Expecting value", "<html>not json</html>", 0)
+            ),
+        )
+
+        async with session_factory() as session:
+            with pytest.raises(HTTPException) as exc:
+                await oidc_routes.oidc_callback(
+                    request=SimpleNamespace(),  # type: ignore[arg-type]
+                    config=_config(),
+                    session=session,
+                    user_store=UserStore(),
+                )
+            assert exc.value.status_code == 502
+
+    async def test_missing_userinfo_endpoint_maps_to_500(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A provider whose discovery document has no userinfo_endpoint (it's
+        # optional in the OIDC spec — WorkOS's User Management surface is one
+        # such provider) combined with a token carrying no id_token leaves
+        # nowhere to read claims from. That's a configuration mistake for
+        # this deployment, not a transient upstream fault, so it must not be
+        # confused with the 502 cases above.
+        monkeypatch.setattr(
+            oidc_routes,
+            "_client",
+            lambda: _FakeClientNoUserinfoInToken(KeyError("userinfo_endpoint")),
+        )
+
+        async with session_factory() as session:
+            with pytest.raises(HTTPException) as exc:
+                await oidc_routes.oidc_callback(
+                    request=SimpleNamespace(),  # type: ignore[arg-type]
+                    config=_config(),
+                    session=session,
+                    user_store=UserStore(),
+                )
+            assert exc.value.status_code == 500
 
 
 class TestAuthConfigEndpoint:

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -452,6 +452,7 @@ class TestOidcCallback:
                     user_store=UserStore(),
                 )
             assert exc.value.status_code == 502
+            assert exc.value.detail == "OIDC provider did not respond"
 
     async def test_userinfo_non_json_response_maps_to_502(
         self,

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -479,7 +479,7 @@ class TestOidcCallback:
                 )
             assert exc.value.status_code == 502
 
-    async def test_missing_userinfo_endpoint_maps_to_500(
+    async def test_missing_userinfo_endpoint_maps_to_503(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         monkeypatch: pytest.MonkeyPatch,
@@ -488,8 +488,9 @@ class TestOidcCallback:
         # optional in the OIDC spec — WorkOS's User Management surface is one
         # such provider) combined with a token carrying no id_token leaves
         # nowhere to read claims from. That's a configuration mistake for
-        # this deployment, not a transient upstream fault, so it must not be
-        # confused with the 502 cases above.
+        # this deployment, not a transient upstream fault — 503, not 500,
+        # since it's diagnosed precisely enough to name rather than
+        # unanticipated, and not a 502 since the provider didn't misbehave.
         monkeypatch.setattr(
             oidc_routes,
             "_client",
@@ -504,7 +505,10 @@ class TestOidcCallback:
                     session=session,
                     user_store=UserStore(),
                 )
-            assert exc.value.status_code == 500
+            assert exc.value.status_code == 503
+            assert exc.value.detail == (
+                "OIDC provider has no userinfo endpoint and issued no id_token"
+            )
 
 
 class TestAuthConfigEndpoint:

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -478,6 +478,7 @@ class TestOidcCallback:
                     user_store=UserStore(),
                 )
             assert exc.value.status_code == 502
+            assert exc.value.detail == "OIDC provider did not respond"
 
     async def test_missing_userinfo_endpoint_maps_to_503(
         self,
@@ -486,10 +487,10 @@ class TestOidcCallback:
     ) -> None:
         # A provider whose discovery document has no userinfo_endpoint (it's
         # optional in the OIDC spec — WorkOS's User Management surface is one
-        # such provider) combined with a token carrying no id_token leaves
-        # nowhere to read claims from. That's a configuration mistake for
-        # this deployment, not a transient upstream fault — 503, not 500,
-        # since it's diagnosed precisely enough to name rather than
+        # such provider) combined with a token carrying no usable claims
+        # leaves nowhere to read claims from. That's a configuration mistake
+        # for this deployment, not a transient upstream fault — 503, not
+        # 500, since it's diagnosed precisely enough to name rather than
         # unanticipated, and not a 502 since the provider didn't misbehave.
         monkeypatch.setattr(
             oidc_routes,
@@ -507,7 +508,8 @@ class TestOidcCallback:
                 )
             assert exc.value.status_code == 503
             assert exc.value.detail == (
-                "OIDC provider has no userinfo endpoint and issued no id_token"
+                "OIDC provider has no userinfo endpoint and no claims were "
+                "available from the token"
             )
 
 

--- a/core/tests/switch_core/gateway/test_oidc_routes.py
+++ b/core/tests/switch_core/gateway/test_oidc_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -29,6 +30,7 @@ def _config(**overrides: object) -> SwitchConfig:
         gateway_oidc_issuer_url="https://idp.example",
         gateway_oidc_client_id="cid",
         gateway_oidc_client_secret="sec",
+        gateway_oidc_scopes="openid email profile",
     )
     base.update(overrides)
     return SwitchConfig(**base)  # type: ignore[arg-type]
@@ -42,6 +44,19 @@ class _FakeClient:
 
     async def authorize_access_token(self, _request: object) -> dict:
         return self._token
+
+
+class _FakeClientNoUserinfoInToken:
+    """A token with no embedded userinfo, forcing the userinfo HTTP call."""
+
+    def __init__(self, userinfo_error: Exception) -> None:
+        self._userinfo_error = userinfo_error
+
+    async def authorize_access_token(self, _request: object) -> dict:
+        return {"access_token": "at"}
+
+    async def userinfo(self, **_kwargs: object) -> dict:
+        raise self._userinfo_error
 
 
 class TestOidcCallback:
@@ -411,6 +426,32 @@ class TestOidcCallback:
                 )
             assert exc.value.status_code == 401
 
+    async def test_userinfo_upstream_failure_maps_to_502(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A token with no embedded userinfo forces the fallback HTTP call to
+        # the provider's userinfo endpoint; that call failing is the IdP's
+        # fault, not the caller's, and must not surface as an unhandled 500.
+        monkeypatch.setattr(
+            oidc_routes,
+            "_client",
+            lambda: _FakeClientNoUserinfoInToken(
+                httpx.ConnectError("connection refused")
+            ),
+        )
+
+        async with session_factory() as session:
+            with pytest.raises(HTTPException) as exc:
+                await oidc_routes.oidc_callback(
+                    request=SimpleNamespace(),  # type: ignore[arg-type]
+                    config=_config(),
+                    session=session,
+                    user_store=UserStore(),
+                )
+            assert exc.value.status_code == 502
+
 
 class TestAuthConfigEndpoint:
     async def test_reports_enabled_oidc_and_label(self) -> None:
@@ -425,6 +466,7 @@ class TestAuthConfigEndpoint:
             gateway_oidc_issuer_url=None,
             gateway_oidc_client_id=None,
             gateway_oidc_client_secret=None,
+            gateway_oidc_scopes=None,
             gateway_password_login_enabled=False,
         )
         result = await auth_config(config=config)

--- a/deploy/remote/helm/switch/templates/_helpers.tpl
+++ b/deploy/remote/helm/switch/templates/_helpers.tpl
@@ -267,8 +267,12 @@ Include with `nindent 12`.
     secretKeyRef:
       name: {{ include "switch.secretName" . }}
       key: GATEWAY_OIDC_CLIENT_SECRET
+{{- $oidcScopes := required "switchCore.oidc.scopes is required when oidc.enabled" .Values.switchCore.oidc.scopes }}
+{{- if not (has "openid" (regexSplit "\\s+" (trim $oidcScopes) -1)) }}
+{{- fail (printf "switchCore.oidc.scopes must include \"openid\" — without it the provider issues no id_token and the gateway falls back to a userinfo call it may not answer. Got %q." $oidcScopes) }}
+{{- end }}
 - name: GATEWAY_OIDC_SCOPES
-  value: {{ .Values.switchCore.oidc.scopes | quote }}
+  value: {{ $oidcScopes | quote }}
 - name: GATEWAY_OIDC_PROVIDER_LABEL
   value: {{ .Values.switchCore.oidc.providerLabel | quote }}
 {{- if .Values.switchCore.oidc.redirectUrl }}


### PR DESCRIPTION
## Stacking note

Stacked on #397 (`work/multi-tenancy-phase2`, currently green): this
branch is based on that branch's tip, not `main`, and its base is set
accordingly. Do not merge before #397. Review this diff against
`work/multi-tenancy-phase2`, not against `main` — a diff against `main`
will also show #397's changes.

Both files this PR touches (`config.py`, `oidc_routes.py`) are also
touched by #397. Nothing belonging to #397 was modified here; its
`_validate_gateway_oidc`, callback error handling (the `OidcIdentityRaceError`
→ 503 branch in particular) and tests were read and built on as-is.

## Fix 1 — `GATEWAY_OIDC_SCOPES` is now required, and must include `openid`

`register_oidc_client` passes `client_kwargs={"scope": config.gateway_oidc_scopes}`.
With `authlib==1.7.2`, when this is unset authlib omits the `scope`
parameter from the authorization request entirely, so the provider applies
whatever default scope it likes. Two silent failure modes follow: without
`openid` in the granted scope the provider issues no `id_token`, and the
callback falls through to the provider's `userinfo` endpoint, which may or
may not answer. A single malformed line in an env file can drop just this
one variable while leaving OIDC looking enabled and the deployment healthy.

`GATEWAY_OIDC_SCOPES` now joins the existing all-or-nothing group in
`_validate_gateway_oidc` (issuer / client id / client secret), and a value
that doesn't include `openid` is rejected outright.

**This is a breaking change** for any deployment that turned on gateway
OIDC login without setting `GATEWAY_OIDC_SCOPES`: it will now fail to
start. The fix is to set `GATEWAY_OIDC_SCOPES` to a value that includes
`openid`, e.g. `"openid email profile"`.

Blast radius, checked directly:
- Neither `deploy/local/docker-compose.yml` nor
  `deploy/local/standalone-docker-compose.yml` plumbs *any* `GATEWAY_OIDC_*`
  variable — gateway OIDC login isn't wired up for local dev at all, so
  there's nothing to update there.
- `.env.example`'s `OIDC` section documents the unrelated `OAUTH_*` MCP
  auth variables, not `GATEWAY_OIDC_*`; no existing example needed updating.
- The Helm chart (`deploy/remote/helm/switch/templates/_helpers.tpl`) already
  renders `GATEWAY_OIDC_SCOPES` whenever `switchCore.oidc.enabled`, and
  `values.yaml` already defaults `switchCore.oidc.scopes` to
  `"openid profile email"`. A chart-managed deployment on the default is
  unaffected; only one that explicitly overrode `scopes` to something
  without `openid` (or to empty) is affected, and:
- The chart's own validation now covers it. `switchCore.oidc.scopes` gets
  the same `required "... is required when oidc.enabled"` treatment as
  `issuerUrl` and `clientId`, plus a `fail` if it doesn't include `openid`
  — verified with `helm lint` and `helm template` (both the happy path and
  the two failure paths render/fail as expected; commands in the review
  notes below).

## Fix 2 — a userinfo-endpoint hiccup no longer 500s the callback

`oidc_callback` only wraps `authorize_access_token` in
`try/except OAuthError`. When the token carries no `userinfo` claims it
falls back to `await client.userinfo(token=token)` — `authlib`'s
`StarletteOAuth2App.userinfo` does `resp = await self.get(...)` then
`resp.raise_for_status()`, so a non-2xx response raises
`httpx.HTTPStatusError`, and a network-level failure (timeout, connection
refused) raises another `httpx.HTTPError` subclass. Neither was caught, so
either reached the browser as an unhandled 500 with a stack trace at the
end of a sign-in redirect.

Now caught as `httpx.HTTPError` (covers both cases), logged with
`logger.error` — the exception's message carries the endpoint and HTTP
status, never the token or any secret — and turned into a `502`.

**Status code reasoning:** the userinfo endpoint is an upstream dependency
outside the gateway's control, and its failure is the provider's fault,
not the caller's — the same reasoning already applied a few lines below
this change, where `OidcIdentityRaceError` (this branch's own database
contention) maps to `503`. I chose `502` rather than reusing `503` because
the two failures are semantically different and worth telling apart in
logs/alerts: `503` here would mean "Switch itself can't handle this right
now," while `502` means "Switch tried to reach the identity provider and
that failed" — a `Bad Gateway` in the literal RFC 7231 sense (a server
acting as a gateway got an invalid response from an upstream server).

**Two more failure modes in the same call, added after the first review
pass:** `httpx.HTTPError` doesn't cover everything `authlib`'s
`userinfo()` can raise there.

- `resp.json()` runs after `raise_for_status()` passes, and raises
  `json.JSONDecodeError` (a `ValueError`, not an `httpx.HTTPError`) on a
  200 whose body isn't JSON — e.g. a proxy or captive portal sitting in
  front of the provider. Same fault as the two cases above (the provider,
  or something posing as it, misbehaved), so it's caught alongside
  `httpx.HTTPError` and mapped to the same `502`.
- `metadata["userinfo_endpoint"]` is a plain dict lookup, and that field
  is optional in OIDC discovery — a provider that doesn't publish one
  raises `KeyError`, again not an `httpx.HTTPError`. Reaching this line
  means `token["userinfo"]` was falsy (the `if not claims:` above), which
  `authlib` only sets when *both* an `id_token` and the stored nonce are
  present — so it can mean no `id_token` came back at all, or one did but
  the nonce didn't match what was stored. Either way, a provider that
  also has no `userinfo_endpoint` leaves nowhere to read claims from at
  all — the message below says exactly that and no more, so it stays
  true in both cases (a first draft asserted "no id_token was issued"
  specifically, which a review pass caught as false in the nonce-mismatch
  case).

  I treated this one as a **configuration fault, not an upstream one**,
  and gave it its own status rather than folding it into the `502`s: the
  provider isn't misbehaving — omitting `userinfo_endpoint` is
  spec-legal — so calling it a bad *response* would be inaccurate, and
  unlike a transient network hiccup, retrying changes nothing. Reaching
  it at all means the issuer for this deployment can't complete a login
  under the assumptions this callback makes, which is a Switch-side
  configuration problem (wrong `GATEWAY_OIDC_ISSUER_URL`, or a provider
  surface that was never going to work).

  It's `503`, not `500` (an earlier revision of this PR used `500`; a
  review pass pushed back and I agreed). `500` would put the same signal
  on the wire this PR exists to remove — an unhandled `500` and a
  deliberate one are indistinguishable to monitoring, and this would page
  someone for a settings mistake, not a crash. A fault diagnosed
  precisely enough to name in the message is by definition not a `500`;
  that status should keep meaning "we did not anticipate this." `503`
  also matches how the sibling agent-registration fix on this same
  multi-tenancy work
  (`work/multi-tenancy-phase2-agent-reg`, commit `94cfe7a4`'s follow-up)
  already treats a misconfigured deployment on its own registration
  path — a plain `503` with the diagnostic detail in the logs — so a
  login this deployment cannot currently complete as configured gets one
  answer, whether the cause is database contention
  (`OidcIdentityRaceError`, a few lines below) or a provider with
  nowhere to read claims from, instead of two. The set this callback now
  returns reads coherently end to end: `401` failed authentication,
  `409` identity conflict, `502` a provider that answered badly or not
  at all, `503` a deployment that cannot complete a login as configured.

  The message names the cause directly — "OIDC provider has no userinfo
  endpoint and no claims were available from the token" — rather than a
  generic upstream-failure or contention message, because this is the
  single easiest wrong turn when standing up gateway OIDC: WorkOS's User
  Management surface, for one, publishes an OIDC-shaped discovery
  document with no `userinfo_endpoint` at all, so pointing the issuer at
  it hits exactly this path.

**Explicitly not fixed, noted as a follow-up:** every failure path on this
callback (the ones already here, and the one added by this PR) returns a
raw FastAPI JSON error body to what is always a browser mid-redirect,
because there's no exception handler registered and the frontend handles
none of them. The right fix is a redirect back to the login page carrying
an error, applied uniformly to every failure path on this callback rather
than just the new one — but that touches the gateway SPA and is out of
scope here.

## Testing

`core/tests/switch_core/gateway/test_oidc_config.py`:
- `test_enabled_when_all_required_set` (renamed from `..._all_three_set`,
  now also sets scopes)
- `test_scopes_required_alongside_the_others` (new: issuer/client id/secret
  set, scopes unset → `ValidationError`)
- `test_scopes_must_include_openid` (new: all four set but scopes lacks
  `openid` → `ValidationError`)

`core/tests/switch_core/gateway/test_oidc_routes.py`:
- `_config()` now includes `gateway_oidc_scopes` so the fixture keeps
  constructing a valid config
- `test_userinfo_upstream_failure_maps_to_502` (new: a token with no
  embedded userinfo forces the fallback HTTP call; a `_FakeClientNoUserinfoInToken`
  raises `httpx.ConnectError` from `userinfo()`, and the callback is
  asserted to raise a 502 rather than propagate)
- `test_userinfo_non_json_response_maps_to_502` (new: `userinfo()` raises
  `json.JSONDecodeError` → 502, asserts both status and detail)
- `test_missing_userinfo_endpoint_maps_to_503` (new: `userinfo()` raises
  `KeyError("userinfo_endpoint")` → 503, distinct from the 502s above,
  asserts both status and detail)

All three new callback tests were confirmed to fail (as an unhandled
exception, not a clean `HTTPException`) against the callback before this
PR's exception handling was added.

One known gap left as-is: `test_userinfo_upstream_failure_maps_to_502`
(the first of the three, `httpx.ConnectError`) still asserts only the
status, not the detail, same class of gap review caught on its neighbor.
Flagging rather than fixing since it wasn't part of what was asked for
this round — happy to add it as a one-line follow-up if wanted.

Ran `just format`, `just typecheck`, and `just test` (full suite, plus a
targeted `-k oidc` run) from the worktree root — all pass. Testcontainers
needs `DOCKER_HOST` pointed at the local Docker socket and
`TESTCONTAINERS_RYUK_DISABLED=true` in this environment; unrelated to the
change.

For the Helm chart, installed `helm` and ran `helm lint` /
`helm template` against `deploy/remote/helm/switch` with the default
scopes (passes), an empty override (fails at render time with a clear
message), and an override missing `openid` (same).

## Not in scope

- The frontend-redirect-on-error follow-up noted above.
- Nothing in #397 was touched or re-derived.
- **No CHANGELOG entry.** This PR deliberately does not add an `[Unreleased]`
  entry for the breaking `GATEWAY_OIDC_SCOPES` change or the 502 fix —
  releasing, and writing the changelog for a release, is someone else's job.
  Whoever cuts the next switch-core release should add an entry covering
  both; the breaking-change explanation and remedy are above in this PR
  body in the meantime.



