### PR TITLE
docs: hosted agents design spike

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,8 @@ site presents them.
 ## `old/`
 
 Design and operator material written for this repository: the architecture
-overview, the agent protocol, and per-bridge setup guides. None of it is
+overview, the agent protocol, per-bridge setup guides, and design spikes for
+work that has not been built. A spike says so in its first line. None of it is
 published, and none of it is covered by the pages under `official/` — where the
 two describe the same thing, this is the deeper account and the published page is
 the one users act on.

--- a/docs/old/hosted-agents.md
+++ b/docs/old/hosted-agents.md
@@ -19,6 +19,11 @@ agent with nothing installed. It is an argument rather than an agreed plan, and
 The deliverable is the design, the order of work, and the questions still open.
 No code was written.
 
+It refers throughout to the multi-tenancy design spike, which is
+`docs/old/multi-tenancy.md` — **in flight on an unmerged branch**, so it is not
+on `main` and a reader of this document may not be able to open it yet. Where
+this document quotes it, the quote is reproduced in full for that reason.
+
 ---
 
 ## 1. Where we are today
@@ -34,13 +39,14 @@ addressed to it, spawns the agent CLI under `tmux`, types prompts into the
 running terminal UI, and keeps a session registry on disk that it reconciles
 against live `tmux` panes when it restarts.
 
-It needs Node 20, `tmux` and `git`, and nothing else. The build script *enforces*
-that: a custom esbuild resolver fails the build if Electron, the local SQLite
-database or the ORM are ever pulled in transitively. The sidecar cannot acquire
-a desktop dependency by accident.
+It needs `tmux`, `git`, and Node 18 or newer — the preflight's floor, though the
+build targets Node 20, now past end of life, so a new image should pin 22 or 24.
+Nothing else, and the build script enforces it: a custom esbuild resolver fails
+the build if Electron, the local database or the ORM are pulled in transitively,
+so the sidecar cannot acquire a desktop dependency by accident.
 
