### PR TITLE
fix(deploy): keep the setup job authenticated to the gateway

### DIFF
--- a/deploy/shared_resources/setup.py
+++ b/deploy/shared_resources/setup.py
@@ -181,9 +181,16 @@ def gateway_login() -> httpx.Client:
 
     Bridge administration is admin-gated, so we log in as the seeded gateway
     admin (cookie-based JWT) and drive the same authorized endpoints the
-    dashboard uses — there is no unauthenticated bridge-admin surface. The
-    login sets the switch_auth cookie on the client, which every subsequent
-    gateway call carries.
+    dashboard uses — there is no unauthenticated bridge-admin surface.
+
+    The session cookie is then carried by hand rather than left to the cookie
+    jar. A deployment served over HTTPS mints it with the Secure flag, and this
+    job reaches switch-core over plain HTTP on its in-cluster address, so a
+    conforming client accepts the cookie at login and declines to send it back:
+    the login succeeds and every call after it is anonymous. Replaying the value
+    as a header discloses nothing the login did not — the admin password crossed
+    the same hop a moment earlier — and leaves the Secure flag doing its real
+    job for browsers.
     """
     client = httpx.Client(base_url=SWITCH_URL, timeout=10)
     resp = client.post(
@@ -196,6 +203,15 @@ def gateway_login() -> httpx.Client:
             f"{GATEWAY_ADMIN_EMAIL}: {resp.status_code} {resp.text}"
         )
         sys.exit(1)
+    token = resp.cookies.get("switch_auth")
+    if token is None:
+        print(
+            "ERROR: The Switch gateway accepted the login as "
+            f"{GATEWAY_ADMIN_EMAIL} but issued no switch_auth cookie, so the "
+            "setup calls that follow cannot be authenticated."
+        )
+        sys.exit(1)
+    client.headers["Cookie"] = f"switch_auth={token}"
     return client
 
 


### PR DESCRIPTION
## The failure

On any deployment served over HTTPS, the post-install/post-upgrade `setup` job
fails:

```
Traceback (most recent call last):
  File "/setup.py", line 351, in main
    bridge_id = register_bridge(client)
  File "/setup.py", line 252, in register_bridge
    resp.raise_for_status()
httpx.HTTPStatusError: Client error '401 Unauthorized' for url
'http://<release>-switch-core:8000/gateway/collaborations'
```

Everything before it succeeds — Mattermost is seeded, switch-core answers its
health check, the gateway accepts the admin login.

## Why

The gateway mints `switch_auth` with the `Secure` flag whenever
`GATEWAY_COOKIE_SECURE` is on, which is the chart default and correct for a
deployment behind HTTPS. The setup job, though, reaches switch-core over plain
HTTP on the in-cluster service address.

A conforming HTTP client stores a `Secure` cookie received over HTTP and then
refuses to send it back over HTTP. So the login returns 200, the cookie jar
holds a token, and no request after it carries one. `GET /gateway/collaborations`
401s — silently, since that call only checks `is_success` — and the `POST` that
follows 401s loudly.

Reproduced against a mock transport:

```
token readable from response: TOK123
WITHOUT fix, Cookie header: None
WITH fix, Cookie header:    switch_auth=TOK123
HTTPS with fix, Cookie header: switch_auth=TOK123
```

Present since setup moved onto the admin-gated gateway API in #120; the flag
has defaulted on since the chart was written.

## The fix

Take the token from the login response and set it as an explicit `Cookie`
header on the client.

It discloses nothing the login did not: `GATEWAY_ADMIN_PASSWORD` crosses that
same hop in the clear a moment earlier. The alternative — turning
`GATEWAY_COOKIE_SECURE` off so the jar cooperates — would drop the flag for
browsers, where it is doing real work. As the last line above shows, an HTTPS
deployment is unaffected: the jar's own header replaces the explicit one with
the same value, so there is no duplicate cookie.

A login that returns success without issuing a cookie now exits with a message
naming that, rather than proceeding to a 401 several calls later.

## Testing

- Mock-transport check of the cookie behaviour, above.
- `ruff format --check` / `ruff check` on the changed file.
- Not yet exercised against a live cluster; the next `switch-dev` deploy is the
  real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)