### PR TITLE
perf(rooms): index rooms.group_id

### DIFF
--- a/core/switch_core/db/models.py
+++ b/core/switch_core/db/models.py
@@ -258,6 +258,10 @@ class Room(Base):
             unique=True,
             postgresql_where=text("external_channel_id IS NOT NULL"),
         ),
+        # group_id is a foreign key with no index, so listing rooms by group
+        # and the ON DELETE SET NULL when a group is removed both scan the
+        # table. Mirrors ix_agents_parent_agent_id.
+        Index("ix_rooms_group_id", "group_id"),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)

--- a/core/switch_core/migrations/versions/a1c7e2f9b430_index_rooms_group_id.py
+++ b/core/switch_core/migrations/versions/a1c7e2f9b430_index_rooms_group_id.py
@@ -1,0 +1,29 @@
+"""index rooms.group_id
+
+group_id is a foreign key with no index, so listing rooms by group and the
+ON DELETE SET NULL when a group is removed both scan the rooms table. Mirrors
+ix_agents_parent_agent_id.
+
+Revision ID: a1c7e2f9b430
+Revises: c8e4a10b7f36
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1c7e2f9b430"
+down_revision: str | None = "c8e4a10b7f36"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_rooms_group_id", "rooms", ["group_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_rooms_group_id", table_name="rooms")


### PR DESCRIPTION
## Summary

- `rooms.group_id` is a foreign key with no index. Listing rooms by group, and the `ON DELETE SET NULL` when a group is removed, both scan the rooms table.
- Adds `ix_rooms_group_id`, the same treatment `agents.parent_agent_id` already gets.
- Model change plus a one-line Alembic migration; downgrade drops the index. Verified the full chain applies against Postgres and the index is created.

Noticed while working on group templates. When tenant scoping this may want to become `(tenant_id, group_id)`.