### PR TITLE
release: switch-core 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,34 @@ version of their own to them without also giving them a release of their own.
 
 ### [Unreleased]
 
+### [0.26.0] - 2026-09-09
+
+#### Added
+- **Multi-tenancy groundwork (phase 0).** Tenant scoping across the backend, and
+  the tenant id plus request context are now stamped on every log line.
+- **Typed `params` block in rooms YAML** with `{var}` interpolation, so room
+  definitions can be parameterised (#402).
+- **An agent can read any room it is a member of without connecting to it**
+  (CHOO-2628) — a new agent operation. (Reaches agents once the runtime and
+  connector plugins that expose it are released; the server side ships here.)
+- Users can change their own password in the gateway (#323).
+
+#### Fixed
+- **OIDC account linking hardened.** A verified OIDC identity is linked to its
+  account by email; multi-issuer and null-issuer collisions are handled rather
+  than guessed, duplicate emails no longer resolve silently, legacy identities
+  are backfilled and matched case-insensitively, and the race is retried with
+  savepoints (CHOO-2624).
+- **Agent bootstrap-key and registration hardening** — resilient bootstrap-key
+  seeding across admin changes and legacy migrations, retired key hashes are
+  revoked and keys retired rather than deleted, a config fault is no longer
+  misreported as a bad token, and the deployment-wide registration token is
+  scoped to a non-admin owner (CHOO-2624).
+- A Postgres server that fails over without closing the connection is now
+  noticed by the notify listener (CHOO-2622).
+- The setup job stays authenticated to the gateway (CHOO-2622); Helm applies the
+  secret and CA bundle before the migration that needs them.
+
 ### [0.25.0] - 2026-09-06
 
 #### Added

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -60,7 +60,7 @@
 artifacts:
   switch-core:
     description: The backend service, and the gateway API it serves.
-    version: 0.25.0
+    version: 0.26.0
     declared_in: core/pyproject.toml
     published_as: switch-core
 

--- a/console/packages/shared/src/artifacts.ts
+++ b/console/packages/shared/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.25.0',
+  'switch-core': '0.26.0',
   'switch-console': '0.34.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.25.0',
-  setup: '0.25.0',
-  'helm-chart': '0.25.0',
-  compose: '0.25.0',
+  gateway: '0.26.0',
+  setup: '0.26.0',
+  'helm-chart': '0.26.0',
+  compose: '0.26.0',
   'switch-connector': '0.9.14',
   'switch-connector-codex': '0.3.15',
   'switch-connector-opencode': '0.1.10',

--- a/console/packages/switch-agent-runtime/src/artifacts.ts
+++ b/console/packages/switch-agent-runtime/src/artifacts.ts
@@ -20,14 +20,14 @@ export interface ContractRange {
  * `CONTRACTS` below. The two must never be derived from one another.
  */
 export const ARTIFACT_VERSIONS = {
-  'switch-core': '0.25.0',
+  'switch-core': '0.26.0',
   'switch-console': '0.34.0',
   'agent-runtime': '0.4.1',
   sidecar: '1.9.7',
-  gateway: '0.25.0',
-  setup: '0.25.0',
-  'helm-chart': '0.25.0',
-  compose: '0.25.0',
+  gateway: '0.26.0',
+  setup: '0.26.0',
+  'helm-chart': '0.26.0',
+  compose: '0.26.0',
   'switch-connector': '0.9.14',
   'switch-connector-codex': '0.3.15',
   'switch-connector-opencode': '0.1.10',

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "switch-core"
-version = "0.25.0"
+version = "0.26.0"
 description = "Switch — AI agent orchestration and governance platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/core/switch_core/artifacts.py
+++ b/core/switch_core/artifacts.py
@@ -20,14 +20,14 @@ class ContractRange(NamedTuple):
 # Where each artifact is. Says nothing about compatibility — that is
 # CONTRACTS below. The two must never be derived from one another.
 ARTIFACT_VERSIONS: Final[dict[str, str]] = {
-    "switch-core": "0.25.0",
+    "switch-core": "0.26.0",
     "switch-console": "0.34.0",
     "agent-runtime": "0.4.1",
     "sidecar": "1.9.7",
-    "gateway": "0.25.0",
-    "setup": "0.25.0",
-    "helm-chart": "0.25.0",
-    "compose": "0.25.0",
+    "gateway": "0.26.0",
+    "setup": "0.26.0",
+    "helm-chart": "0.26.0",
+    "compose": "0.26.0",
     "switch-connector": "0.9.14",
     "switch-connector-codex": "0.3.15",
     "switch-connector-opencode": "0.1.10",

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -2334,7 +2334,7 @@ wheels = [
 
 [[package]]
 name = "switch-core"
-version = "0.25.0"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **switch-core 0.26.0** (minor).

- **Added** — multi-tenancy phase 0 (tenant scoping + tenant id/request context on every log line); rooms-yaml typed `params` with `{var}` interpolation (#402); read-any-room agent operation, server side (CHOO-2628); gateway self-service password (#323).
- **Fixed/Security** — OIDC account linking (verified-email linking, multi/null-issuer collisions, dup-email, legacy backfill, savepoint retry) (CHOO-2624); agent bootstrap-key/registration hardening + non-admin registration token (CHOO-2624); DB failover-listener detection, setup-job gateway auth, helm migration ordering (CHOO-2622).
- **Migrations:** yes (OIDC identities + tenancy).

Bumped `core/pyproject.toml` + `artifacts.yaml`, regenerated (`just artifacts-check` green), cut the `## switch-core` changelog. **agent-protocol contract left unchanged** — the read-room operation is additive and its runtime peer isn't part of this release (the tool reaches agents when the runtime + plugins ship).

Package-only release — no GitHub Release; the tag + changelog are the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)