-It also touches SSH nowhere. SSH is how Switch Console *delivers* it, and the
-seam between the two is two methods:
+It contains no SSH code — only comments mentioning it. SSH is how Switch Console
+*delivers* it, and the seam between the two is two methods:
 
 ```ts
 export interface SidecarHost {
@@ -53,56 +59,43 @@ One implementation exists, over SSH. Anything that can run a command and put a
 file can host the sidecar.
 
 `AgentLaunchSpec` (`src/sidecar/agent-launch-spec.ts`) is the other half: a
-plain-JSON launch recipe — command, args, env, cwd, optional files to write into
-the home directory, provider id, and two behaviour flags — round-tripped through
-base64 and `JSON.parse`. It exists precisely so a headless watcher with no plugin
-registry never has to call back into desktop code to work out how to start an
-agent. It is already the interface a control plane would want.
+plain-JSON launch recipe — command, args, env, cwd, optional home-directory
+files, provider id and two behaviour flags — that exists precisely so a headless
+watcher with no plugin registry never has to call back into desktop code to work
+out how to start an agent. It is already the interface a control plane would
+want.
 
 Put that bundle in an image and the runtime problem is mostly solved.
 
 ### What assumes a human owns the box
 
-The parts around it assume ownership, and would be discarded rather than ported:
+Everything around the sidecar does. A host is an entry in the user's own
+`~/.ssh/config` and nothing else — `listSshConfigHosts()` is the whole of host
+onboarding, and its comment notes that Switch Console stores no credentials, so
+there is nothing a server could enumerate. The deployer imports `electron` and
+resolves the bundle out of `process.resourcesPath`, so the desktop app is the
+only thing that can deploy it. Setup is deliberately manual: *"There is
+deliberately no run-the-whole-plan loop — the ordering in a plan is guidance for
+a person, not a script."* And a deploy lock, a bundle-hash dedupe, log trimming
+and reattach logic all exist because the box outlives the client and is shared
+between installs — none of which is true of a machine we create per agent.
+§4 lists what that means for the port.
 
-- **A host is an entry in the user's own SSH config.** `listSshConfigHosts()`
-  parses `~/.ssh/config` and that is the whole of host onboarding. Its own
-  comment says authentication "resolves from the SSH config/agent (Switch
-  Console stores no credentials)". There is no host record, no inventory, and
-  nothing a server could enumerate.
-- **The deployer is an Electron app.** `resolveSidecarBundlePath()` imports
-  `electron` and resolves the bundle out of `process.resourcesPath`. The bundle
-  ships as an app resource, so the app is the only thing that can deploy it.
-- **Setup is deliberately interactive.** From the setup runner's own docstring:
-  *"There is deliberately no run-the-whole-plan loop — the ordering in a plan is
-  guidance for a person, not a script."* That is right for a machine a person
-  owns and exactly wrong for provisioning.
-- **A deploy lock, bundle-hash dedupe, log trimming and reattach logic.** An
-  atomic-`mkdir` mutex with a two-minute staleness break; a hash compare that
-  skips the upload when an identical bundle is already there; an 8 MB log
-  trimmed to 1 MB on relaunch; and `decideExisting()`, which reattaches to a
-  running sidecar rather than replacing it and defers a major upgrade while
-  sessions are live. All of it exists because the box outlives the client and is
-  shared between installs. A sandbox we create per agent has one client, one
-  bundle, one lifetime, and needs none of it.
-- **Model credentials are assumed to be already there.** The remote preflight
-  checks `tmux`, `node`, `git`, the Switch credentials and Switch reachability.
-  It never checks for a model credential, and the launch spec's `env` is built
-  from the provider plugin and Switch Console's own settings — the desktop's
-  `ANTHROPIC_API_KEY` is forwarded only to *local* terminal sessions. A remote
-  session works because a person logged the CLI in on that host by hand. Nothing
-  provisions it and nothing notices it is missing.
-
-That last one is not a rough edge. It is the whole of §6.
+One of them is not a rough edge but the whole of §6. **Model credentials are
+assumed to be already there.** The remote preflight checks `tmux`, `node`,
+`git`, the Switch credentials and Switch reachability, and never checks for a
+model credential; the launch spec's `env` comes from the provider plugin and
+Switch Console's settings, and the desktop's own `ANTHROPIC_API_KEY` is
+forwarded to *local* terminal sessions only. A remote session works because a
+person logged the CLI in on that host by hand. Nothing provisions it and nothing
+notices it is missing.
 
 ### The watcher is on the wrong side
 
 The thing that notices "someone addressed an agent that has no live session" is
-`NotificationWatcher`, and it runs inside the sidecar. It opens a stream with
-`scope: 'all', filter: 'addressed', spawnCapable: true`, and on an addressed
-event it takes a per-room in-flight guard, asks whether a session is already
-attending, and spawns one if not — three attempts, two seconds apart, posting a
-failure notice into the room if it never comes up.
+`NotificationWatcher`, and it runs inside the sidecar: a stream opened with
+`scope: 'all', filter: 'addressed', spawnCapable: true`, a per-room in-flight
+guard, and a spawn if nothing is already attending.
 
 That is a good design for a machine that is already running. It is circular for
 hosting: if the sidecar does not exist yet, nothing is listening.
@@ -111,9 +104,12 @@ The server knows this and says so. `connection_model` is one of `always_on`,
 `session_addressable`, `session_passive`, `auto_session`, and for an
 `auto_session` agent with a watcher connected the server posts *"Starting a
 session to handle this — one moment."* on the agent's behalf and waits. With no
-watcher connected it posts an offline message whose text tells the room that the
-agent "is brought online by Switch Console watching on its owner's machine" and
-that "the fix is for the OWNER to open it, and nobody else in the room can act."
+watcher connected, what the room actually gets is *"@owner — I'm not online in
+this room, and @asker needs me. Open Switch Console to bring me online here."*
+The reasoning behind that wording is in the function's docstring rather than in
+the room: an `auto_session` agent "is brought online by Switch Console watching
+on its owner's machine", so "the fix is for the OWNER to open it, and nobody else
+in the room can act."
 
 The model is already there. Only the actor is missing.
 
@@ -137,11 +133,12 @@ There is nowhere for a hosted customer to talk to their agent.
 
 The gateway API has thirteen routers and none of them read or post messages;
 `rooms.py` has twenty-two routes covering roles, groups, protection, membership
-and archiving, and not one of them touches the conversation. Reading and writing
-messages exists only on the agent-facing bridge — `read_context`, `post_message`,
-`send_targeted_message`, `send_attachment`. The operator dashboard has no message
-list and no composer; a search for a conversation view finds only `err.message`
-in error dialogs.
+and archiving, and not one touches the conversation. The only *API* for reading
+and writing messages is the agent-facing one — `read_context`, `post_message`,
+`send_targeted_message`, `send_attachment` — though the collaboration bridge
+moves the same rows on behalf of humans in Slack and the rest. What does not
+exist is a surface a person can point a browser at: the dashboard has no message
+list and no composer.
 
 Every human conversation in Switch today therefore goes through a collaboration
 bridge, and every bridge is an admin-created row with an operator-pasted
@@ -154,10 +151,10 @@ running."
 
 ### The security posture is a policy plane with no enforcement plane
 
-Covered in §8. In short: nothing in this repository sandboxes, restricts or
-limits an agent session today, because the machine belongs to the person running
-it and the operating system is the boundary. Hosting removes that boundary and
-supplies nothing in its place.
+Nothing in this repository sandboxes, restricts or limits an agent session today,
+because the machine belongs to the person running it and the operating system is
+the boundary. Hosting removes that boundary and supplies nothing in its place.
+§8 has the detail.
 
 ---
 
@@ -188,200 +185,188 @@ have different working directories and different credentials. A per-conversation
 sandbox throws away the working directory every time a conversation ends, which
 is exactly what the sidecar's durable session registry exists to avoid.
 
-An agent is also the unit the product already talks about: it has a name, a
-working directory, a provider and a set of rooms.
+A *machine*, though, is shorter-lived than an agent. Under the recommendation
+below it is destroyed when the agent goes idle and started again when it is next
+addressed, so the agent's durable state has to outlive its machine rather than
+live inside it. That is the hardest consequence of the recommendation and it is
+worked through under cold start.
 
-A *machine*, though, is a shorter-lived thing than an agent. Under the
-recommendation below a machine is destroyed when the agent goes idle and started
-again when it is next addressed, so the agent's durable state has to outlive its
-machine rather than living inside it. That is the thing to get right, and it is
-why the persistent-volume question in the cold-start discussion is load-bearing
-rather than an optimisation.
-
-### The shape: a microVM, not a container
-
-A sandbox here means a **microVM** — a real virtual machine with its own kernel,
-booted by Firecracker — not a container sharing the host kernel. That distinction
-is the entire security argument. We are running a stranger's coding agent, which
-means a stranger's shell, and a shared kernel is the wrong boundary for that.
-State it explicitly wherever this design is summarised, because "sandbox" is used
-loosely enough elsewhere to mean a container with a seccomp profile.
+The machine is a **microVM** — its own kernel — not a container sharing the
+host's. That distinction is the entire security argument: we are running a
+stranger's coding agent, which means a stranger's shell, and a shared kernel is
+the wrong boundary for that. Worth saying explicitly wherever this is summarised,
+because "sandbox" elsewhere often means a container with a seccomp profile.
 
 ### The recommendation: ECS Fargate
 
-Stay on AWS. **AWS Fargate already gives per-task microVM isolation** — in AWS's
-own words, each task has its own isolation boundary and does not share the
-underlying kernel, CPU, memory or network interface with another task. Tasks run
-on Firecracker microVMs, the same primitive the specialist agent-sandbox vendors
-sell, each with its own elastic network interface in our VPC and its own IAM task
-role.
+Stay on AWS. In AWS's own words, each Fargate task **"has its own isolation
+boundary and does not share the underlying kernel, CPU resources, memory
+resources, or elastic network interface with another task"** — which is the
+property §3 needs, stated by the vendor, and it does all the work on its own.
+Each task also gets its own elastic network interface in our VPC and its own IAM
+task role.
 
-That combination is what makes it the right answer rather than merely an
-acceptable one. We get the isolation boundary without operating a cluster and
-without the hardening our existing cluster would need; the network interface
-lands in a VPC we already control, so egress policy is a security group rather
-than a feature request; the task role is a real credential boundary rather than a
-convention; and because it runs in our own account and region, the data-residency
-question that would have decided against at least one specialist provider does
-not arise.
+Which gets us the isolation boundary without operating a cluster; egress policy
+as a security group rather than a feature request; a real credential boundary
+rather than a convention; and, because it is our own account and region, no new
+subprocessor and a residency answer that follows from the account.
 
 **ECS Fargate, not EKS Fargate.** EKS on Fargate has neither ARM nor spot
 pricing, and it puts back the Kubernetes cluster the whole point was to avoid.
 
 **And not our own existing cluster.** Per-session pods there are the right
-long-term shape in the abstract — we already run Kubernetes and it removes a
-dependency — but that cluster has no network policy, no resource limits and no
-pod isolation; node cloud credentials are reachable; the database holding every
-room's messages is one connection away in the same namespace; there are roughly
-six spare cores, no autoscaler, and the Kubernetes version is out of standard
-support with a forced upgrade ahead. Putting a stranger's shell in that namespace
-is not a decision about hosting, it is a decision about the database.
+long-term shape in the abstract, but that cluster is not hardened for untrusted
+workloads and shares a namespace with the database holding every room's messages.
+Putting a stranger's shell there is a decision about the database, not a decision
+about hosting.
 
-Sources: `docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html`
-and `aws.amazon.com/fargate/pricing/`.
+Source: `docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html`.
 
 ### Cold start is the central engineering risk
 
-AWS's own guidance is that a new Fargate task normally takes **thirty to
-forty-five seconds or longer** to start, and practitioner reports range much wider
-depending on image size. The billing clock starts when the image pull begins, not
-when the container is healthy. Both figures come from AWS's task-startup guidance
-rather than from our own measurement — which is why phase 0 measures it before
-anything is built on top of it.
+AWS's task-startup guidance puts a new Fargate task at **thirty to forty-five
+seconds or longer**, and practitioner reports range wider depending on image
+size. The billing clock starts when the image pull begins, not when the container
+is healthy. Both are AWS's figures rather than our measurements, which is why
+phase 0 measures them before anything is built on top.
 
-Set that against the trigger this whole design exists to serve: somebody
-addresses an agent in a chat window and waits for it to answer. Forty-five
-seconds of nothing is the difference between a product that feels alive and one
-that feels broken. This is the central risk of the recommendation and it should
-be treated as such, not as a tuning detail discovered in phase 2.
+Set that against the trigger this design exists to serve: somebody addresses an
+agent in a chat window and waits. Forty-five seconds of silence is the difference
+between a product that feels alive and one that feels broken.
 
-Three mitigations genuinely help, in ascending order of effort:
+Three mitigations, in ascending order of effort:
 
 - **An aggressively small image.** Node, `tmux`, `git`, the sidecar bundle and
   one agent CLI. Every megabyte is pull time on the critical path.
-- **Seekable OCI lazy image loading**, which AWS reports as the single
-  highest-return optimisation available here, at over fifty per cent. That is
-  AWS's number for its own workloads, not ours.
+- **Seekable OCI lazy image loading**, which AWS reports as the highest-return
+  optimisation available here at over fifty per cent — its number for its own
+  workloads, not ours.
 - **A small pre-warmed pool** rather than scaling to zero.
 
-The pool deserves a caveat, because it is easy to over-claim. A warm pool answers
-"how long until a container exists". It does not answer "how long until *this
-agent's* session is ready" — that needs the agent's working directory, its
-credentials and its CLI state, which is a per-agent restore on top. Total wake
-latency is pool-assign plus agent-restore, and only the first half is what a pool
-buys. Whether a pooled task can mount a per-agent persistent volume fast enough
-to make the second half cheap is unverified and is an open question below.
+**The pool buys less than it looks like, and permanently.** A Fargate task takes
+its volume configuration at launch and cannot attach an existing volume
+afterwards. So a pooled task can be waiting, but it cannot then adopt a specific
+agent's disk — which means a pool removes the infrastructure half of wake latency
+and nothing else, by construction rather than pending a workaround.
+
+That has a consequence the rest of this design has to carry: **durable per-agent
+state cannot live in the task.** It is either a filesystem mounted at launch — so
+the task is created for one agent and the pool is a pool of *unassigned* tasks
+that can never be reassigned — or a restore from object storage after the task
+starts. Neither is free and neither is currently anywhere in the design. The
+honest remaining question is not whether a pool can adopt state, which is settled
+and negative, but **how long a restore takes**, which nobody has measured.
 
 ### The honest trade against the specialists
 
-Three vendors were considered and rejected, and the reasoning is worth keeping
-because it is the reasoning that would reverse the decision if the risk above
-turns out to be fatal.
+Two vendors were evaluated and rejected; a third was not evaluated at all.
 
-- **Fly Sprites** — persistent Firecracker VMs with root and a durable root
-  filesystem, created in a second or two, with automatic sleep when idle. Three
-  billing states of which only *running* is billed. Roughly $0.07 per CPU-hour
-  and $0.04375 per GB-hour. Live checkpoint in around 300 ms and restore well
-  under a second. Coding agents are the advertised target workload.
+- **Fly Sprites** — persistent VMs with root and a durable root filesystem,
+  created in a second or two, with automatic sleep when idle. Three billing
+  states, of which only *running* is billed. Roughly $0.07 per CPU-hour and
+  $0.04375 per GB-hour. Live checkpoint in around 300 ms and restore well under a
+  second. Coding agents are the advertised target workload.
 - **E2B** — the one most widely used by other agent products. $0.000014 per
   vCPU-second and $0.0000045 per GiB-second. Session length is capped by plan
   tier: one hour on the entry tier, twenty-four hours above it.
-- **Northflank** — the only one of the three that runs in our own cloud account,
-  which is the answer if a customer says their code may not leave infrastructure
-  we control. Fargate answers that too, and more directly.
+- **Northflank** — **not evaluated.** It is the one option that would run in our
+  own cloud account, but nobody has established its price, its restore latency or
+  whether it pauses at all, so it is named here only so that it is not silently
+  dropped. It belongs in the phase 0 measurement, not in this comparison.
 
 **What we give up is pause.** The specialists snapshot and restore a paused
 machine in well under a second and charge nothing while it sleeps. Fargate has no
-pause: an idle session is either destroyed and rebuilt slowly, or kept warm and
-paid for. There is no third state. That is the real cost of staying on AWS, and
-it is paid in exactly the dimension — wake latency for a mostly-idle agent — that
-this product cares most about.
+third state: a session is running and billed, or gone.
 
-Two things blunt it. Fargate is cheaper per running hour than either specialist,
-so keeping something warm is less punitive than it sounds. And **destroying a
-session loses the agent CLI's in-memory context regardless of provider** — a
-restored microVM gives you back a `tmux` pane with a process in it whose sockets
-are dead, which is not the same as a session that can carry on. Session
-resumption is a design question in its own right, not something a hosting choice
-solves. The specialists' sub-second restore is a real advantage over cold start,
-but it is a smaller advantage than it first appears.
+### The numbers, including the case where we lose
 
-There was also a residency problem on at least one of them: Fly's Sprites do not
-appear to expose region selection, and their own community forum has a user in
-Germany finding their machine in France, apparently routed to a nearby point of
-presence rather than a chosen region. For a European company selling to European
-customers that is close to disqualifying on its own. Sources: `fly.io/sprites`,
-`e2b.dev/pricing`, and the Fly community thread at
+Estimates throughout, with the assumptions stated.
+
+Per *running* hour, for a 2 vCPU / 4 GB shape, Fargate is cheapest. Its published
+`us-east-1` rates are about $0.04 per vCPU-hour and $0.0044 per GB-hour, giving
+`2 × $0.04 + 4 × $0.0044 = $0.098`. European regions run higher; ten to thirty
+per cent is a working assumption here rather than a quoted rate, so call it
+**$0.10 to $0.13**. ARM is around twenty per cent cheaper again.
+
+| Per running hour, 2 vCPU / 4 GB | |
+|---|---|
+| Fargate (Europe, estimated) | $0.10 – $0.13 |
+| E2B | $0.17 |
+| Fly Sprites | $0.32 |
+
+That is the flattering denominator, and it is not the one the workload lives in.
+A hosted agent is expected to be **mostly idle**, and Fargate cannot be idle
+cheaply. Take the same agent worked one hour a day:
+
+| One hour a day, per month | |
+|---|---|
+| Fargate, destroyed when idle | ~$3.60, plus a cold start on every wake |
+| E2B, asleep the rest of the time | ~$5 |
+| Fly Sprites, asleep the rest of the time | ~$9 |
+| Fargate, kept warm to hide the cold start | ~$86 |
+
+**Warm Fargate is the most expensive option on the table by an order of
+magnitude.** E2B beats it below roughly seventy per cent duty cycle and Sprites
+below roughly forty — and a mostly-idle agent is nowhere near either. So the
+specialists dominate warm Fargate on price *and* on wake latency simultaneously.
+Fargate wins on price only in the destroy-when-idle regime, which is exactly the
+regime that pays the cold start this section calls the central risk.
+
+**The recommendation therefore does not rest on price, and should not be
+defended on it.** It rests on two things that are real and independent of cost:
+no new subprocessor holding customer code, and infrastructure we control in a
+region we choose. Those are strong arguments. If the phase 0 cold-start
+measurement comes back badly enough that a warm pool is mandatory, the price
+argument inverts completely and this decision should be reopened rather than
+defended.
+
+And the latency gap is wider than the boot numbers suggest, not narrower. A
+paused machine keeps its processes, so a specialist's sub-second restore really
+does return a session that carries on. **A destroyed task does not**: the agent
+CLI's in-memory context goes with it, and what comes back is a terminal with a
+dead socket in it. So Fargate's wake is not thirty to forty-five seconds, it is
+thirty to forty-five seconds *plus* a state restore *plus* whatever reloading the
+agent's context costs — against something close to zero. Session resumption is a
+design question in its own right (see the open questions), and it is one the
+recommendation creates and the alternative largely avoids.
+
+On residency: **Fly places a sprite near the caller and does not currently let
+you choose a region.** Placement looks sensible in practice — a Berlin user gets
+Frankfurt — but "usually nearby" is not a commitment a data-processing agreement
+can rest on. A gap needing a contractual answer, not a disqualification. Sources:
+`fly.io/sprites`, `e2b.dev/pricing`, `aws.amazon.com/fargate/pricing/`, and the
+Fly community thread at
 `community.fly.io/t/where-do-sprites-dev-sprites-live-as-in-which-fly-io-region-is-it/26775`.
 
-Note that renting from any of them would also make that vendor a **subprocessor
-of customer code and prompts**, requiring a contract, a security review and an
-entry in a privacy notice. Staying in our own account removes one layer of that
-problem — but only one layer. §10 is about the layer that remains.
+Renting from any of them would also make that vendor a **subprocessor of customer
+code and prompts**, requiring a contract, a security review and an entry in a
+privacy notice. Staying in our own account removes one layer of that. §10 is
+about the layer that remains.
 
 ### Rejected: rootless containers
 
-Podman was raised as a cheaper boundary than a microVM. Rootless containers share
-the host kernel, and it is worth being fair about what that means rather than
-treating it as an obvious error. It is a perfectly reasonable posture when you
-have contractual recourse against whoever is running the code — most CI systems
-work exactly this way, and they run arbitrary build scripts all day. The question
-is not "is a shared kernel secure", it is "how strong does the boundary need to
-be given who is on the other side of it".
+Podman was raised as a cheaper boundary, and it deserves a fair hearing rather
+than a reflex. A shared kernel is a reasonable posture when you have contractual
+recourse against whoever runs the code — most CI systems work exactly this way
+and run arbitrary build scripts all day. The question is not whether a shared
+kernel is secure but how strong the boundary needs to be given who is on the
+other side of it, and for anonymous free-tier users running whatever a model
+decides to type there is no contract and no recourse.
 
-For anonymous free-tier users running whatever a model decides to type, a shared
-kernel is the wrong boundary. There is no contract, no identity worth the name,
-and no recourse.
-
-There is also a practical point that settles it: if the task is already a
-microVM, the task *is* the boundary. Podman inside it would be a second boundary
-inside the first, adding a layer to reason about for no gain — and Fargate blocks
-the privileges nested containers usually want anyway.
-
-### The numbers
-
-Estimates, with the assumptions stated, because every one of them turns on a
-ratio we do not have data for.
-
-Fargate is roughly $0.04 per vCPU-hour and $0.0044 per GB-hour in the cheapest
-region. European regions run higher; ten to thirty per cent is the working
-assumption here rather than a quoted rate, and the real figure should be read off
-the pricing page for whichever region is chosen. A 2 vCPU /
-4 GB task is therefore about `2 × $0.04 + 4 × $0.0044 = $0.098` per hour before
-the regional uplift, so call it **$0.10 to $0.13 an hour in Europe**. ARM is
-around twenty per cent cheaper again, and billing granularity is one minute. For
-comparison, the same shape is about $0.315 an hour on the Sprites rates and about
-$0.17 on the E2B rates — Fargate undercuts both.
-
-Assume an actively working session — the CLI in a turn, reading files and calling
-the model — costs roughly $1.50 per hour on a mid-tier model with prompt caching
-working properly, and about five times that if caching breaks. So **compute is
-under a tenth of the model bill while working**, and under the credential model
-in §6 the model bill is not ours to pay at all.
-
-Which means our entire exposure is idle time, and idle time is the number we have
-no data for. Two bounds make the shape clear. An agent kept warm around the clock
-costs roughly $0.12 × 24 × 30 ≈ **$86 a month**, whether or not anyone speaks to
-it. An agent that is destroyed when idle and works one hour a day costs about
-**$3.60 a month**, and pays for it in a cold start every time. Nothing sensible
-sits at the first number for every agent; the design lives somewhere between,
-which is what makes the pooling question in the cold-start section the one that
-decides the unit economics.
+A practical point settles it anyway: if the task is already a microVM, the task
+*is* the boundary. Podman inside it is a second boundary inside the first, for no
+gain, and Fargate blocks the privileges nested containers usually want.
 
 ### What is decided and what is not
 
 Decided: ECS Fargate, in our own account and region, one task per agent, with a
-small image and lazy image loading from the start rather than retrofitted.
+small image and lazy image loading from the start rather than retrofitted — on
+the subprocessor and control arguments, not on price.
 
-Not decided: whether a warm pool is needed at launch or can wait for evidence;
-whether a pooled task can adopt a specific agent's state quickly enough to be
-worth having; and what the acceptable wake latency actually is, which is a
-product judgement nobody has made. Those are open questions below, and the first
-phase of the plan exists partly to answer them with measurements rather than
-argument.
-
----
-
+Not decided: whether a warm pool is needed at launch; how durable per-agent state
+is carried, given a pooled task cannot adopt a volume; and what wake latency is
+actually acceptable, which is a product judgement nobody has made. Phase 0 exists
+to answer the first two with measurements.
 ## 4. What is reused and what is discarded
 
 | Reused as-is | Discarded |
@@ -393,17 +378,24 @@ argument.
 | Startup and stall watches that report failures into the room | Log trimming on relaunch |
 | The event stream, cursor and `Last-Event-ID` resume | The assumption that a model credential is already on the machine |
 
-The image is the bundle plus Node 20, `tmux`, `git`, and one agent CLI — and
-nothing else, because §3 makes image size a latency budget rather than a
-housekeeping preference.
+The image is the bundle plus a current Node (22 or 24 — the sidecar's floor is
+18, but 20 is end of life and a new image should not start there), `tmux`, `git`,
+and one agent CLI. Nothing else, because §3 makes image size a latency budget
+rather than a housekeeping preference.
 
 Hosting simplifies the delivery seam rather than reimplementing it. `SidecarHost`
 is `exec` plus `putFile`; on Fargate the image *is* the file delivery, so
 `putFile` mostly disappears and the launch spec arrives as a container override
-or from a secret store at task start. What remains of `exec` is served by ECS
-Exec. Both paths coexist easily at that size — a self-hosted user keeps SSH, a
-hosted one gets the task API — and keeping the interface is what stops the two
-diverging the way the two on-demand-start implementations already have.
+or from a secret store at task start. Both paths coexist easily at that size — a
+self-hosted user keeps SSH, a hosted one gets the task API — and keeping the
+interface is what stops the two diverging the way the two on-demand-start
+implementations already have.
+
+What remains of `exec` is served by ECS Exec, and that is not free: it requires
+`ssmmessages` permissions on the task role, it is incompatible with a read-only
+root filesystem, and its sessions run as root. So it is **enabled per task, for
+the tasks that need it** — principally the interactive sign-in in §6 — rather
+than switched on across the fleet. §8 states the resulting default.
 
 The one genuinely new piece inside the sandbox is credential delivery, and it is
 new because today there is nothing there at all.
@@ -539,14 +531,28 @@ API key pasted at enrollment is the clean path and is the case the terms address
 in as many words: provisioning your own key into a machine image for your own
 authorized users, billed to the key owner.
 
-Subscription sign-in is harder and the terms are the reason. *"Developers may not
-collect, store, or intermediate Claude.ai credentials or session tokens — sign-in
-to a Claude account must complete through Anthropic's own flow."* So we cannot
-proxy an OAuth login, which means the end user has to complete it themselves
-against a terminal inside their own sandbox — a browser-based terminal, or a
-one-time interactive attach. Whether the resulting token sitting on a filesystem
-we operate counts as "storing" it is not addressed anywhere on that page, and it
-is an open question for a lawyer rather than a judgement call for an engineer.
+Subscription sign-in is harder, and the adverse text belongs in front of the
+reader in full rather than in the convenient half. The same page says:
+
+> Anthropic does not permit third-party developers to offer Claude.ai login into
+> their own applications, or to route requests through Free, Pro, or Max plan
+> credentials on behalf of their users. Moreover, developers may not collect,
+> store, or intermediate Claude.ai credentials or session tokens — sign-in to a
+> Claude account must complete through Anthropic's own flow.
+
+The second sentence rules out proxying the login, which is why an end user would
+have to complete it themselves against a terminal inside their own sandbox. But
+**the first sentence is arguably a direct description of that arrangement** — a
+platform putting a login in front of its users and then running their requests on
+subscription credentials — and it sits immediately before the carve-out quoted
+above, which permits an end user "signing in to the unmodified Claude Code binary
+with their own Claude subscription" on a platform that hosts it.
+
+Those two readings point in opposite directions and this document cannot resolve
+them. The honest expectation is **no** for anything resembling a sign-in screen
+of ours, and plausibly yes only for a raw terminal in which the user runs the
+vendor's own command themselves. The API-key path avoids the question entirely,
+which is a reason to make it the default rather than the fallback.
 
 Note that the same shape applies to the other providers. Codex and OpenCode have
 their own terms and their own answers, and nothing here should be generalised
@@ -592,9 +598,9 @@ That leaves four options and only two of them enforce anything.
   way everywhere it is displayed so nobody later builds billing on it.
 - **Meter and cap the thing we actually pay for: task wall-clock.** We start the
   task, we hold its handle, we can stop it. A budget in task-seconds is
-  enforceable and maps exactly onto our cost — Fargate bills at one-minute
-  granularity, so the accounting and the limit are the same unit rather than an
-  approximation of each other.
+  enforceable and maps exactly onto our cost — Fargate bills **per second, with a
+  one-minute minimum**, so the accounting and the limit are the same unit down to
+  the second rather than an approximation of each other.
 
 The last one is the answer. It is also a better fit for the multi-tenancy
 document's own rule that "a limit that only alerts is not a limit", because it is
@@ -644,9 +650,10 @@ Threats, roughly in order of how much they should worry us:
    sandbox per agent bounds the damage to one agent's room scope and one
    customer's model spend, which is an argument for the unit chosen in §3
    independent of cost. The Switch credential should be short-lived and issued by
-   the supervisor per task rather than baked into an image, and the task role
-   should grant nothing — a session has no legitimate reason to call our cloud
-   API at all.
+   the supervisor per task rather than baked into an image. The task role should
+   grant **nothing beyond the `ssmmessages` actions ECS Exec requires**, and only
+   on the tasks where the exec path is enabled at all (§4) — a session has no
+   other legitimate reason to call our cloud API.
 4. **Prompt injection reaching across rooms.** Content arriving in a room can
    instruct an agent. Switch already has answers here — room scoping, the scoped
    addressing policy, owner-only defaults for new agents — and hosting does not
@@ -702,11 +709,19 @@ The enforcement plane for a hosted session is the VM boundary, the security
 group, the filesystem it can reach and the clock — mechanisms outside the agent's
 own process, which cannot be talked out of a decision by a model.
 
-Concretely, a hosted session defaults to: a task role that grants nothing; no
-credentials in its environment beyond the two it needs; a writable filesystem
-limited to its own working directory; default-deny egress; and a compute cap that
-stops it. Getting those five right matters more than any amount of tool-level
-policy, and none of them requires the agent's cooperation.
+Concretely, a hosted session defaults to: a task role granting nothing beyond
+what ECS Exec needs, on the tasks that need it; no credentials in its environment
+beyond the two it must have; a writable filesystem limited to its own working
+directory; default-deny egress; and a compute cap that stops it. Getting those
+five right matters more than any amount of tool-level policy, and none of them
+requires the agent's cooperation.
+
+One of them cannot be had as stated. A **read-only root filesystem is
+incompatible with ECS Exec**, and ECS Exec sessions run as root — so the sign-in
+flow of §6 and the strongest filesystem posture are mutually exclusive on the
+same task. Keep them apart in time: exec enabled for enrollment, disabled for the
+working life of the session, and any task still carrying it treated and displayed
+as one with a weaker posture.
 
 One thing to fix regardless of hosting: the generic registration endpoint accepts
 a caller-supplied tool list with no validation, so an agent registering outside
@@ -718,27 +733,38 @@ indefensible once registration is a self-serve action.
 
 ## 9. The free tier: an open model on our own account
 
-§6 closes a door. This section finds the one next to it that is open.
+§6 closes a door. This section looks for the one next to it.
 
-The original proposal was to ship OpenCode rather than Claude Code, pointed at an
-internal model proxy with per-key spend limits. It was attractive because OpenCode
-is not Anthropic's binary, so the terms quoted in §6 do not bind it; because a
-proxy is exactly the mechanism §7 says a hard stop requires; and because it
-removes the worst step in the enrollment path — a stranger who has to produce an
-API key before they can see anything is a stranger who does not see anything.
-
-The objection to it was that serving external customers through our own model
-account raises the same resale question with the inference provider that
-Anthropic's terms raise for Claude. That objection turns out not to survive
-contact with the terms.
+The proposal was to ship OpenCode rather than Claude Code against a model we pay
+for: OpenCode is not Anthropic's binary, so §6's terms do not bind it; owning the
+credential is what §7 says a hard stop requires; and it removes the worst step in
+enrollment, since a stranger who must produce an API key before seeing anything
+is a stranger who does not see anything. The standing objection was that paying
+for external customers' usage raises the same resale question with whichever
+provider we use that Anthropic's terms raise for Claude.
 
 ### The door that is open
 
-**AWS's terms for third-party models on Bedrock distinguish our own engineers
-from our product's end users, and permit serving end users — including free
-ones.** That is the ordinary SaaS-wrapper pattern, and it is allowed. What they
-prohibit is handing customers raw API-level access to the model, and training a
-competing model on it. Neither describes what we would be doing.
+The reading this section rests on is that **serving a third-party model on
+Bedrock to our product's end users, including free ones, is permitted** — the
+ordinary SaaS-wrapper pattern — and that what is prohibited is handing customers
+raw API-level access to the model, and training a competing model on it. Neither
+of those describes what we would be doing.
+
+**That reading is not verified here, and it is the only major external claim in
+this document with no quotation behind it.** Everything in §6 is quoted from a
+named page; this is not, and it is a legal claim doing more work than any other
+sentence in the section. Two things make it worth checking rather than assuming.
+The operative instrument is probably not "AWS's terms" generically but **the
+model provider's own end-user licence as presented through the marketplace at
+subscription time**, which differs per model. And some providers' licences
+restrict use to the subscribing customer's *internal business purposes* — if the
+one attached to the chosen model does, this free tier is dead and the section
+does not survive it.
+
+So: name the instrument, quote the operative clause the way §6 quotes Anthropic's,
+and only then schedule anything. Until that is done it is an open question, and
+it is listed as one.
 
 So the resolution to the credential problem the rest of this document sets up is:
 
@@ -746,17 +772,12 @@ So the resolution to the credential problem the rest of this document sets up is
 > connects their own Claude or OpenAI credential when they want the good
 > models.**
 
-That is a coherent product shape rather than a workaround. The free tier is not a
-crippled version of the paid one; it is a different model tier, which is a thing
-users already understand from every other tool they use.
-
-It also simplifies §7 considerably. On the free tier we *are* the account holder,
-so the first of the four metering options — own the credential and cap it at the
-provider — becomes available after all, and it is the strongest of the four. What
-owning the account does not give us for free is *per-tenant* attribution, and
-whether that comes from provider-side request tagging or from a thin gateway of
-our own is an open question rather than a solved one. The global cap is the
-safety net; the per-tenant cap is the product.
+It also simplifies §7. On the free tier we *are* the account holder, so the
+strongest of the four metering options — own the credential and cap it at the
+provider — becomes available after all. What owning the account does not give us
+is *per-tenant* attribution, and whether that comes from provider-side request
+tagging or from a gateway of our own is open. The global cap is the safety net;
+the per-tenant cap is the product.
 
 ### The candidate
 
@@ -775,12 +796,8 @@ model, since caching is exactly what a real deployment would use. It is the righ
 comparison for a free tier all the same: a free tier is where caching is least
 likely to be working, because sessions are short, cold and unrelated.
 
-Note that this $3.90 and the $1.50-to-$7.50 range in §3 come from different
-assumed call rates and context sizes, so they are not the same calculation
-disagreeing with itself. Read them together as one range — somewhere between a
-dollar and eight dollars an active hour for a commercial model, depending mostly
-on whether caching is working — inside which $3.90 is an unremarkable point. The
-comparison that matters is not the absolute figure but the ratio to $0.13.
+The absolute figures matter less than the ratio: **thirty to one**, on
+assumptions chosen to flatter the expensive option.
 
 ### Self-hosting: ruled out, with numbers
 
@@ -818,19 +835,17 @@ harness's own issue history before shipping it, not to pick from a leaderboard.*
 That validation is a phase-6 task with a real cost, and pretending otherwise is
 how a free tier ships that loops forever on its first conversation.
 
-One licence caution that is independent of all of the above: **Meta's open-weight
-licence excludes European-domiciled companies from the grant.** That is a legal
-question about our own entity, not about which region we deploy in, and it rules
-their open weights out for us regardless of how they benchmark.
+One licence caution independent of all of the above: **some open-weight releases
+carry a restriction keyed to the licensee's domicile rather than to where it
+deploys.** One Meta licence was checked and has no such clause, so this is
+emphatically not a reason to exclude any vendor wholesale — it is a reason to
+read the licence of the specific release being evaluated, because the answer is
+per-release and turns on our own entity rather than on our region.
 
-### The closed flagship, briefly
-
-Meta's new closed flagship was raised as a candidate. It is real, and it is the
-wrong tier: priced like a mid-range commercial model rather than a
-cheap one, and its cheap variant requires that the vendor be allowed to train on
-prompts — which a governance product cannot accept on its customers' behalf and
-should not want to. Its open-weight sibling has no agentic benchmarks yet, which
-makes it a thing to revisit rather than a candidate to evaluate.
+Meta's new closed flagship was also raised and is the wrong tier — priced like a
+mid-range commercial model, with a cheap variant conditional on the vendor being
+allowed to train on prompts, which a governance product cannot accept on its
+customers' behalf.
 
 ### What stays uncertain
 
@@ -876,8 +891,8 @@ have to pass. As a European company selling to European customers, none of that
 is optional or deferrable.
 
 **It is a different business.** Hosting is an operations business with a
-round-the-clock expectation. Four environments are deployed by hand today, the
-cluster is on an unsupported Kubernetes version, and nobody is on call. Adding
+round-the-clock expectation. Deployment is manual today, the platform carries the
+usual debts of something built at pilot scale, and nobody is on call. Adding
 customer workloads to that is adding a promise we have no mechanism to keep.
 
 **The market has already run this experiment.** From a separate market review
@@ -970,10 +985,10 @@ grows past that, the positioning objection was right.
 | Decision | Chosen | Alternative and why not |
 |---|---|---|
 | Isolation boundary | microVM with its own kernel | Rootless containers — a shared kernel is a defensible boundary when you have recourse against whoever is inside it, and we would not. Redundant anyway once the task is already a microVM. |
-| Where sessions run | ECS Fargate, in our own account and region | Specialist sandbox vendors (Fly Sprites, E2B, Northflank) — sub-second restore and free sleep, but a new subprocessor, and at least one cannot answer the residency question. Fargate is also cheaper per running hour. |
+| Where sessions run | ECS Fargate, in our own account and region | Specialist sandbox vendors — sub-second restore and free sleep, and **cheaper than warm Fargate for a mostly-idle agent**. Chosen against them on subprocessor and account-control grounds, not on price. Northflank was not evaluated. |
 | Which Fargate | ECS | EKS on Fargate has neither ARM nor spot pricing and puts back the cluster we are avoiding. |
-| Not our existing cluster | Explicitly excluded | No network policy, no limits, no autoscaler, six spare cores, an out-of-support version, and the message database one connection away in the same namespace. |
-| Idle handling | Destroy and rebuild, with cold start attacked directly | Modelling a sleep state — Fargate has no pause, and a state the platform cannot provide is a fiction that becomes a support ticket. |
+| Not our existing cluster | Explicitly excluded | It is not hardened for untrusted workloads and shares a namespace with the message database. Putting a stranger's shell there is a decision about the database. |
+| Idle handling | Destroy and rebuild, with cold start attacked directly | Modelling a sleep state — Fargate has no pause, and a state the platform cannot provide is a fiction that becomes a support ticket. The cost is that a destroyed task loses the agent's in-memory context, which a paused machine would have kept. |
 | Unit of hosting | One task per agent | Per tenant shares a blast radius between agents with different credentials; per session throws away the working directory and the CLI's state every time. |
 | Runtime | The existing sidecar, containerised | A new server-side runner — discards working, tested code for no gain. The `SidecarHost` seam is already two methods wide. |
 | Delivery mechanism | The image, plus container overrides; keep the `SidecarHost` interface | Replacing SSH — self-hosted users still own machines, and keeping one interface is what stops the two paths diverging the way on-demand start already has. |
@@ -986,7 +1001,7 @@ grows past that, the positioning objection was right.
 | Permission model for a hosted session | VM boundary, default-deny egress, scoped filesystem, compute cap | Today's defaults — checks disabled off-laptop, name-based matching, shell allowed, one host of three. The mediation hook is not an enforcement plane. |
 | First chat surface | A message list and composer in the gateway, scoped to first-run and support | Slack first — depends on an app install review a stranger cannot complete during signup. |
 | Free tier | OpenCode on a cheap open model through our own account | A free tier on our Claude credentials — prohibited by the terms in §6. AWS's terms for third-party models permit serving end users, which is the door §6 leaves open. |
-| Free-tier model | Qwen's 30B coder on Bedrock on demand, validated against the harness before shipping | Picking from a leaderboard — the surveyed cheap models each have a dated failure mode in this class of harness, and the inference backend alone can move a score by forty points. Meta's open weights are excluded by a licence term about European-domiciled companies. |
+| Free-tier model | **A validation process**: drive a model-and-backend pairing through the real harness and check it against that harness's issue history. Qwen's 30B coder is the leading candidate to test first | Picking a model from a leaderboard — the surveyed cheap models each have a dated failure mode in this class of harness, and the inference backend alone can move a score by forty points. |
 | Serving the free-tier model | Per-token through our own account | Self-hosting on GPUs — twenty to a hundred and sixty times the price at a free tier's duty cycle, and the European regions we would use have no current-generation datacentre GPUs on demand anyway. |
 | Relationship to multi-tenancy | Downstream of it for self-serve; the existing-deployment case ships first | Building hosting first — signup, tenant isolation and the Slack app are all prerequisites for a stranger. |
 
@@ -1033,8 +1048,13 @@ the dashboard why.
 view in the dashboard.
 *Done when:* someone with no Slack can hold a conversation with their agent.
 
-**Phase 5 — self-serve.** Needs multi-tenancy phases 1 and 2. Signup creates a
-tenant, the tenant's first agent is hosted, payment.
+**Phase 5 — self-serve, paid-only beta.** Needs multi-tenancy phases 1 and 2.
+Signup creates a tenant, the tenant's first agent is hosted, payment. Call it a
+beta and mean it: §9 identifies "bring an API key before you can see anything" as
+the step that loses people, and this phase still has it. Phase 6 is the fix, and
+the two may well want to ship together rather than in sequence — the argument for
+splitting them is only that phase 5 can be measured without waiting on a legal
+answer.
 *Done when:* a stranger with a card and an API key has a working agent without
 talking to anyone.
 
@@ -1054,10 +1074,12 @@ conversation with an agent, and a runaway one stops at a cap we set.
   and the thing the whole cold-start argument in §3 is measured against. Thirty
   seconds with a "working on it" message in the room may be fine; the same thirty
   seconds in silence is not.
-- **Is a warm pool needed at launch, and can a pooled task adopt a specific
-  agent's state?** A pool removes the infrastructure cold start, not the agent
-  restore. Whether a task can mount a per-agent persistent volume fast enough for
-  the second half to be cheap is unverified.
+- **Is a warm pool needed at launch, and how is durable per-agent state
+  carried?** Whether a pooled task can adopt an agent's disk is *not* open — a
+  Fargate task takes its volume configuration at launch and cannot attach one
+  afterwards, so it cannot. What is open is how long a restore from object
+  storage takes, which is the only remaining route to a pool that is worth
+  having.
 - **What is the idle-to-active ratio of a real agent?** Every number in §3 turns
   on it and we have no data. It is measurable today from existing sessions and
   should be measured before the pooling decision, not after.
@@ -1066,6 +1088,17 @@ conversation with an agent, and a runaway one stops at a cap we set.
   a specific account, or their own. Northflank was the only rented option that
   could have offered the last of those; Fargate can, at the price of operating a
   second deployment path.
+- **Will we agree to Anthropic's Commercial Terms of Service, and who signs?**
+  §6 makes this a gate on the entire paid path — no agreement, no hosted Claude
+  Code, and the plan below has no phase 1. It is a commercial decision with a
+  named owner, and it has neither.
+- **Will the positioning change, and when?** §10 argues that shipping a hosted
+  tier while the public material still says data stays where it is would be the
+  worst outcome available. Nobody has decided whether it changes, so nobody has
+  decided whether this is buildable as described.
+- **What does the model licence behind the free tier actually say?** §9 rests on
+  an unverified reading. If the applicable instrument restricts use to the
+  subscribing customer's internal business purposes, phase 6 does not exist.
 - Does an inline proxy carrying the customer's *own* key count as
   "intermediating" under Anthropic's terms? A legal read, not an engineering
   call, and §9 depends on the equivalent answer from whichever provider sits

--- a/docs/old/hosted-agents.md
+++ b/docs/old/hosted-agents.md
@@ -266,14 +266,13 @@ trade rather than a closed door:
   being a storage-layer impossibility and becomes something the runtime has to
   get right.
 
-**And this changes the price argument below, so read the two together.** The $86
-figure is one agent kept warm around the clock, which nobody would do. A shared
-pool is the actual proposal: on the same rates, five warm tasks serving a hundred
-mostly-idle agents is roughly `5 × $0.12 × 720 / 100 ≈ $4` per agent-month —
-competitive with the specialists' sleeping cost, and with none of their wake
-penalty. That defence was unavailable while a pool looked impossible. With the
-shared filesystem it is available again, at the cost of one isolation layer, and
-it is the strongest remaining argument for the recommendation.
+**And this bears on the price argument below, so read the two together.** The $86
+figure is one agent kept warm around the clock, which nobody would do; a shared
+pool is the actual proposal, and it is much cheaper than that. It is still not
+cheaper than the specialists — the numbers are below — because the pool is spare
+capacity we pay for and they charge nothing to sleep. What the pool buys is the
+wake penalty, and it is available only if the shared filesystem above is
+acceptable.
 
 ### The honest trade against the specialists
 
@@ -322,7 +321,14 @@ state for an individual agent. Take the same agent worked one hour a day:
 | E2B, asleep the rest of the time | ~$5 |
 | Fly Sprites, asleep the rest of the time | ~$9 |
 | Fargate, one agent kept warm to hide the cold start | ~$86 |
-| Fargate, a shared warm pool (see cold start, above) | ~$4 |
+| Fargate, a shared warm pool (see cold start, above) | ~$7.90 |
+
+The pool row is two terms, and both belong in it. The work itself still costs
+what the destroy-when-idle row costs — a hundred agents worked an hour a day is
+`100 × 1 × 30 × $0.12 ≈ $360` a month, or **$3.60** an agent. The pool sits on
+top of that: five spare tasks held ready is `5 × $0.12 × 720 ≈ $432`, or
+**$4.32** an agent. It is genuinely additive, because a spare task handed to an
+agent stops being spare and has to be replaced.
 
 **Keeping one agent warm is the most expensive option on the table by an order of
 magnitude.** E2B beats it below roughly seventy per cent duty cycle and Sprites
@@ -332,20 +338,28 @@ on price either by destroying when idle, which is exactly the regime that pays
 the cold start this section calls the central risk, or by pooling, which is only
 available at the isolation cost set out above.
 
-**Whether the recommendation is competitive on price comes down to one storage
-decision.** With a per-agent volume there is no pool, warm means $86 an agent,
-and the specialists win outright. With the shared filesystem from the cold-start
-section a pooled warm task is roughly $4 an agent-month at the ratio assumed
-there — competitive with the specialists' sleeping cost and with no wake penalty
-— bought by giving up a storage-layer isolation boundary for path scoping inside
-the VM.
+**Pooling helps, and it is still not a price win.** With a per-agent volume
+there is no pool at all, warm means $86 an agent, and the specialists win
+outright. With the shared filesystem from the cold-start section, a pool puts us
+at roughly $7.90 an agent-month — between the two specialists, meaningfully
+cheaper than Sprites and about sixty per cent more than E2B — bought by giving up
+a storage-layer isolation boundary for path scoping inside the VM. What the pool
+buys is the wake penalty, not the bill.
 
-So the price case is real but conditional, and it should be argued that way
-rather than asserted. What is *not* conditional is the pair of reasons the
-recommendation actually rests on: no new subprocessor holding customer code, and
-infrastructure we control in a region we choose. If phase 0 shows the shared
-filesystem is unacceptable and a warm pool is nonetheless mandatory, price
-inverts completely and this decision should be reopened rather than defended.
+Treat the pool size as illustrative rather than derived. Five is defensible only
+as a buffer absorbing arrivals while a replacement task starts, not as coverage
+of peak concurrency, and this document has neither an arrival rate nor a
+replenishment time to size it from. Both belong in the phase 0 measurement
+alongside the cold-start number.
+
+So the recommendation should not be defended on price at all. On the workload we
+expect, the cheaper specialist beats every Fargate configuration, and the best
+Fargate can do is sit between the two. **The reasons it rests on are the ones
+that do not move with a spreadsheet: no new subprocessor holding customer code,
+and infrastructure we control in a region we choose.** Price is a thing it
+survives, not a thing it wins. If phase 0 shows the shared filesystem is
+unacceptable and a warm pool is nonetheless mandatory, the gap widens to an order
+of magnitude and this decision should be reopened rather than defended.
 
 And the latency gap is wider than the boot numbers suggest, not narrower. A
 paused machine keeps its processes: memory survives, connections do not, so a
@@ -1029,7 +1043,7 @@ grows past that, the positioning objection was right.
 | Decision | Chosen | Alternative and why not |
 |---|---|---|
 | Isolation boundary | microVM with its own kernel | Rootless containers — a shared kernel is a defensible boundary when you have recourse against whoever is inside it, and we would not. Redundant anyway once the task is already a microVM. |
-| Where sessions run | ECS Fargate, in our own account and region | Specialist sandbox vendors — sub-second restore and free sleep, and cheaper than Fargate for a mostly-idle agent **unless a shared warm pool is acceptable**, which trades a storage isolation boundary for path scoping. Chosen against them on subprocessor and account-control grounds; the price case is conditional. Northflank was not evaluated. |
+| Where sessions run | ECS Fargate, in our own account and region | Specialist sandbox vendors — sub-second restore, free sleep, and cheaper than every Fargate configuration for a mostly-idle agent. A shared warm pool closes the wake gap, not the price gap, and trades a storage isolation boundary for path scoping. Chosen against them on subprocessor and account-control grounds, not on price. Northflank was not evaluated. |
 | Which Fargate | ECS | EKS on Fargate has neither ARM nor spot pricing and puts back the cluster we are avoiding. |
 | Not our existing cluster | Explicitly excluded | It is not hardened for untrusted workloads and shares a namespace with the message database. Putting a stranger's shell there is a decision about the database. |
 | Idle handling | Destroy and rebuild, with cold start attacked directly | Modelling a sleep state — Fargate has no pause, and a state the platform cannot provide is a fiction that becomes a support ticket. The cost is that a destroyed task loses the agent's in-memory context, which a paused machine would have kept. |

--- a/docs/old/hosted-agents.md
+++ b/docs/old/hosted-agents.md
@@ -243,19 +243,37 @@ Three mitigations, in ascending order of effort:
   workloads, not ours.
 - **A small pre-warmed pool** rather than scaling to zero.
 
-**The pool buys less than it looks like, and permanently.** A Fargate task takes
-its volume configuration at launch and cannot attach an existing volume
-afterwards. So a pooled task can be waiting, but it cannot then adopt a specific
-agent's disk — which means a pool removes the infrastructure half of wake latency
-and nothing else, by construction rather than pending a workaround.
+**A pool cannot adopt an agent's disk.** A Fargate task takes its volume
+configuration at launch and cannot attach an existing volume afterwards, so a
+task's storage identity is fixed the moment it starts. That is a property of the
+platform, not a gap pending a workaround.
 
-That has a consequence the rest of this design has to carry: **durable per-agent
-state cannot live in the task.** It is either a filesystem mounted at launch — so
-the task is created for one agent and the pool is a pool of *unassigned* tasks
-that can never be reassigned — or a restore from object storage after the task
-starts. Neither is free and neither is currently anywhere in the design. The
-honest remaining question is not whether a pool can adopt state, which is settled
-and negative, but **how long a restore takes**, which nobody has measured.
+Which leaves three ways to carry durable per-agent state, and they are a priced
+trade rather than a closed door:
+
+- **A per-agent volume mounted at launch.** Strongest isolation, and it kills the
+  pool: the task is created for one agent, so a pool is a pool of *unassigned*
+  tasks that can never be assigned.
+- **A restore from object storage after the task starts.** Keeps the pool and
+  keeps the per-agent boundary, at the price of a restore on the critical path.
+  How long that takes is unmeasured and is the open question here.
+- **A shared elastic filesystem mounted at launch, with a directory per agent.**
+  Fargate supports this, and it is what makes a warm pool actually viable: a
+  pooled task mounts the shared filesystem at launch and is pointed at an agent's
+  directory when it is assigned. The price is real and should be stated —
+  **it trades the per-agent volume boundary that §8's third threat leans on for
+  path scoping inside the VM.** One agent's escape from its own directory stops
+  being a storage-layer impossibility and becomes something the runtime has to
+  get right.
+
+**And this changes the price argument below, so read the two together.** The $86
+figure is one agent kept warm around the clock, which nobody would do. A shared
+pool is the actual proposal: on the same rates, five warm tasks serving a hundred
+mostly-idle agents is roughly `5 × $0.12 × 720 / 100 ≈ $4` per agent-month —
+competitive with the specialists' sleeping cost, and with none of their wake
+penalty. That defence was unavailable while a pool looked impossible. With the
+shared filesystem it is available again, at the cost of one isolation layer, and
+it is the strongest remaining argument for the recommendation.
 
 ### The honest trade against the specialists
 
@@ -295,39 +313,49 @@ per cent is a working assumption here rather than a quoted rate, so call it
 | Fly Sprites | $0.32 |
 
 That is the flattering denominator, and it is not the one the workload lives in.
-A hosted agent is expected to be **mostly idle**, and Fargate cannot be idle
-cheaply. Take the same agent worked one hour a day:
+A hosted agent is expected to be **mostly idle**, and Fargate has no cheap idle
+state for an individual agent. Take the same agent worked one hour a day:
 
 | One hour a day, per month | |
 |---|---|
 | Fargate, destroyed when idle | ~$3.60, plus a cold start on every wake |
 | E2B, asleep the rest of the time | ~$5 |
 | Fly Sprites, asleep the rest of the time | ~$9 |
-| Fargate, kept warm to hide the cold start | ~$86 |
+| Fargate, one agent kept warm to hide the cold start | ~$86 |
+| Fargate, a shared warm pool (see cold start, above) | ~$4 |
 
-**Warm Fargate is the most expensive option on the table by an order of
+**Keeping one agent warm is the most expensive option on the table by an order of
 magnitude.** E2B beats it below roughly seventy per cent duty cycle and Sprites
-below roughly forty — and a mostly-idle agent is nowhere near either. So the
-specialists dominate warm Fargate on price *and* on wake latency simultaneously.
-Fargate wins on price only in the destroy-when-idle regime, which is exactly the
-regime that pays the cold start this section calls the central risk.
+below roughly forty — and a mostly-idle agent is nowhere near either — so on that
+row the specialists dominate on price *and* on wake latency at once. Fargate wins
+on price either by destroying when idle, which is exactly the regime that pays
+the cold start this section calls the central risk, or by pooling, which is only
+available at the isolation cost set out above.
 
-**The recommendation therefore does not rest on price, and should not be
-defended on it.** It rests on two things that are real and independent of cost:
-no new subprocessor holding customer code, and infrastructure we control in a
-region we choose. Those are strong arguments. If the phase 0 cold-start
-measurement comes back badly enough that a warm pool is mandatory, the price
-argument inverts completely and this decision should be reopened rather than
-defended.
+**Whether the recommendation is competitive on price comes down to one storage
+decision.** With a per-agent volume there is no pool, warm means $86 an agent,
+and the specialists win outright. With the shared filesystem from the cold-start
+section a pooled warm task is roughly $4 an agent-month at the ratio assumed
+there — competitive with the specialists' sleeping cost and with no wake penalty
+— bought by giving up a storage-layer isolation boundary for path scoping inside
+the VM.
+
+So the price case is real but conditional, and it should be argued that way
+rather than asserted. What is *not* conditional is the pair of reasons the
+recommendation actually rests on: no new subprocessor holding customer code, and
+infrastructure we control in a region we choose. If phase 0 shows the shared
+filesystem is unacceptable and a warm pool is nonetheless mandatory, price
+inverts completely and this decision should be reopened rather than defended.
 
 And the latency gap is wider than the boot numbers suggest, not narrower. A
-paused machine keeps its processes, so a specialist's sub-second restore really
-does return a session that carries on. **A destroyed task does not**: the agent
-CLI's in-memory context goes with it, and what comes back is a terminal with a
-dead socket in it. So Fargate's wake is not thirty to forty-five seconds, it is
-thirty to forty-five seconds *plus* a state restore *plus* whatever reloading the
-agent's context costs — against something close to zero. Session resumption is a
-design question in its own right (see the open questions), and it is one the
+paused machine keeps its processes: memory survives, connections do not, so a
+specialist's sub-second restore returns a live session that needs a
+**reconnect**. **A destroyed task returns nothing to reconnect** — it comes back
+as a fresh container with no `tmux` server and no agent process in it, and the
+CLI's in-memory context went with the old one. So Fargate's wake is not thirty to
+forty-five seconds, it is that *plus* a state restore *plus* whatever reloading
+the agent's context costs, against a reconnect. Session resumption is a design
+question in its own right (see the open questions), and it is one the
 recommendation creates and the alternative largely avoids.
 
 On residency: **Fly places a sprite near the caller and does not currently let
@@ -345,17 +373,15 @@ about the layer that remains.
 
 ### Rejected: rootless containers
 
-Podman was raised as a cheaper boundary, and it deserves a fair hearing rather
-than a reflex. A shared kernel is a reasonable posture when you have contractual
-recourse against whoever runs the code — most CI systems work exactly this way
-and run arbitrary build scripts all day. The question is not whether a shared
-kernel is secure but how strong the boundary needs to be given who is on the
-other side of it, and for anonymous free-tier users running whatever a model
-decides to type there is no contract and no recourse.
+Podman was raised as a cheaper boundary, and it deserves a fair hearing: a shared
+kernel is a reasonable posture when you have contractual recourse against whoever
+runs the code, which is how most CI systems run arbitrary build scripts all day.
+For anonymous free-tier users running whatever a model decides to type there is
+no contract and no recourse, so the answer would be no on those grounds alone.
 
-A practical point settles it anyway: if the task is already a microVM, the task
-*is* the boundary. Podman inside it is a second boundary inside the first, for no
-gain, and Fargate blocks the privileges nested containers usually want.
+But the question is moot once the task is already a microVM — the task *is* the
+boundary, Podman inside it adds a second one inside the first for no gain, and
+Fargate blocks the privileges nested containers usually want.
 
 ### What is decided and what is not
 
@@ -363,10 +389,14 @@ Decided: ECS Fargate, in our own account and region, one task per agent, with a
 small image and lazy image loading from the start rather than retrofitted — on
 the subprocessor and control arguments, not on price.
 
-Not decided: whether a warm pool is needed at launch; how durable per-agent state
-is carried, given a pooled task cannot adopt a volume; and what wake latency is
-actually acceptable, which is a product judgement nobody has made. Phase 0 exists
-to answer the first two with measurements.
+Not decided: which of the three storage shapes carries durable per-agent state,
+which is the same decision as whether a warm pool is possible and at what
+isolation cost; and what wake latency is actually acceptable, which is a product
+judgement nobody has made. Phase 0 exists to answer the first with measurements;
+the second needs somebody to decide it.
+
+---
+
 ## 4. What is reused and what is discarded
 
 | Reused as-is | Discarded |
@@ -393,9 +423,14 @@ implementations already have.
 
 What remains of `exec` is served by ECS Exec, and that is not free: it requires
 `ssmmessages` permissions on the task role, it is incompatible with a read-only
-root filesystem, and its sessions run as root. So it is **enabled per task, for
-the tasks that need it** — principally the interactive sign-in in §6 — rather
-than switched on across the fleet. §8 states the resulting default.
+root filesystem, and its sessions run as root. It also **cannot be toggled on a
+running task** — it is fixed at launch and can only be turned on for new ones.
+
+So it is separated by *task*, not by phase: the interactive sign-in of §6 runs in
+its own short-lived task with exec enabled, and the working session runs in a
+task launched without it. That is a task replacement between enrollment and
+steady state, and therefore a second lifecycle for the supervisor in §5 to manage
+rather than a flag it can flip. §8 states the resulting default.
 
 The one genuinely new piece inside the sandbox is credential delivery, and it is
 new because today there is nothing there at all.
@@ -527,9 +562,11 @@ Three consequences that are not obvious from the headline:
 ### The model
 
 **The customer brings their own credential, per end user, billed to them.** An
-API key pasted at enrollment is the clean path and is the case the terms address
-in as many words: provisioning your own key into a machine image for your own
-authorized users, billed to the key owner.
+API key pasted at enrollment is the clean path, and the first bullet above
+supports it directly: the binary's built-in authentication methods must not be
+removed, disabled or restricted, expressly including the one that signs in with
+"the user's own API key". A hosted session in which the customer supplies their
+own key is that method working as the terms require.
 
 Subscription sign-in is harder, and the adverse text belongs in front of the
 reader in full rather than in the convenient half. The same page says:
@@ -719,9 +756,14 @@ requires the agent's cooperation.
 One of them cannot be had as stated. A **read-only root filesystem is
 incompatible with ECS Exec**, and ECS Exec sessions run as root — so the sign-in
 flow of §6 and the strongest filesystem posture are mutually exclusive on the
-same task. Keep them apart in time: exec enabled for enrollment, disabled for the
-working life of the session, and any task still carrying it treated and displayed
-as one with a weaker posture.
+same task, and exec is fixed at launch so no task can move between them. They are
+kept apart in *tasks*: a short-lived enrollment task with exec on, then a
+replacement task without it for the working session (§4). Any task still carrying
+exec is treated and displayed as one with a weaker posture.
+
+The shared-filesystem option in §3, if taken, weakens the third threat above in
+the same way: one agent's separation from another's files stops being a
+storage-layer impossibility and becomes path scoping the runtime has to enforce.
 
 One thing to fix regardless of hosting: the generic registration endpoint accepts
 a caller-supplied tool list with no validation, so an agent registering outside
@@ -781,12 +823,13 @@ the per-tenant cap is the product.
 
 ### The candidate
 
-**Qwen's 30B coder model**, served on Bedrock on demand. It is available in
-Ireland, Frankfurt, Milan and Stockholm — all inside the European footprint the
-rest of this design assumes, so it does not reopen the residency question. And it
-is genuinely capable at agentic work rather than only at chat, which is the
-distinction that matters for a harness that expects tool calls rather than
-prose.
+**Qwen's 30B coder model**, served on Bedrock on demand. On-demand availability
+was reported in Ireland, Frankfurt, Milan and Stockholm — inside the European
+footprint the rest of this design assumes, so on that reading it does not reopen
+the residency question, but regional model availability changes often enough that
+it should be confirmed rather than inherited from this page. It is genuinely
+capable at agentic work rather than only at chat, which is the distinction that
+matters for a harness that expects tool calls rather than prose.
 
 On cost: roughly **$0.13 per active session-hour**, against about **$3.90** for a
 mid-tier commercial model on the same assumptions. State the assumptions, because
@@ -796,7 +839,7 @@ model, since caching is exactly what a real deployment would use. It is the righ
 comparison for a free tier all the same: a free tier is where caching is least
 likely to be working, because sessions are short, cold and unrelated.
 
-The absolute figures matter less than the ratio: **thirty to one**, on
+The absolute figures matter less than the ratio: **twenty to thirty to one**, on
 assumptions chosen to flatter the expensive option.
 
 ### Self-hosting: ruled out, with numbers
@@ -822,13 +865,14 @@ stated one, not better.
 This is the part that a leaderboard will not tell you, and it is the reason the
 recommendation is a process rather than a name.
 
-Every cheap model surveyed has a dated, concrete failure mode in exactly this
-class of harness. One has a reproduced infinite-loop bug in OpenCode's own issue
-tracker. Another has a structural tool-calling protocol mismatch despite strong
-benchmark scores — it scores well and then cannot drive the harness. And the
-choice of inference backend alone has been observed to swing a single model's
-measured score by forty points, which means "which model" is not even a
-well-formed question without "served by what".
+Every cheap model surveyed had a dated, concrete failure mode in this class of
+harness — reproduced loop bugs in a harness's own issue tracker, tool-calling
+protocol mismatches behind strong benchmark scores, and a single model's measured
+score moving substantially with nothing changed but the inference backend. Those
+findings come from the same market review as §10's and are reproduced here
+without their sources, so treat them as a reason to test rather than as evidence
+about any named model. The general point stands on its own: "which model" is not
+a well-formed question without "served by what".
 
 **So the recommendation is to validate a model-and-backend pairing against the
 harness's own issue history before shipping it, not to pick from a leaderboard.**
@@ -985,7 +1029,7 @@ grows past that, the positioning objection was right.
 | Decision | Chosen | Alternative and why not |
 |---|---|---|
 | Isolation boundary | microVM with its own kernel | Rootless containers — a shared kernel is a defensible boundary when you have recourse against whoever is inside it, and we would not. Redundant anyway once the task is already a microVM. |
-| Where sessions run | ECS Fargate, in our own account and region | Specialist sandbox vendors — sub-second restore and free sleep, and **cheaper than warm Fargate for a mostly-idle agent**. Chosen against them on subprocessor and account-control grounds, not on price. Northflank was not evaluated. |
+| Where sessions run | ECS Fargate, in our own account and region | Specialist sandbox vendors — sub-second restore and free sleep, and cheaper than Fargate for a mostly-idle agent **unless a shared warm pool is acceptable**, which trades a storage isolation boundary for path scoping. Chosen against them on subprocessor and account-control grounds; the price case is conditional. Northflank was not evaluated. |
 | Which Fargate | ECS | EKS on Fargate has neither ARM nor spot pricing and puts back the cluster we are avoiding. |
 | Not our existing cluster | Explicitly excluded | It is not hardened for untrusted workloads and shares a namespace with the message database. Putting a stranger's shell there is a decision about the database. |
 | Idle handling | Destroy and rebuild, with cold start attacked directly | Modelling a sleep state — Fargate has no pause, and a state the platform cannot provide is a fiction that becomes a support ticket. The cost is that a destroyed task loses the agent's in-memory context, which a paused machine would have kept. |
@@ -1000,7 +1044,7 @@ grows past that, the positioning objection was right.
 | Client-reported usage | Telemetry, labelled as such | Enforcement or billing — the process reporting the number belongs to the tenant. |
 | Permission model for a hosted session | VM boundary, default-deny egress, scoped filesystem, compute cap | Today's defaults — checks disabled off-laptop, name-based matching, shell allowed, one host of three. The mediation hook is not an enforcement plane. |
 | First chat surface | A message list and composer in the gateway, scoped to first-run and support | Slack first — depends on an app install review a stranger cannot complete during signup. |
-| Free tier | OpenCode on a cheap open model through our own account | A free tier on our Claude credentials — prohibited by the terms in §6. AWS's terms for third-party models permit serving end users, which is the door §6 leaves open. |
+| Free tier | OpenCode on a cheap open model through our own account | A free tier on our Claude credentials — prohibited by the terms in §6. A third-party model *may* permit serving end users, which would be the door §6 leaves open, but **that reading is unverified** and rests on a per-model licence nobody has read. See the open questions. |
 | Free-tier model | **A validation process**: drive a model-and-backend pairing through the real harness and check it against that harness's issue history. Qwen's 30B coder is the leading candidate to test first | Picking a model from a leaderboard — the surveyed cheap models each have a dated failure mode in this class of harness, and the inference backend alone can move a score by forty points. |
 | Serving the free-tier model | Per-token through our own account | Self-hosting on GPUs — twenty to a hundred and sixty times the price at a free tier's duty cycle, and the European regions we would use have no current-generation datacentre GPUs on demand anyway. |
 | Relationship to multi-tenancy | Downstream of it for self-serve; the existing-deployment case ships first | Building hosting first — signup, tenant isolation and the Slack app are all prerequisites for a stranger. |
@@ -1111,11 +1155,11 @@ conversation with an agent, and a runaway one stops at a cap we set.
   sandbox? A browser terminal is the obvious answer and is also a remote shell we
   are handing to a stranger.
 - **What does session resumption mean?** Destroying a task loses the agent CLI's
-  in-memory context, and no hosting choice fixes that — a restored machine gives
-  back a terminal with a dead socket in it, not a conversation that carries on.
-  Whether a resumed session reloads context from the room, from the CLI's own
-  transcript, or starts clean is a product decision that nobody has taken and
-  that hosting forces.
+  in-memory context, and a rebuilt task starts clean. Whether a resumed session
+  reloads from the room, from the CLI's own transcript, or simply starts fresh is
+  a product decision nobody has taken — and it is one **destroy-and-rebuild
+  forces on us that a pausing platform would not**, which is a cost of the
+  recommendation in §3 rather than a fact of hosting.
 - §5 guesses that one supervising process is fine at ten sandboxes and not at a
   thousand. Nobody has established where between those the `replicaCount must be
   1` constraint actually breaks, or what breaks first — the reconciliation loop,
@@ -1124,10 +1168,6 @@ conversation with an agent, and a runaway one stops at a cap we set.
   a global cap. Whether per-tenant numbers come from provider-side request tagging
   or from a thin gateway of our own is unresolved, and the second answer puts a
   system holding every tenant's prompts into the request path.
-- Our production cluster is in a region with no on-demand models available at
-  all, so any model call from our own infrastructure would be cross-region today.
-  That is outside this document's scope but it lands squarely on whoever builds
-  the free tier.
 - Should hosted customers be a separate deployment from self-hosted ones, the way
   the multi-tenancy spike keeps the demo environment separate?
 - Who is on call, and what is the promise? Neither has an answer today, and

--- a/docs/old/hosted-agents.md
+++ b/docs/old/hosted-agents.md
@@ -136,7 +136,7 @@ either lives in that one process or lives somewhere new.
 There is nowhere for a hosted customer to talk to their agent.
 
 The gateway API has thirteen routers and none of them read or post messages;
-`rooms.py` has twenty-one routes covering roles, groups, protection, membership
+`rooms.py` has twenty-two routes covering roles, groups, protection, membership
 and archiving, and not one of them touches the conversation. Reading and writing
 messages exists only on the agent-facing bridge — `read_context`, `post_message`,
 `send_targeted_message`, `send_attachment`. The operator dashboard has no message
@@ -172,8 +172,9 @@ Five things, and the runtime is the only one that exists:
 5. Somebody's credential pays for the model, and the licence permits it being
    that somebody's.
 
-The rest of this document takes them in that order, then argues about whether to
-do it at all.
+The rest of this document takes them roughly in that order — the chat surface
+waits until §11, because what it should be depends on who is enrolling and why.
+§10 then argues about whether to do any of it.
 
 ---
 
@@ -244,7 +245,9 @@ and `aws.amazon.com/fargate/pricing/`.
 AWS's own guidance is that a new Fargate task normally takes **thirty to
 forty-five seconds or longer** to start, and practitioner reports range much wider
 depending on image size. The billing clock starts when the image pull begins, not
-when the container is healthy.
+when the container is healthy. Both figures come from AWS's task-startup guidance
+rather than from our own measurement — which is why phase 0 measures it before
+anything is built on top of it.
 
 Set that against the trigger this whole design exists to serve: somebody
 addresses an agent in a chat window and waits for it to answer. Forty-five
@@ -257,7 +260,8 @@ Three mitigations genuinely help, in ascending order of effort:
 - **An aggressively small image.** Node, `tmux`, `git`, the sidecar bundle and
   one agent CLI. Every megabyte is pull time on the critical path.
 - **Seekable OCI lazy image loading**, which AWS reports as the single
-  highest-return optimisation available here, at over fifty per cent.
+  highest-return optimisation available here, at over fifty per cent. That is
+  AWS's number for its own workloads, not ours.
 - **A small pre-warmed pool** rather than scaling to zero.
 
 The pool deserves a caveat, because it is easy to over-claim. A warm pool answers
@@ -340,7 +344,9 @@ Estimates, with the assumptions stated, because every one of them turns on a
 ratio we do not have data for.
 
 Fargate is roughly $0.04 per vCPU-hour and $0.0044 per GB-hour in the cheapest
-region, with European regions typically ten to thirty per cent higher. A 2 vCPU /
+region. European regions run higher; ten to thirty per cent is the working
+assumption here rather than a quoted rate, and the real figure should be read off
+the pricing page for whichever region is chosen. A 2 vCPU /
 4 GB task is therefore about `2 × $0.04 + 4 × $0.0044 = $0.098` per hour before
 the regional uplift, so call it **$0.10 to $0.13 an hour in Europe**. ARM is
 around twenty per cent cheaper again, and billing granularity is one minute. For
@@ -355,7 +361,7 @@ in §6 the model bill is not ours to pay at all.
 
 Which means our entire exposure is idle time, and idle time is the number we have
 no data for. Two bounds make the shape clear. An agent kept warm around the clock
-costs roughly $0.12 × 24 × 30 ≈ **$85 a month**, whether or not anyone speaks to
+costs roughly $0.12 × 24 × 30 ≈ **$86 a month**, whether or not anyone speaks to
 it. An agent that is destroyed when idle and works one hour a day costs about
 **$3.60 a month**, and pays for it in a cold start every time. Nothing sensible
 sits at the first number for every agent; the design lives somewhere between,
@@ -508,7 +514,11 @@ And, under *Authentication and credential use*:
 
 Read plainly: **hosting Claude Code is explicitly contemplated and explicitly
 permitted, on conditions.** A hosted Switch where the customer brings their own
-credential is allowed. A free tier on our tokens is not.
+credential is allowed. A free tier that runs Claude Code on our tokens is not.
+
+That last sentence is narrower than it looks, and §9 turns on the difference: it
+closes the door on *Claude* usage we pay for, and says nothing at all about a
+different model from a different vendor under a different contract.
 
 Three consequences that are not obvious from the headline:
 
@@ -565,8 +575,10 @@ CLI, inside the sandbox, straight to the provider. No amount of accounting in
 
 That leaves four options and only two of them enforce anything.
 
-- **Own the credential and cap it at the provider.** The cleanest hard stop and
-  unavailable to us, because §6 says the credential is the customer's.
+- **Own the credential and cap it at the provider.** The cleanest hard stop, and
+  unavailable on the paid path because §6 says the credential is the customer's.
+  It becomes available again on the free tier, where the account is ours — see
+  §9.
 - **Run an inline proxy.** Point the CLI at a base URL we control and the request
   path is ours again. This is the only way to hard-stop model spend, and it is
   the shape of the option in §9. Whether a proxy carrying the *customer's own*
@@ -704,57 +716,142 @@ indefensible once registration is a self-serve action.
 
 ---
 
-## 9. The option to assess: OpenCode behind a spend-capped proxy
+## 9. The free tier: an open model on our own account
 
-A proposal worth taking seriously rather than adopting: ship OpenCode rather than
-Claude Code, pointed at an internal model proxy with per-key spend limits.
+§6 closes a door. This section finds the one next to it that is open.
 
-It is attractive for three real reasons. OpenCode is not Anthropic's binary, so
-the terms quoted in §6 do not bind it and the specific prohibition on paying for
-end users' usage does not apply. A proxy is exactly the mechanism §7 says a hard
-stop requires, and it is the only one of the four options that both enforces and
-does not require the customer to bring anything. And it removes the single worst
-step in the enrollment path — a stranger who has to produce an API key before
-they can see anything is a stranger who does not see anything.
+The original proposal was to ship OpenCode rather than Claude Code, pointed at an
+internal model proxy with per-key spend limits. It was attractive because OpenCode
+is not Anthropic's binary, so the terms quoted in §6 do not bind it; because a
+proxy is exactly the mechanism §7 says a hard stop requires; and because it
+removes the worst step in the enrollment path — a stranger who has to produce an
+API key before they can see anything is a stranger who does not see anything.
 
-Be clear about what it moves rather than solves:
+The objection to it was that serving external customers through our own model
+account raises the same resale question with the inference provider that
+Anthropic's terms raise for Claude. That objection turns out not to survive
+contact with the terms.
 
-- **Serving external customers through our own model account raises resale
-  questions with the inference provider that internal use does not.** A proxy set
-  up so employees can use models is a different contract from one serving paying
-  strangers, and every major provider's terms have some version of the clause
-  quoted in §6. This needs a commercial answer before it needs an engineering
-  one.
-- **A proxy that logs prompts becomes a place where customer code is stored** —
-  and unlike a per-tenant sandbox, it is one system holding every tenant's code,
-  which is the worst possible blast radius for the most sensitive data in the
-  product. If this is built, prompt logging is off by default and turning it on
-  is a decision with a paper trail.
-- **It makes the trial experience a different product from the paid one.** If
-  most customers run Claude Code, a free tier that only runs OpenCode is not a
-  trial of what they will buy. That is survivable if it is deliberate and stated;
-  it is a problem if it is discovered later.
+### The door that is open
 
-Assessment: worth building, as the free and trial tier only, explicitly not as
-the paid path, and only after the resale question is answered contractually. It
-is not a substitute for the bring-your-own-credential model — it is the thing
-that lets someone see the product before they decide to bring one.
+**AWS's terms for third-party models on Bedrock distinguish our own engineers
+from our product's end users, and permit serving end users — including free
+ones.** That is the ordinary SaaS-wrapper pattern, and it is allowed. What they
+prohibit is handing customers raw API-level access to the model, and training a
+competing model on it. Neither describes what we would be doing.
 
-Two assessments bearing on this section were commissioned while the document was
-written and had not arrived by the time it was finished: one on the proxy option
-itself, and one on cheap open-weight models for a free tier, including whether
-self-hosting on GPU instances ever beats paying per token for bursty usage. The
-second matters because it decides what sits behind the proxy: a per-token API
-from a commodity provider has the resale question above, while a model we run
-ourselves does not — at the cost of a GPU bill that, for a workload as bursty as
-this one, is very likely the wrong shape.
+So the resolution to the credential problem the rest of this document sets up is:
 
-So the paragraphs above are argued from the proposal, from §6 and from §7. The
-commercial claims in particular are reasoning about how these terms usually read,
-not a verified account of any specific provider's contract, and the choice of
-model behind the proxy is left open rather than assumed. **Treat this section as
-the weakest in the document until both assessments land**, and do not let the
-free tier be scheduled on the strength of it.
+> **A free tier on a cheap open model through our own account. The customer
+> connects their own Claude or OpenAI credential when they want the good
+> models.**
+
+That is a coherent product shape rather than a workaround. The free tier is not a
+crippled version of the paid one; it is a different model tier, which is a thing
+users already understand from every other tool they use.
+
+It also simplifies §7 considerably. On the free tier we *are* the account holder,
+so the first of the four metering options — own the credential and cap it at the
+provider — becomes available after all, and it is the strongest of the four. What
+owning the account does not give us for free is *per-tenant* attribution, and
+whether that comes from provider-side request tagging or from a thin gateway of
+our own is an open question rather than a solved one. The global cap is the
+safety net; the per-tenant cap is the product.
+
+### The candidate
+
+**Qwen's 30B coder model**, served on Bedrock on demand. It is available in
+Ireland, Frankfurt, Milan and Stockholm — all inside the European footprint the
+rest of this design assumes, so it does not reopen the residency question. And it
+is genuinely capable at agentic work rather than only at chat, which is the
+distinction that matters for a harness that expects tool calls rather than
+prose.
+
+On cost: roughly **$0.13 per active session-hour**, against about **$3.90** for a
+mid-tier commercial model on the same assumptions. State the assumptions, because
+they do the work — about sixty model calls an hour over a growing context, with
+no prompt caching applied. That is deliberately unflattering to the commercial
+model, since caching is exactly what a real deployment would use. It is the right
+comparison for a free tier all the same: a free tier is where caching is least
+likely to be working, because sessions are short, cold and unrelated.
+
+Note that this $3.90 and the $1.50-to-$7.50 range in §3 come from different
+assumed call rates and context sizes, so they are not the same calculation
+disagreeing with itself. Read them together as one range — somewhere between a
+dollar and eight dollars an active hour for a commercial model, depending mostly
+on whether caching is working — inside which $3.90 is an unremarkable point. The
+comparison that matters is not the absolute figure but the ratio to $0.13.
+
+### Self-hosting: ruled out, with numbers
+
+The obvious next thought is to run the open model ourselves on GPU instances and
+avoid the per-token bill entirely. At the duty cycle a free tier actually
+produces — bursty, mostly idle, five to twenty concurrent sessions at around ten
+per cent utilisation — **owning the GPU costs twenty to a hundred and sixty times
+the API price for the same model.**
+
+The sharpest way to put it: self-hosting a cheap open model would cost more per
+session than paying full price, per token, for a top-tier commercial model. That
+is not a marginal call requiring a spreadsheet, it is two orders of magnitude.
+
+Part of the cause is structural rather than economic. The European regions we
+would deploy in have no current-generation datacentre GPUs available on demand at
+all, so every throughput figure in the analysis is an optimistic extrapolation
+from hardware we could not actually rent. The real number is worse than the
+stated one, not better.
+
+### What the cheap models actually get wrong
+
+This is the part that a leaderboard will not tell you, and it is the reason the
+recommendation is a process rather than a name.
+
+Every cheap model surveyed has a dated, concrete failure mode in exactly this
+class of harness. One has a reproduced infinite-loop bug in OpenCode's own issue
+tracker. Another has a structural tool-calling protocol mismatch despite strong
+benchmark scores — it scores well and then cannot drive the harness. And the
+choice of inference backend alone has been observed to swing a single model's
+measured score by forty points, which means "which model" is not even a
+well-formed question without "served by what".
+
+**So the recommendation is to validate a model-and-backend pairing against the
+harness's own issue history before shipping it, not to pick from a leaderboard.**
+That validation is a phase-6 task with a real cost, and pretending otherwise is
+how a free tier ships that loops forever on its first conversation.
+
+One licence caution that is independent of all of the above: **Meta's open-weight
+licence excludes European-domiciled companies from the grant.** That is a legal
+question about our own entity, not about which region we deploy in, and it rules
+their open weights out for us regardless of how they benchmark.
+
+### The closed flagship, briefly
+
+Meta's new closed flagship was raised as a candidate. It is real, and it is the
+wrong tier: priced like a mid-range commercial model rather than a
+cheap one, and its cheap variant requires that the vendor be allowed to train on
+prompts — which a governance product cannot accept on its customers' behalf and
+should not want to. Its open-weight sibling has no agentic benchmarks yet, which
+makes it a thing to revisit rather than a candidate to evaluate.
+
+### What stays uncertain
+
+Two cautions from the original objection survive and should not be lost in the
+good news.
+
+- **Anything in the request path that logs prompts becomes a place where customer
+  code is stored** — and unlike a per-agent sandbox, it is one system holding
+  every tenant's code, which is the worst available blast radius for the most
+  sensitive data in the product. If a gateway is built for per-tenant
+  attribution, prompt logging is off by default and turning it on is a decision
+  with a paper trail.
+- **The trial is a different product from the paid one.** If most customers
+  intend to run Claude Code, a free tier on OpenCode and an open model is not a
+  trial of what they will buy. That is survivable when it is deliberate and
+  stated on the page; it is a problem when a user discovers it by being
+  disappointed.
+
+Assessment: build it, as the free and trial tier only, explicitly not as the paid
+path. It is not a substitute for the bring-your-own-credential model of §6 — it
+is what lets someone see the product before deciding to bring one.
 
 ---
 
@@ -783,18 +880,22 @@ round-the-clock expectation. Four environments are deployed by hand today, the
 cluster is on an unsupported Kubernetes version, and nobody is on call. Adding
 customer workloads to that is adding a promise we have no mechanism to keep.
 
-**The market has already run this experiment.** Every vendor who built hosted
-agent execution themselves repriced upward during 2026 once real per-session
-costs landed. The honest counter is that their exposure was the model bill and
+**The market has already run this experiment.** From a separate market review
+rather than from anything derived here: every vendor who built hosted agent
+execution themselves repriced upward during 2026 once real per-session costs
+landed. No vendor is named and no underlying data is reproduced, so treat it as a
+read rather than a citation. The honest counter is that their exposure was the
+model bill and
 ours would not be — under §6 the customer pays for inference and we pay for
 compute, and compute is the part that has commoditised. That materially changes
 the outcome, and it is worth saying so rather than treating the repricing as a
 verdict on all hosting.
 
 **And the argument for.** Sandbox infrastructure is now a commodity, so the cost
-of trying is low. The closest competitor to Switch's pitch shipped a coding agent
-into team chat in August with governance at the protocol level, so "agents in
-chat" is no longer differentiating on its own. The genuine white space is
+of trying is low. From the same market review: the closest competitor to Switch's
+pitch shipped a coding agent into team chat in August with governance at the
+protocol level — again unnamed here and unsourced — so "agents in chat" is no
+longer differentiating on its own. The genuine white space is
 multiple agents *from different vendors* collaborating in one room under one
 governance layer — something no single-vendor product has a reason to build.
 That is the thing worth demonstrating, and today demonstrating it requires
@@ -884,7 +985,9 @@ grows past that, the positioning objection was right.
 | Client-reported usage | Telemetry, labelled as such | Enforcement or billing — the process reporting the number belongs to the tenant. |
 | Permission model for a hosted session | VM boundary, default-deny egress, scoped filesystem, compute cap | Today's defaults — checks disabled off-laptop, name-based matching, shell allowed, one host of three. The mediation hook is not an enforcement plane. |
 | First chat surface | A message list and composer in the gateway, scoped to first-run and support | Slack first — depends on an app install review a stranger cannot complete during signup. |
-| Free tier | Deferred, and only via a non-Anthropic host behind a spend-capped proxy | A free tier on our Claude credentials — prohibited. |
+| Free tier | OpenCode on a cheap open model through our own account | A free tier on our Claude credentials — prohibited by the terms in §6. AWS's terms for third-party models permit serving end users, which is the door §6 leaves open. |
+| Free-tier model | Qwen's 30B coder on Bedrock on demand, validated against the harness before shipping | Picking from a leaderboard — the surveyed cheap models each have a dated failure mode in this class of harness, and the inference backend alone can move a score by forty points. Meta's open weights are excluded by a licence term about European-domiciled companies. |
+| Serving the free-tier model | Per-token through our own account | Self-hosting on GPUs — twenty to a hundred and sixty times the price at a free tier's duty cycle, and the European regions we would use have no current-generation datacentre GPUs on demand anyway. |
 | Relationship to multi-tenancy | Downstream of it for self-serve; the existing-deployment case ships first | Building hosting first — signup, tenant isolation and the Slack app are all prerequisites for a stranger. |
 
 ---
@@ -935,7 +1038,13 @@ tenant, the tenant's first agent is hosted, payment.
 *Done when:* a stranger with a card and an API key has a working agent without
 talking to anyone.
 
-**Phase 6 — the free tier**, if and only if §9's commercial question is answered.
+**Phase 6 — the free tier.** OpenCode plus a cheap open model served from our own
+account, with the global spend cap that owning the account makes possible. The
+real work here is validation, not plumbing: a model-and-backend pairing has to be
+driven through the actual harness and checked against that harness's own issue
+history before anyone sees it.
+*Done when:* a stranger who has brought no credential at all can hold a working
+conversation with an agent, and a runaway one stops at a cap we set.
 
 ---
 
@@ -974,8 +1083,18 @@ talking to anyone.
   Whether a resumed session reloads context from the room, from the CLI's own
   transcript, or starts clean is a product decision that nobody has taken and
   that hosting forces.
-- Does the `replicaCount must be 1` constraint hold once one process supervises a
-  fleet? At what number does it stop holding?
+- §5 guesses that one supervising process is fine at ten sandboxes and not at a
+  thousand. Nobody has established where between those the `replicaCount must be
+  1` constraint actually breaks, or what breaks first — the reconciliation loop,
+  the connection registry, or the database pool.
+- **Per-tenant attribution for free-tier model spend.** Owning the account gives
+  a global cap. Whether per-tenant numbers come from provider-side request tagging
+  or from a thin gateway of our own is unresolved, and the second answer puts a
+  system holding every tenant's prompts into the request path.
+- Our production cluster is in a region with no on-demand models available at
+  all, so any model call from our own infrastructure would be cross-region today.
+  That is outside this document's scope but it lands squarely on whoever builds
+  the free tier.
 - Should hosted customers be a separate deployment from self-hosted ones, the way
   the multi-tenancy spike keeps the demo environment separate?
 - Who is on call, and what is the promise? Neither has an answer today, and

--- a/docs/old/hosted-agents.md
+++ b/docs/old/hosted-agents.md
@@ -1,0 +1,982 @@
+# Hosted agents: design and plan
+
+Status: design spike. Not implemented.
+
+Every Switch agent runs on a machine somebody owns — a laptop, or a server they
+onboarded over SSH. That is deliberate, and the README lists it among the things
+Switch is not: *"Not a black box self-service platform. Switch's code is here for
+everyone to see and contribute to. It is designed to be self-hostable and for
+your data to stay where it is."* It is also why nobody can try Switch without
+installing three things first, and why the shortest honest answer to "can I see
+it?" is "install Node, install a coding agent, install the connector, run a
+server."
+
+This document asks what it would take to run an agent session *for* a customer,
+on infrastructure we operate, so that someone can sign up and have a working
+agent with nothing installed. It is an argument rather than an agreed plan, and
+§10 argues the other side of it.
+
+The deliverable is the design, the order of work, and the questions still open.
+No code was written.
+
+---
+
+## 1. Where we are today
+
+### The runtime already exists
+
+The hard part of running an agent away from its owner is already built and
+shipped. `console/apps/switch-console-desktop/src/sidecar/` is a headless agent
+runner: eleven source files, roughly 2,400 lines, bundled by esbuild into a
+single `sidecar.mjs`. It reads credentials from a JSON file, opens one event
+stream to Switch covering every room the agent belongs to, watches for messages
+addressed to it, spawns the agent CLI under `tmux`, types prompts into the
+running terminal UI, and keeps a session registry on disk that it reconciles
+against live `tmux` panes when it restarts.
+
+It needs Node 20, `tmux` and `git`, and nothing else. The build script *enforces*
+that: a custom esbuild resolver fails the build if Electron, the local SQLite
+database or the ORM are ever pulled in transitively. The sidecar cannot acquire
+a desktop dependency by accident.
+
+It also touches SSH nowhere. SSH is how Switch Console *delivers* it, and the
+seam between the two is two methods:
+
+```ts
+export interface SidecarHost {
+  exec(command: string, args: string[]): Promise<{ stdout: string; stderr: string }>;
+  putFile(localAbsPath: string, remoteRelPath: string): Promise<void>;
+}
+```
+
+One implementation exists, over SSH. Anything that can run a command and put a
+file can host the sidecar.
+
+`AgentLaunchSpec` (`src/sidecar/agent-launch-spec.ts`) is the other half: a
+plain-JSON launch recipe — command, args, env, cwd, optional files to write into
+the home directory, provider id, and two behaviour flags — round-tripped through
+base64 and `JSON.parse`. It exists precisely so a headless watcher with no plugin
+registry never has to call back into desktop code to work out how to start an
+agent. It is already the interface a control plane would want.
+
+Put that bundle in an image and the runtime problem is mostly solved.
+
+### What assumes a human owns the box
+
+The parts around it assume ownership, and would be discarded rather than ported:
+
+- **A host is an entry in the user's own SSH config.** `listSshConfigHosts()`
+  parses `~/.ssh/config` and that is the whole of host onboarding. Its own
+  comment says authentication "resolves from the SSH config/agent (Switch
+  Console stores no credentials)". There is no host record, no inventory, and
+  nothing a server could enumerate.
+- **The deployer is an Electron app.** `resolveSidecarBundlePath()` imports
+  `electron` and resolves the bundle out of `process.resourcesPath`. The bundle
+  ships as an app resource, so the app is the only thing that can deploy it.
+- **Setup is deliberately interactive.** From the setup runner's own docstring:
+  *"There is deliberately no run-the-whole-plan loop — the ordering in a plan is
+  guidance for a person, not a script."* That is right for a machine a person
+  owns and exactly wrong for provisioning.
+- **A deploy lock, bundle-hash dedupe, log trimming and reattach logic.** An
+  atomic-`mkdir` mutex with a two-minute staleness break; a hash compare that
+  skips the upload when an identical bundle is already there; an 8 MB log
+  trimmed to 1 MB on relaunch; and `decideExisting()`, which reattaches to a
+  running sidecar rather than replacing it and defers a major upgrade while
+  sessions are live. All of it exists because the box outlives the client and is
+  shared between installs. A sandbox we create per agent has one client, one
+  bundle, one lifetime, and needs none of it.
+- **Model credentials are assumed to be already there.** The remote preflight
+  checks `tmux`, `node`, `git`, the Switch credentials and Switch reachability.
+  It never checks for a model credential, and the launch spec's `env` is built
+  from the provider plugin and Switch Console's own settings — the desktop's
+  `ANTHROPIC_API_KEY` is forwarded only to *local* terminal sessions. A remote
+  session works because a person logged the CLI in on that host by hand. Nothing
+  provisions it and nothing notices it is missing.
+
+That last one is not a rough edge. It is the whole of §6.
+
+### The watcher is on the wrong side
+
+The thing that notices "someone addressed an agent that has no live session" is
+`NotificationWatcher`, and it runs inside the sidecar. It opens a stream with
+`scope: 'all', filter: 'addressed', spawnCapable: true`, and on an addressed
+event it takes a per-room in-flight guard, asks whether a session is already
+attending, and spawns one if not — three attempts, two seconds apart, posting a
+failure notice into the room if it never comes up.
+
+That is a good design for a machine that is already running. It is circular for
+hosting: if the sidecar does not exist yet, nothing is listening.
+
+The server knows this and says so. `connection_model` is one of `always_on`,
+`session_addressable`, `session_passive`, `auto_session`, and for an
+`auto_session` agent with a watcher connected the server posts *"Starting a
+session to handle this — one moment."* on the agent's behalf and waits. With no
+watcher connected it posts an offline message whose text tells the room that the
+agent "is brought online by Switch Console watching on its owner's machine" and
+that "the fix is for the OWNER to open it, and nobody else in the room can act."
+
+The model is already there. Only the actor is missing.
+
+### There is no server-side control plane
+
+Nothing in `core/switch_core` can create or run anything. `AgentSession` is
+documented as tracking "agent reachability and MCP-session room bindings"; its
+rows are written by `touch_heartbeat` in response to a client calling in.
+`AgentRuntimeState` mirrors state *reported* by a session. The closest thing to a
+launch endpoint is `gateway/known_agents.py`, which renders a shell command for a
+human to paste. The server has a complete picture of what is running and no way
+to change it.
+
+The server also cannot be scaled out. The Helm chart fails the render outright:
+`switchCore.replicaCount must be 1`. Whatever supervises a fleet of sandboxes
+either lives in that one process or lives somewhere new.
+
+### There is no chat surface
+
+There is nowhere for a hosted customer to talk to their agent.
+
+The gateway API has thirteen routers and none of them read or post messages;
+`rooms.py` has twenty-one routes covering roles, groups, protection, membership
+and archiving, and not one of them touches the conversation. Reading and writing
+messages exists only on the agent-facing bridge — `read_context`, `post_message`,
+`send_targeted_message`, `send_attachment`. The operator dashboard has no message
+list and no composer; a search for a conversation view finds only `err.message`
+in error dialogs.
+
+Every human conversation in Switch today therefore goes through a collaboration
+bridge, and every bridge is an admin-created row with an operator-pasted
+credential. Slack is Socket Mode with a bot token and an app token; Teams is
+app-only client credentials. There is no OAuth install flow for any platform and
+no callback route to build one on.
+
+So the enrollment path for a stranger dead-ends immediately after "your agent is
+running."
+
+### The security posture is a policy plane with no enforcement plane
+
+Covered in §8. In short: nothing in this repository sandboxes, restricts or
+limits an agent session today, because the machine belongs to the person running
+it and the operating system is the boundary. Hosting removes that boundary and
+supplies nothing in its place.
+
+---
+
+## 2. What has to be true
+
+Five things, and the runtime is the only one that exists:
+
+1. A session runs somewhere we operate, isolated from every other session.
+2. The server can start, stop and destroy one.
+3. The server, not a desktop app, notices that a session should start.
+4. The customer can reach their agent in a conversation.
+5. Somebody's credential pays for the model, and the licence permits it being
+   that somebody's.
+
+The rest of this document takes them in that order, then argues about whether to
+do it at all.
+
+---
+
+## 3. Where a session runs
+
+### The unit
+
+The unit of identity and state is the **agent**, not the tenant and not the
+conversation. A tenant-wide sandbox shares a blast radius between agents that may
+have different working directories and different credentials. A per-conversation
+sandbox throws away the working directory every time a conversation ends, which
+is exactly what the sidecar's durable session registry exists to avoid.
+
+An agent is also the unit the product already talks about: it has a name, a
+working directory, a provider and a set of rooms.
+
+A *machine*, though, is a shorter-lived thing than an agent. Under the
+recommendation below a machine is destroyed when the agent goes idle and started
+again when it is next addressed, so the agent's durable state has to outlive its
+machine rather than living inside it. That is the thing to get right, and it is
+why the persistent-volume question in the cold-start discussion is load-bearing
+rather than an optimisation.
+
+### The shape: a microVM, not a container
+
+A sandbox here means a **microVM** — a real virtual machine with its own kernel,
+booted by Firecracker — not a container sharing the host kernel. That distinction
+is the entire security argument. We are running a stranger's coding agent, which
+means a stranger's shell, and a shared kernel is the wrong boundary for that.
+State it explicitly wherever this design is summarised, because "sandbox" is used
+loosely enough elsewhere to mean a container with a seccomp profile.
+
+### The recommendation: ECS Fargate
+
+Stay on AWS. **AWS Fargate already gives per-task microVM isolation** — in AWS's
+own words, each task has its own isolation boundary and does not share the
+underlying kernel, CPU, memory or network interface with another task. Tasks run
+on Firecracker microVMs, the same primitive the specialist agent-sandbox vendors
+sell, each with its own elastic network interface in our VPC and its own IAM task
+role.
+
+That combination is what makes it the right answer rather than merely an
+acceptable one. We get the isolation boundary without operating a cluster and
+without the hardening our existing cluster would need; the network interface
+lands in a VPC we already control, so egress policy is a security group rather
+than a feature request; the task role is a real credential boundary rather than a
+convention; and because it runs in our own account and region, the data-residency
+question that would have decided against at least one specialist provider does
+not arise.
+
+**ECS Fargate, not EKS Fargate.** EKS on Fargate has neither ARM nor spot
+pricing, and it puts back the Kubernetes cluster the whole point was to avoid.
+
+**And not our own existing cluster.** Per-session pods there are the right
+long-term shape in the abstract — we already run Kubernetes and it removes a
+dependency — but that cluster has no network policy, no resource limits and no
+pod isolation; node cloud credentials are reachable; the database holding every
+room's messages is one connection away in the same namespace; there are roughly
+six spare cores, no autoscaler, and the Kubernetes version is out of standard
+support with a forced upgrade ahead. Putting a stranger's shell in that namespace
+is not a decision about hosting, it is a decision about the database.
+
+Sources: `docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html`
+and `aws.amazon.com/fargate/pricing/`.
+
+### Cold start is the central engineering risk
+
+AWS's own guidance is that a new Fargate task normally takes **thirty to
+forty-five seconds or longer** to start, and practitioner reports range much wider
+depending on image size. The billing clock starts when the image pull begins, not
+when the container is healthy.
+
+Set that against the trigger this whole design exists to serve: somebody
+addresses an agent in a chat window and waits for it to answer. Forty-five
+seconds of nothing is the difference between a product that feels alive and one
+that feels broken. This is the central risk of the recommendation and it should
+be treated as such, not as a tuning detail discovered in phase 2.
+
+Three mitigations genuinely help, in ascending order of effort:
+
+- **An aggressively small image.** Node, `tmux`, `git`, the sidecar bundle and
+  one agent CLI. Every megabyte is pull time on the critical path.
+- **Seekable OCI lazy image loading**, which AWS reports as the single
+  highest-return optimisation available here, at over fifty per cent.
+- **A small pre-warmed pool** rather than scaling to zero.
+
+The pool deserves a caveat, because it is easy to over-claim. A warm pool answers
+"how long until a container exists". It does not answer "how long until *this
+agent's* session is ready" — that needs the agent's working directory, its
+credentials and its CLI state, which is a per-agent restore on top. Total wake
+latency is pool-assign plus agent-restore, and only the first half is what a pool
+buys. Whether a pooled task can mount a per-agent persistent volume fast enough
+to make the second half cheap is unverified and is an open question below.
+
+### The honest trade against the specialists
+
+Three vendors were considered and rejected, and the reasoning is worth keeping
+because it is the reasoning that would reverse the decision if the risk above
+turns out to be fatal.
+
+- **Fly Sprites** — persistent Firecracker VMs with root and a durable root
+  filesystem, created in a second or two, with automatic sleep when idle. Three
+  billing states of which only *running* is billed. Roughly $0.07 per CPU-hour
+  and $0.04375 per GB-hour. Live checkpoint in around 300 ms and restore well
+  under a second. Coding agents are the advertised target workload.
+- **E2B** — the one most widely used by other agent products. $0.000014 per
+  vCPU-second and $0.0000045 per GiB-second. Session length is capped by plan
+  tier: one hour on the entry tier, twenty-four hours above it.
+- **Northflank** — the only one of the three that runs in our own cloud account,
+  which is the answer if a customer says their code may not leave infrastructure
+  we control. Fargate answers that too, and more directly.
+
+**What we give up is pause.** The specialists snapshot and restore a paused
+machine in well under a second and charge nothing while it sleeps. Fargate has no
+pause: an idle session is either destroyed and rebuilt slowly, or kept warm and
+paid for. There is no third state. That is the real cost of staying on AWS, and
+it is paid in exactly the dimension — wake latency for a mostly-idle agent — that
+this product cares most about.
+
+Two things blunt it. Fargate is cheaper per running hour than either specialist,
+so keeping something warm is less punitive than it sounds. And **destroying a
+session loses the agent CLI's in-memory context regardless of provider** — a
+restored microVM gives you back a `tmux` pane with a process in it whose sockets
+are dead, which is not the same as a session that can carry on. Session
+resumption is a design question in its own right, not something a hosting choice
+solves. The specialists' sub-second restore is a real advantage over cold start,
+but it is a smaller advantage than it first appears.
+
+There was also a residency problem on at least one of them: Fly's Sprites do not
+appear to expose region selection, and their own community forum has a user in
+Germany finding their machine in France, apparently routed to a nearby point of
+presence rather than a chosen region. For a European company selling to European
+customers that is close to disqualifying on its own. Sources: `fly.io/sprites`,
+`e2b.dev/pricing`, and the Fly community thread at
+`community.fly.io/t/where-do-sprites-dev-sprites-live-as-in-which-fly-io-region-is-it/26775`.
+
+Note that renting from any of them would also make that vendor a **subprocessor
+of customer code and prompts**, requiring a contract, a security review and an
+entry in a privacy notice. Staying in our own account removes one layer of that
+problem — but only one layer. §10 is about the layer that remains.
+
+### Rejected: rootless containers
+
+Podman was raised as a cheaper boundary than a microVM. Rootless containers share
+the host kernel, and it is worth being fair about what that means rather than
+treating it as an obvious error. It is a perfectly reasonable posture when you
+have contractual recourse against whoever is running the code — most CI systems
+work exactly this way, and they run arbitrary build scripts all day. The question
+is not "is a shared kernel secure", it is "how strong does the boundary need to
+be given who is on the other side of it".
+
+For anonymous free-tier users running whatever a model decides to type, a shared
+kernel is the wrong boundary. There is no contract, no identity worth the name,
+and no recourse.
+
+There is also a practical point that settles it: if the task is already a
+microVM, the task *is* the boundary. Podman inside it would be a second boundary
+inside the first, adding a layer to reason about for no gain — and Fargate blocks
+the privileges nested containers usually want anyway.
+
+### The numbers
+
+Estimates, with the assumptions stated, because every one of them turns on a
+ratio we do not have data for.
+
+Fargate is roughly $0.04 per vCPU-hour and $0.0044 per GB-hour in the cheapest
+region, with European regions typically ten to thirty per cent higher. A 2 vCPU /
+4 GB task is therefore about `2 × $0.04 + 4 × $0.0044 = $0.098` per hour before
+the regional uplift, so call it **$0.10 to $0.13 an hour in Europe**. ARM is
+around twenty per cent cheaper again, and billing granularity is one minute. For
+comparison, the same shape is about $0.315 an hour on the Sprites rates and about
+$0.17 on the E2B rates — Fargate undercuts both.
+
+Assume an actively working session — the CLI in a turn, reading files and calling
+the model — costs roughly $1.50 per hour on a mid-tier model with prompt caching
+working properly, and about five times that if caching breaks. So **compute is
+under a tenth of the model bill while working**, and under the credential model
+in §6 the model bill is not ours to pay at all.
+
+Which means our entire exposure is idle time, and idle time is the number we have
+no data for. Two bounds make the shape clear. An agent kept warm around the clock
+costs roughly $0.12 × 24 × 30 ≈ **$85 a month**, whether or not anyone speaks to
+it. An agent that is destroyed when idle and works one hour a day costs about
+**$3.60 a month**, and pays for it in a cold start every time. Nothing sensible
+sits at the first number for every agent; the design lives somewhere between,
+which is what makes the pooling question in the cold-start section the one that
+decides the unit economics.
+
+### What is decided and what is not
+
+Decided: ECS Fargate, in our own account and region, one task per agent, with a
+small image and lazy image loading from the start rather than retrofitted.
+
+Not decided: whether a warm pool is needed at launch or can wait for evidence;
+whether a pooled task can adopt a specific agent's state quickly enough to be
+worth having; and what the acceptable wake latency actually is, which is a
+product judgement nobody has made. Those are open questions below, and the first
+phase of the plan exists partly to answer them with measurements rather than
+argument.
+
+---
+
+## 4. What is reused and what is discarded
+
+| Reused as-is | Discarded |
+|---|---|
+| The sidecar bundle — stream, watcher, spawner, injector, state store | The SSH transport, and `listSshConfigHosts()` as host identity |
+| `AgentLaunchSpec` as the launch contract | The Electron bundle resolver and `extraResources` packaging |
+| The `SidecarHost` seam (`exec` + `putFile`) | The interactive setup runner and its refusal to run a whole plan |
+| The tmux session model and prompt injection | The deploy lock, bundle-hash dedupe and reattach logic |
+| Startup and stall watches that report failures into the room | Log trimming on relaunch |
+| The event stream, cursor and `Last-Event-ID` resume | The assumption that a model credential is already on the machine |
+
+The image is the bundle plus Node 20, `tmux`, `git`, and one agent CLI — and
+nothing else, because §3 makes image size a latency budget rather than a
+housekeeping preference.
+
+Hosting simplifies the delivery seam rather than reimplementing it. `SidecarHost`
+is `exec` plus `putFile`; on Fargate the image *is* the file delivery, so
+`putFile` mostly disappears and the launch spec arrives as a container override
+or from a secret store at task start. What remains of `exec` is served by ECS
+Exec. Both paths coexist easily at that size — a self-hosted user keeps SSH, a
+hosted one gets the task API — and keeping the interface is what stops the two
+diverging the way the two on-demand-start implementations already have.
+
+The one genuinely new piece inside the sandbox is credential delivery, and it is
+new because today there is nothing there at all.
+
+---
+
+## 5. The control plane
+
+### What has to exist server-side
+
+A record of a sandbox and its lifecycle, and something that drives it:
+
+```
+hosted_sandboxes
+  id, agent_id, task_arn, region, image_version,
+  state (provisioning|running|stopping|stopped|failed),
+  created_at, last_active_at, stopped_at, stop_reason
+```
+
+Plus a supervisor with three verbs — start, stop, destroy — and a reconciler,
+because our view and the task's will disagree and the task is right. Everything
+else is bookkeeping.
+
+There is deliberately no `asleep`. Fargate has no pause, so a session is running
+or it does not exist, and modelling a sleeping state the platform cannot provide
+would be the kind of comfortable fiction that produces a support ticket six
+months later. If a warm pool arrives it is a separate concept — a task that
+exists and has not yet been assigned an agent — and it should get its own table
+rather than a fourth value in this column.
+
+The state column is not decoration. It is what a support conversation is
+conducted against, what a metering job sums over, and what tells the room why an
+agent did not answer instead of the current guess.
+
+### Moving the watcher
+
+The watcher moves into the server. It is a small change to a component that
+already exists on both sides of the wire: `AgentClient` already decides that a
+message addresses an agent, already knows the agent's `connection_model`, and
+already posts *"Starting a session to handle this — one moment."* For a hosted
+agent, the branch that posts that message calls the supervisor instead of waiting
+for a desktop watcher to notice.
+
+The sidecar's watcher stays. Both must exist, and the failure mode of having two
+is a double-spawn, so the in-flight guard has to be server-side and authoritative
+rather than per-process. A hosted agent should have the sidecar's own watcher
+gated off — the `watch-enabled` flag it already re-reads every poll is the
+mechanism, so nothing new is needed to express it.
+
+The documentation already warns about this pair drifting: *"Fixing on-demand
+start in Console does not fix it on a remote host."* Adding a third
+implementation server-side makes that worse, not better. The honest end state is
+that the server owns the decision and both clients only execute it. That is
+larger than this phase and should be named as the direction rather than pretended
+away.
+
+### The single-process problem
+
+`switch-core` refuses to run more than one replica. A supervisor for N sandboxes
+inside that process inherits the constraint: one deploy, one restart, and every
+sandbox's reconciliation loop stops. That is tolerable at ten sandboxes and not
+at a thousand, and it is worth deciding early whether the supervisor is a module
+in `switch-core` or a separate service that talks to the same database. The
+cheap answer is a module with all its state in Postgres and no in-memory
+authority, so extracting it later is a deployment change rather than a rewrite.
+
+---
+
+## 6. Credentials and payment
+
+This is the section that decides the product, and it is decided by somebody
+else's licence rather than by us.
+
+### What Anthropic's terms say
+
+From `code.claude.com/docs/en/legal-and-compliance`, under *"Can customers offer
+Claude Code in their products?"*:
+
+> Unless we've mutually agreed otherwise, preinstalling or running Claude Code in
+> your products or services (e.g. in hosted sandboxes or other agent
+> infrastructure) requires agreeing to our Commercial Terms of Service and
+> complying with the conditions below:
+>
+> - **The Claude Code binary must not be modified.** Claude Code must be
+>   installed and run as published by Anthropic, and customers may not remove,
+>   disable, or restrict any authentication method built into it (including
+>   methods that permit signing in with a Claude account or the user's own API
+>   key).
+> - **Customers may not pay for, resell, or intermediate Claude usage on their
+>   end users' behalf.** Each end user must authenticate with their own Anthropic
+>   API key, Claude subscription plan credentials, or 3P inference provider
+>   credential (Amazon Bedrock, Google Cloud's Agent Platform, Microsoft
+>   Foundry). That usage is billed directly to the end user under their own
+>   agreement with Anthropic or, for third-party inference providers, with the
+>   applicable provider.
+
+And, under *Authentication and credential use*:
+
+> This does not restrict how customers provision and manage their own API keys or
+> third-party inference provider credentials — for example, configuring an API
+> key in a development environment, secrets manager, or machine image for use by
+> the customer's own authorized users — provided the resulting usage is billed to
+> the key owner under their agreement with Anthropic (or the applicable provider)
+> and is not resold or intermediated as described above. Nor does it prevent an
+> end user from signing in to the unmodified Claude Code binary with their own
+> Claude subscription, including where a platform hosts Claude Code as described
+> under *Can customers offer Claude Code in their products?* above.
+
+Read plainly: **hosting Claude Code is explicitly contemplated and explicitly
+permitted, on conditions.** A hosted Switch where the customer brings their own
+credential is allowed. A free tier on our tokens is not.
+
+Three consequences that are not obvious from the headline:
+
+- It requires **agreeing to the Commercial Terms of Service**. That is a
+  commercial action taken by a person with authority, not an engineering task,
+  and it should be started before the work is, not after it.
+- We must not disable any built-in authentication method. Anything that forces
+  a single credential path — including a well-meaning "we manage this for you"
+  — is on the wrong side of the first condition.
+- Naming is constrained. We can say in plain text that Switch runs Claude Code.
+  We cannot name a feature after it or use the marks in a way that implies a
+  partnership.
+
+### The model
+
+**The customer brings their own credential, per end user, billed to them.** An
+API key pasted at enrollment is the clean path and is the case the terms address
+in as many words: provisioning your own key into a machine image for your own
+authorized users, billed to the key owner.
+
+Subscription sign-in is harder and the terms are the reason. *"Developers may not
+collect, store, or intermediate Claude.ai credentials or session tokens — sign-in
+to a Claude account must complete through Anthropic's own flow."* So we cannot
+proxy an OAuth login, which means the end user has to complete it themselves
+against a terminal inside their own sandbox — a browser-based terminal, or a
+one-time interactive attach. Whether the resulting token sitting on a filesystem
+we operate counts as "storing" it is not addressed anywhere on that page, and it
+is an open question for a lawyer rather than a judgement call for an engineer.
+
+Note that the same shape applies to the other providers. Codex and OpenCode have
+their own terms and their own answers, and nothing here should be generalised
+from Anthropic's page to all three without reading them.
+
+### The consequence for the multi-tenancy plan
+
+The multi-tenancy spike's quota phase opens with *"Every agent turn costs LLM
+money, so one customer's runaway loop is our bill."* Against these terms that
+premise does not hold for Claude Code. Under a bring-your-own-credential model a
+runaway loop is the customer's bill, at the customer's provider, and our
+exposure is the sandbox it runs in.
+
+That is not a small correction. It moves the hard stop from tokens, which we
+cannot enforce, to compute-seconds, which we own outright — see §7. Whoever picks
+up that phase should read this section first, because building token quotas for
+a cost we do not carry is work spent in the wrong place.
+
+---
+
+## 7. Metering and abuse
+
+**Switch is not in the request path.** The model call goes from the customer's
+CLI, inside the sandbox, straight to the provider. No amount of accounting in
+`switch-core` sees it.
+
+That leaves four options and only two of them enforce anything.
+
+- **Own the credential and cap it at the provider.** The cleanest hard stop and
+  unavailable to us, because §6 says the credential is the customer's.
+- **Run an inline proxy.** Point the CLI at a base URL we control and the request
+  path is ours again. This is the only way to hard-stop model spend, and it is
+  the shape of the option in §9. Whether a proxy carrying the *customer's own*
+  key, billed to the customer, counts as "intermediating Claude usage on their
+  end users' behalf" is genuinely unclear — the end user is the key owner, which
+  reads more like a corporate egress proxy than resale, but the word
+  "intermediate" is doing a lot of work and we should not guess.
+- **Client-reported usage.** Claude Code can emit a cost estimate per
+  invocation. It is useful, it is cheap, and it is reported by a process the
+  tenant controls. **Telemetry, not enforcement**, and it must be labelled that
+  way everywhere it is displayed so nobody later builds billing on it.
+- **Meter and cap the thing we actually pay for: task wall-clock.** We start the
+  task, we hold its handle, we can stop it. A budget in task-seconds is
+  enforceable and maps exactly onto our cost — Fargate bills at one-minute
+  granularity, so the accounting and the limit are the same unit rather than an
+  approximation of each other.
+
+The last one is the answer. It is also a better fit for the multi-tenancy
+document's own rule that "a limit that only alerts is not a limit", because it is
+the only limit here that can be made true.
+
+Note the interaction with §3: the cheapest way to run a hosted fleet is to
+destroy idle tasks, and destroying idle tasks is also the metering enforcement.
+The cost control and the abuse control are the same mechanism, which is a good
+sign about both.
+
+What it does not cover is abuse that costs us nothing directly: using a hosted
+task as an egress point for scanning, spam or mining. Compute caps bound it but
+do not address it; that is a security-group question and belongs in §8.
+
+On free-tier farming the multi-tenancy spike's reasoning carries over unchanged —
+cap what an account can spend rather than how many accounts can exist. Hosting
+adds one lever it did not have: a free tenant's task is destroyed the moment it
+goes idle and never started on a schedule, so a farmed account that nobody talks
+to costs nothing at all.
+
+---
+
+## 8. Isolation and the threat model
+
+### What we would be doing
+
+Running an agent, controlled by a customer, executing a model's decisions, in
+infrastructure we operate, with a shell. Every part of that sentence is a
+liability.
+
+Threats, roughly in order of how much they should worry us:
+
+1. **Escape to other tenants or to our infrastructure.** The microVM boundary is
+   the answer, and it is the reason §3 insists on a real kernel rather than a
+   container. This is the threat that is solved by choosing correctly, once.
+2. **Egress abuse.** A sandbox with unrestricted network is a free machine on the
+   internet with our name on its IP address, and neither a VM boundary nor a
+   compute cap addresses it. Default-deny outbound with an allowlist for the
+   model provider, the Switch API and the package registries the agent
+   legitimately needs. On Fargate this is a security group on the task's own
+   network interface — an existing mechanism rather than something to build,
+   which is one of the better arguments for the placement in §3. It is also the
+   control most likely to be skipped under time pressure, so it belongs in the
+   first phase rather than a hardening phase.
+3. **Credential blast radius.** The sandbox holds the agent's Switch API key and
+   the customer's model key, and its task role is a third credential. One
+   sandbox per agent bounds the damage to one agent's room scope and one
+   customer's model spend, which is an argument for the unit chosen in §3
+   independent of cost. The Switch credential should be short-lived and issued by
+   the supervisor per task rather than baked into an image, and the task role
+   should grant nothing — a session has no legitimate reason to call our cloud
+   API at all.
+4. **Prompt injection reaching across rooms.** Content arriving in a room can
+   instruct an agent. Switch already has answers here — room scoping, the scoped
+   addressing policy, owner-only defaults for new agents — and hosting does not
+   make the mechanism worse. It makes the *consequences* worse, because a hosted
+   session runs with nobody watching a terminal.
+5. **The control plane itself.** A supervisor holding credentials that can create
+   machines is a high-value target living in the same process as the agent-facing
+   API.
+
+### What we must not inherit
+
+The current posture is a policy plane with no enforcement plane, and every part
+of that is worse than it first sounds. Verified against the tree:
+
+- **An agent reached over SSH defaults to bypassing permissions.** Switch Console
+  sets `autoApprove` from whether the agent's host is remote, and its own comment
+  says why: remote agents "run unattended on their VM with no operator to answer
+  permission prompts". That translates into the provider's own bypass flag at
+  launch. The reasoning is sound for a machine its owner set up, and it is
+  precisely the reasoning that must not survive into a machine we set up.
+- **The hook suppresses the prompt rather than adding to it.** The pre-tool-use
+  handler emits only `allow` or `deny`, never `ask`, so a permissive verdict
+  removes the agent's own confirmation step instead of layering a second check on
+  top of it. A mediation plane that can only make things more permissive is not a
+  safety mechanism.
+- **It matches on names, and the server never looks at arguments.** The
+  server-side decision is a name-membership check against the agent's attached
+  tool rows; the docstring says outright that arguments are accepted but not
+  inspected.
+- **Shell is on the default list.** Both the Claude Code and OpenCode known-agent
+  definitions seed `Bash`, and Codex seeds `Shell`. Since the check is by name
+  and shell is allowed, everything reachable from a shell is allowed, which is
+  everything. The name-based check is decorative in the presence of that one
+  entry.
+- **It exists for one host of three.** Only the Claude Code connector ships a
+  hook. Codex and OpenCode register with no pre-invocation mediation at all, and
+  the Codex definition says so in a comment: it "runs auto-approved".
+- **It is cooperative, and the hook says so.** When the mediation call fails the
+  hook lets the tool run unmediated, and there is no server-side fallback,
+  because these are the CLI's own local tools executing in its own process and
+  they are never proxied through Switch. Post-tool mediation returns `ok`
+  unconditionally today.
+- **Nothing anywhere in the repository sandboxes, restricts or limits an agent
+  session** — no seccomp, no cgroup, no filesystem restriction, no egress rule,
+  no resource cap. A session is an ordinary process with the full authority of
+  the account it runs under.
+
+None of that is a criticism of the local product, where the operating system and
+the person at the keyboard are the real boundary and the hook is a useful record
+of intent. It is disqualifying for hosting, where neither of those exists.
+**The mediation hook must not be counted as a control in any hosted design.**
+The enforcement plane for a hosted session is the VM boundary, the security
+group, the filesystem it can reach and the clock — mechanisms outside the agent's
+own process, which cannot be talked out of a decision by a model.
+
+Concretely, a hosted session defaults to: a task role that grants nothing; no
+credentials in its environment beyond the two it needs; a writable filesystem
+limited to its own working directory; default-deny egress; and a compute cap that
+stops it. Getting those five right matters more than any amount of tool-level
+policy, and none of them requires the agent's cooperation.
+
+One thing to fix regardless of hosting: the generic registration endpoint accepts
+a caller-supplied tool list with no validation, so an agent registering outside
+the known-agent path declares its own allow list. That is defensible when a
+registration token means someone with a machine chose to run something, and
+indefensible once registration is a self-serve action.
+
+---
+
+## 9. The option to assess: OpenCode behind a spend-capped proxy
+
+A proposal worth taking seriously rather than adopting: ship OpenCode rather than
+Claude Code, pointed at an internal model proxy with per-key spend limits.
+
+It is attractive for three real reasons. OpenCode is not Anthropic's binary, so
+the terms quoted in §6 do not bind it and the specific prohibition on paying for
+end users' usage does not apply. A proxy is exactly the mechanism §7 says a hard
+stop requires, and it is the only one of the four options that both enforces and
+does not require the customer to bring anything. And it removes the single worst
+step in the enrollment path — a stranger who has to produce an API key before
+they can see anything is a stranger who does not see anything.
+
+Be clear about what it moves rather than solves:
+
+- **Serving external customers through our own model account raises resale
+  questions with the inference provider that internal use does not.** A proxy set
+  up so employees can use models is a different contract from one serving paying
+  strangers, and every major provider's terms have some version of the clause
+  quoted in §6. This needs a commercial answer before it needs an engineering
+  one.
+- **A proxy that logs prompts becomes a place where customer code is stored** —
+  and unlike a per-tenant sandbox, it is one system holding every tenant's code,
+  which is the worst possible blast radius for the most sensitive data in the
+  product. If this is built, prompt logging is off by default and turning it on
+  is a decision with a paper trail.
+- **It makes the trial experience a different product from the paid one.** If
+  most customers run Claude Code, a free tier that only runs OpenCode is not a
+  trial of what they will buy. That is survivable if it is deliberate and stated;
+  it is a problem if it is discovered later.
+
+Assessment: worth building, as the free and trial tier only, explicitly not as
+the paid path, and only after the resale question is answered contractually. It
+is not a substitute for the bring-your-own-credential model — it is the thing
+that lets someone see the product before they decide to bring one.
+
+Two assessments bearing on this section were commissioned while the document was
+written and had not arrived by the time it was finished: one on the proxy option
+itself, and one on cheap open-weight models for a free tier, including whether
+self-hosting on GPU instances ever beats paying per token for bursty usage. The
+second matters because it decides what sits behind the proxy: a per-token API
+from a commodity provider has the resale question above, while a model we run
+ourselves does not — at the cost of a GPU bill that, for a workload as bursty as
+this one, is very likely the wrong shape.
+
+So the paragraphs above are argued from the proposal, from §6 and from §7. The
+commercial claims in particular are reasoning about how these terms usually read,
+not a verified account of any specific provider's contract, and the choice of
+model behind the proxy is left open rather than assumed. **Treat this section as
+the weakest in the document until both assessments land**, and do not let the
+free tier be scheduled on the strength of it.
+
+---
+
+## 10. Why we might not do this at all
+
+The strongest argument against is not technical.
+
+**It contradicts what we say.** The README's third "what Switch is not" is *"Not
+a black box self-service platform... designed to be self-hostable and for your
+data to stay where it is."* The user documentation says Switch "starts the
+providers you already use on your machine, under your credentials." Hosting
+inverts both. Doing it anyway is defensible, but only if the positioning changes
+with it, in the same release, on purpose. Shipping a hosted tier while the
+homepage still says data stays where it is would be the worst outcome available.
+
+**It makes us a processor of customer code and prompts.** Today a compromise of
+Switch leaks messages. A compromise of a hosted Switch leaks working
+directories. That is a different category of incident, and it brings a data
+processing agreement, a subprocessor list, breach notification obligations, a
+residency answer and a security review that a self-hosted product simply does not
+have to pass. As a European company selling to European customers, none of that
+is optional or deferrable.
+
+**It is a different business.** Hosting is an operations business with a
+round-the-clock expectation. Four environments are deployed by hand today, the
+cluster is on an unsupported Kubernetes version, and nobody is on call. Adding
+customer workloads to that is adding a promise we have no mechanism to keep.
+
+**The market has already run this experiment.** Every vendor who built hosted
+agent execution themselves repriced upward during 2026 once real per-session
+costs landed. The honest counter is that their exposure was the model bill and
+ours would not be — under §6 the customer pays for inference and we pay for
+compute, and compute is the part that has commoditised. That materially changes
+the outcome, and it is worth saying so rather than treating the repricing as a
+verdict on all hosting.
+
+**And the argument for.** Sandbox infrastructure is now a commodity, so the cost
+of trying is low. The closest competitor to Switch's pitch shipped a coding agent
+into team chat in August with governance at the protocol level, so "agents in
+chat" is no longer differentiating on its own. The genuine white space is
+multiple agents *from different vendors* collaborating in one room under one
+governance layer — something no single-vendor product has a reason to build.
+That is the thing worth demonstrating, and today demonstrating it requires
+somebody to install three CLIs. **Hosting is how the differentiator becomes
+visible.** If it is built for any reason, it should be built for that one, which
+also implies a much smaller first version than a full self-serve tier.
+
+The middle path, if the positioning objection wins: host the demo, not the
+product. A hosted agent that is explicitly a trial, time-limited, labelled as
+running on our infrastructure, with the self-hosted path as its destination. It
+answers "can I see it?" without claiming to be where customer code should live.
+
+---
+
+## 11. The enrollment path
+
+What a stranger actually walks, and what each step depends on:
+
+1. **Sign up and create a workspace.** Multi-tenancy spike, phases 1 and 2. Not
+   in this document's scope and entirely blocking for the self-serve case.
+2. **Add an agent.** Name, provider, and nothing else — no working directory to
+   choose, because a hosted agent starts with an empty one.
+3. **Provision.** The supervisor starts a task from the image with the Switch
+   credentials and the launch spec as overrides, and the sidecar comes up. Tens
+   of seconds on the numbers in §3 — which is acceptable here, where the user is
+   watching a progress indicator they asked for, and is exactly the same latency
+   that is not acceptable in step 5.
+4. **Supply a model credential.** Paste an API key, or open a terminal into the
+   sandbox and sign in. This is the step that loses people, and §9 exists mostly
+   to remove it for a first look.
+5. **Talk to the agent.** Needs a chat surface — see below.
+6. **Optionally, connect Slack.** Multi-tenancy spike, phase 4.
+
+Steps 1, 5 and 6 are all downstream of other work, which makes the self-serve
+case downstream of the multi-tenancy spike as a whole. That is a scheduling fact
+worth stating plainly rather than discovering in the middle of it.
+
+### The chat surface
+
+Four options for step 5:
+
+- **The official Slack app.** The best fit with the positioning — we do not
+  replace your chat — and the real product path. But it makes a stranger's first
+  conversation depend on having a Slack workspace and, in most companies, an
+  admin approving an app install. That cannot happen inside a signup flow.
+- **A minimal message list and composer in the gateway.** New endpoints over the
+  same `messages` table, and a single view in the dashboard. It is the smallest
+  thing that makes signup work end to end, and the gateway wants a message read
+  surface anyway for support and audit — today an operator investigating a
+  complaint has no way to see a conversation at all.
+- **An embed of an existing client.** Switch Console already does this for
+  platforms that support it. Not available on the web without the platform, so
+  it does not solve the stranger case.
+- **Telegram or Discord as the first surface.** Genuinely lower friction — a
+  Telegram bot needs nobody's approval — but it is not where companies work, and
+  a first impression formed in Telegram is a first impression of the wrong
+  product.
+
+Take the second. Signup-to-first-message must not depend on a third party's
+install review, and the read half is wanted regardless.
+
+The objection is real: building a chat UI is precisely the thing the README says
+we are not doing. The answer is scope discipline rather than a clever
+distinction. It is a first-run and support surface: a message list, a composer,
+and nothing else. No threads, no reactions, no notifications, no mobile. If it
+grows past that, the positioning objection was right.
+
+---
+
+## 12. Decisions
+
+| Decision | Chosen | Alternative and why not |
+|---|---|---|
+| Isolation boundary | microVM with its own kernel | Rootless containers — a shared kernel is a defensible boundary when you have recourse against whoever is inside it, and we would not. Redundant anyway once the task is already a microVM. |
+| Where sessions run | ECS Fargate, in our own account and region | Specialist sandbox vendors (Fly Sprites, E2B, Northflank) — sub-second restore and free sleep, but a new subprocessor, and at least one cannot answer the residency question. Fargate is also cheaper per running hour. |
+| Which Fargate | ECS | EKS on Fargate has neither ARM nor spot pricing and puts back the cluster we are avoiding. |
+| Not our existing cluster | Explicitly excluded | No network policy, no limits, no autoscaler, six spare cores, an out-of-support version, and the message database one connection away in the same namespace. |
+| Idle handling | Destroy and rebuild, with cold start attacked directly | Modelling a sleep state — Fargate has no pause, and a state the platform cannot provide is a fiction that becomes a support ticket. |
+| Unit of hosting | One task per agent | Per tenant shares a blast radius between agents with different credentials; per session throws away the working directory and the CLI's state every time. |
+| Runtime | The existing sidecar, containerised | A new server-side runner — discards working, tested code for no gain. The `SidecarHost` seam is already two methods wide. |
+| Delivery mechanism | The image, plus container overrides; keep the `SidecarHost` interface | Replacing SSH — self-hosted users still own machines, and keeping one interface is what stops the two paths diverging the way on-demand start already has. |
+| Host identity | A row in the database | An entry in the user's SSH config — meaningless when the user owns nothing. |
+| Who decides to start a session | The server | The sidecar's watcher — circular: nothing is listening before the sidecar exists. The server already models `auto_session` and already posts the "starting a session" message. |
+| Supervisor placement | A module in `switch-core`, all state in Postgres | A separate service now — premature, but keeping no in-memory authority makes extracting it a deployment change rather than a rewrite. |
+| Model credential | The customer's own, per end user, billed to them | Us paying — prohibited for Claude Code by Anthropic's terms, in as many words. |
+| What we hard-stop on | Task wall-clock seconds | Model tokens — we are not in the request path, so a token limit is advice. Compute is the cost we actually carry. |
+| Client-reported usage | Telemetry, labelled as such | Enforcement or billing — the process reporting the number belongs to the tenant. |
+| Permission model for a hosted session | VM boundary, default-deny egress, scoped filesystem, compute cap | Today's defaults — checks disabled off-laptop, name-based matching, shell allowed, one host of three. The mediation hook is not an enforcement plane. |
+| First chat surface | A message list and composer in the gateway, scoped to first-run and support | Slack first — depends on an app install review a stranger cannot complete during signup. |
+| Free tier | Deferred, and only via a non-Anthropic host behind a spend-capped proxy | A free tier on our Claude credentials — prohibited. |
+| Relationship to multi-tenancy | Downstream of it for self-serve; the existing-deployment case ships first | Building hosting first — signup, tenant isolation and the Slack app are all prerequisites for a stranger. |
+
+---
+
+## 13. Plan
+
+Ordered so each phase is useful on its own. The first three are useful to
+*existing* users and need nothing from the multi-tenancy spike, which is what
+makes them worth doing before any decision about self-serve is taken.
+
+**Phase 0 — the image and the measurement.** Build the task image — sidecar, Node
+20, `tmux`, `git`, one CLI — with lazy image loading configured from the start
+rather than retrofitted. Add the sandbox record and its state machine. Then
+measure the two numbers the design turns on: **cold start end to end**, and the
+**idle-to-active ratio of existing sessions**, which is available today from
+production data and does not need any of this to be built.
+*Done when:* a task can be started by hand, the sidecar comes up in it, an agent
+answers in a room, and we know how long that took and how often it would happen.
+
+**Phase 1 — hosted agents for an existing deployment.** The supervisor, task
+start and stop, credential delivery, the security group and task role from §8,
+and a control in the dashboard. Useful on its own to every current user: your
+agent survives your laptop closing without you having to own and maintain a
+server.
+*Done when:* a user of an existing deployment can move an agent off their machine
+from the gateway, supply a model credential, and have it answer in Slack — with
+egress locked down from the first day rather than a later one.
+
+**Phase 2 — server-side on-demand start.** Move the watcher decision into
+`switch-core`, with an authoritative in-flight guard, and gate the sidecar's own
+watcher off for hosted agents. This is where the cold-start number from phase 0
+either is acceptable or forces the warm pool.
+*Done when:* a mention starts a task and gets an answer, with nothing running on
+anyone's laptop, and the room is told what is happening while it waits.
+
+**Phase 3 — metering and the compute hard stop.** Task-seconds per tenant, plan
+ceilings, enforced by stopping tasks. Client-reported model cost recorded and
+displayed as telemetry, labelled as such.
+*Done when:* a tenant out of compute budget has its tasks stopped and can see in
+the dashboard why.
+
+**Phase 4 — the chat surface.** Message read and write on the gateway API, one
+view in the dashboard.
+*Done when:* someone with no Slack can hold a conversation with their agent.
+
+**Phase 5 — self-serve.** Needs multi-tenancy phases 1 and 2. Signup creates a
+tenant, the tenant's first agent is hosted, payment.
+*Done when:* a stranger with a card and an API key has a working agent without
+talking to anyone.
+
+**Phase 6 — the free tier**, if and only if §9's commercial question is answered.
+
+---
+
+## Open questions
+
+- **What is an acceptable wake latency?** A product judgement nobody has made,
+  and the thing the whole cold-start argument in §3 is measured against. Thirty
+  seconds with a "working on it" message in the room may be fine; the same thirty
+  seconds in silence is not.
+- **Is a warm pool needed at launch, and can a pooled task adopt a specific
+  agent's state?** A pool removes the infrastructure cold start, not the agent
+  restore. Whether a task can mount a per-agent persistent volume fast enough for
+  the second half to be cheap is unverified.
+- **What is the idle-to-active ratio of a real agent?** Every number in §3 turns
+  on it and we have no data. It is measurable today from existing sessions and
+  should be measured before the pooling decision, not after.
+- Staying in our own account and region answers residency for us. It does not
+  answer whether any target customer requires more than that — a specific region,
+  a specific account, or their own. Northflank was the only rented option that
+  could have offered the last of those; Fargate can, at the price of operating a
+  second deployment path.
+- Does an inline proxy carrying the customer's *own* key count as
+  "intermediating" under Anthropic's terms? A legal read, not an engineering
+  call, and §9 depends on the equivalent answer from whichever provider sits
+  behind our proxy.
+- Does a sandbox we operate holding the OAuth token that resulted from the
+  customer's own sign-in count as "collect, store, or intermediate Claude.ai
+  credentials"? The API-key case is explicitly permitted; this one is not
+  addressed anywhere on that page.
+- How does an end user complete an interactive provider sign-in in a headless
+  sandbox? A browser terminal is the obvious answer and is also a remote shell we
+  are handing to a stranger.
+- **What does session resumption mean?** Destroying a task loses the agent CLI's
+  in-memory context, and no hosting choice fixes that — a restored machine gives
+  back a terminal with a dead socket in it, not a conversation that carries on.
+  Whether a resumed session reloads context from the room, from the CLI's own
+  transcript, or starts clean is a product decision that nobody has taken and
+  that hosting forces.
+- Does the `replicaCount must be 1` constraint hold once one process supervises a
+  fleet? At what number does it stop holding?
+- Should hosted customers be a separate deployment from self-hosted ones, the way
+  the multi-tenancy spike keeps the demo environment separate?
+- Who is on call, and what is the promise? Neither has an answer today, and
+  neither is an engineering decision.


### PR DESCRIPTION
Adds `docs/old/hosted-agents.md`, a design spike on what it would take for Switch to run an agent session **for** a customer, so that someone can sign up and have a working agent without installing anything. Today every agent runs on a machine the user owns. Marked as a spike and not implemented, in the style of `docs/old/multi-tenancy.md` (which is itself in flight on an unmerged branch, and is named as such in the text since this document references it throughout).

## The argument

**The runtime is mostly done and on the wrong side of the wire.** The Console sidecar is already a complete headless agent runner — around 2,400 lines, no Electron by construction, `tmux` plus `git` plus a Node floor of 18, with `AgentLaunchSpec` as a plain-JSON launch recipe and a two-method `SidecarHost` seam whose only implementation happens to be SSH. Put it in an image and the runtime problem is largely solved. What gets discarded is everything that assumes a person owns the box, most consequentially the assumption that a model credential is already on the machine because somebody typed it there.

**What has to be built is a control plane, a chat surface and a credential model.** Nothing in `switch_core` can start anything. The watcher that notices "this agent was addressed and has no session" lives inside the sidecar, which is circular for hosting; the server already models `auto_session` and already posts the "starting a session" message, so the model is there and only the actor is missing. And there is no surface a person can point a browser at: no message endpoints on the gateway API, no composer in the dashboard.

**Licensing decides the credential model, and it corrects an assumption elsewhere.** Anthropic's terms permit running Claude Code in hosted sandboxes on two conditions — an unmodified binary, and no paying for or intermediating usage on end users' behalf. So bring-your-own-credential is permitted for the paid path and a free tier on our Claude tokens is not. Beyond this document: the multi-tenancy spike's quota phase opens with "one customer's runaway loop is our bill", and against these terms that premise does not hold. The hard stop moves from tokens, which we cannot enforce because Switch is not in the request path, to compute seconds, which we own outright.

**A free tier is still possible, on a different vendor's model** — an open model served through our own account, with the customer connecting their own credential for the good models. That rests on a reading of the applicable model licence which is **explicitly marked unverified in the text** and listed as an open question: if the operative instrument restricts use to the subscribing customer's internal business purposes, that tier does not exist. Self-hosting the model is ruled out with numbers at twenty to a hundred and sixty times the API price for a free tier's duty cycle.

**ECS Fargate in our own account, and not on price.** Per-task isolation quoted from AWS, a network interface in a VPC we control so egress policy is a security group, a real IAM boundary, and residency that follows from the account. Cold start (thirty to forty-five seconds, billed from image pull) is named as the central risk — and the document now shows the case where the recommendation loses: warm Fargate is about $86 a month against roughly $5 for E2B and $9 for Sprites asleep, and they beat it below roughly seventy and forty per cent duty cycle respectively, while also waking in under a second. The recommendation is defended on subprocessor and account-control grounds and says in terms that it should not be defended on price.

**And an honest case against.** Hosting makes us a processor of customer code and prompts, which contradicts the README's own "designed to be self-hostable and for your data to stay where it is". §10 argues the objection rather than dismissing it, and offers the middle path: host the demo, not the product.

## Decisions the reader is being asked to make

The full table is in §12. The contested ones:

1. **ECS Fargate over the specialist sandbox vendors**, accepting that they are cheaper *and* faster to wake for a mostly-idle agent, and that the case is entirely about not adding a subprocessor and controlling the account. If phase 0's cold-start measurement forces a warm pool, the price argument inverts and this should be reopened.
2. **Bring-your-own-credential as the only model for the paid path.** Forced by the licence, and it puts an API key in the signup flow, which is where strangers leave.
3. **A free tier on an open model through our own account**, gated on verifying the licence claim, with the recommendation being a *validation process* against the real harness rather than a model name — every cheap model surveyed has a dated failure mode in this class of harness, and the inference backend alone can move a score by forty points.
4. **Hard-stop on compute seconds rather than tokens** on the paid path; on the free tier we own the account, so the provider-side cap returns.
5. **A minimal message list and composer in the gateway** as the first chat surface, ahead of the official Slack app — the decision most in tension with "Switch is not a messaging app", taken because signup cannot depend on a third party's install review.
6. **Hosted sessions do not inherit today's permission defaults**, and the mediation hook is not counted as a control at all.
7. **Sequencing.** Phases 0 to 3 are useful to current users and need nothing from multi-tenancy. Phase 5 is labelled a paid-only beta because it still contains the enrollment step phase 6 exists to remove; the two may want to ship together.

## Open questions, including two that can kill it

**Will we agree to Anthropic's Commercial Terms of Service, and who signs?** No agreement, no hosted Claude Code, and phase 1 does not exist. **Will the positioning change, and when?** §10 argues that shipping a hosted tier while the public material still says data stays where it is is the worst outcome available, and nobody has decided.

Then: what the free tier's model licence actually says; acceptable wake latency; how durable per-agent state is carried, given a Fargate task cannot attach a volume after launch (so a warm pool buys the infrastructure half of wake latency and nothing else, permanently); the idle-to-active ratio, measurable today; whether an inline proxy carrying the customer's own key counts as "intermediating"; how an end user completes an interactive sign-in without us intermediating it; what session resumption means once a destroyed task takes the CLI's context with it; per-tenant attribution for free-tier spend; where the single-replica constraint breaks; and who is on call.

Two market claims in §10 are labelled in the text as an unsourced read rather than a citation. Northflank is named as **not evaluated** and pushed into the phase 0 measurement rather than rejected on grounds nobody established.

## Scope

Two files: the document, and one sentence in `docs/README.md` so the description of `docs/old/` accounts for design spikes. No code, no version bumps, no changelog. Codebase claims were verified against the tree; the document has been through two review passes and the second one's corrections are in the third commit.