### PR TITLE
Multi-tenancy Phase 1: the tenant model (CHOO-2623)

### DIFF
--- a/core/switch_core/bridges/agent/protocol/service.py
+++ b/core/switch_core/bridges/agent/protocol/service.py
@@ -337,8 +337,9 @@ class ProtocolService:
             InvalidIconUrl: ``icon_url`` is malformed or points somewhere unsafe.
             InvalidDisplayName: ``display_name`` is over-long or unsafe to render.
             AgentExistsError: agent with this name exists and ``overwrite`` is
-                False, or the existing agent is owned by another user (the name
-                is global, but re-registration stays within the owner's tenant).
+                False, or the existing agent is owned by another user
+                (``agents.name`` is unique per tenant, but re-registration
+                stays within the owner's tenant).
         """
         if not _VALID_NAME_RE.match(name):
             raise ValueError(
@@ -367,12 +368,13 @@ class ProtocolService:
                     "replaces integration profile)."
                 )
             if existing and existing.owner_id != owner_id:
-                # Agent names are a global namespace, but re-registration must
-                # stay inside the caller's own tenant. Overwriting an agent
-                # owned by someone else would mint the caller a live API key for
-                # that agent (whose owner_id is left unchanged) and delete the
-                # real owner's key, i.e. a cross-tenant takeover. Report it as a
-                # plain name clash so ownership is never disclosed.
+                # `agents.name` is unique per tenant, not globally, but
+                # re-registration must still stay inside the caller's own
+                # tenant. Overwriting an agent owned by someone else would mint
+                # the caller a live API key for that agent (whose owner_id is
+                # left unchanged) and delete the real owner's key, i.e. a
+                # cross-tenant takeover. Report it as a plain name clash so
+                # ownership is never disclosed.
                 raise AgentExistsError(
                     f"Agent already exists: {name!r}. "
                     "Pass overwrite=True to re-register (rotates API key, "

--- a/core/switch_core/db/models.py
+++ b/core/switch_core/db/models.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     LargeBinary,
@@ -31,6 +32,73 @@ from switch_core.db.notify_ddl import (
 
 def _uuid() -> str:
     return str(uuid.uuid4())
+
+
+# ── Tenants ─────────────────────────────────────────────────────────────────
+
+
+class Tenant(Base):
+    """The top-level customer boundary every scoped table hangs off.
+
+    Deliberately minimal: no `plan`, `status` or `deleted_at`. A later phase
+    adds plans and deletion; a `deleted_at` that nothing honours yet would
+    read as a guarantee the code does not make.
+    """
+
+    __tablename__ = "tenants"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
+    slug: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[str] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class TenantMember(Base):
+    """A user's membership in a tenant, and their role within it.
+
+    Membership is a row, not a column on the user: one login may belong to
+    several tenants. `role` is a checked string rather than an enum type,
+    matching how `users.role` is already stored — a later phase gives these
+    roles meaning; this one only records them.
+    """
+
+    __tablename__ = "tenant_members"
+    __table_args__ = (
+        CheckConstraint(
+            "role IN ('owner', 'admin', 'member')", name="ck_tenant_members_role"
+        ),
+    )
+
+    tenant_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("tenants.id"), primary_key=True
+    )
+    user_id: Mapped[str] = mapped_column(Text, ForeignKey("users.id"), primary_key=True)
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[str] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+# The fixed id of the one tenant that exists before a second is ever onboarded.
+# Written into the migration verbatim rather than read from config, so a later
+# edit to `SwitchConfig.tenant_id` can never desync from the row it names.
+TENANT_ZERO_ID = "00000000-0000-0000-0000-000000000000"
+
+
+class TenantScoped:
+    """Mixin carrying the tenant column shared by every per-tenant table.
+
+    The Python-side default returns tenant zero — the only tenant that exists
+    today — so an ordinary ORM insert needs no change to land in the right
+    place. A later PR replaces this default with a value read from the
+    request/session context; nothing here reads from a contextvar yet.
+    """
+
+    tenant_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("tenants.id"), nullable=False, default=TENANT_ZERO_ID
+    )
 
 
 # ── Users ──────────────────────────────────────────────────────────────────────
@@ -113,11 +181,16 @@ class OidcIdentity(Base):
 # ── API Keys ─────────────────────────────────────────────────────────────────
 
 
-class ApiKey(Base):
+class ApiKey(TenantScoped, Base):
     __tablename__ = "api_keys"
+    __table_args__ = (
+        UniqueConstraint("id", "tenant_id", name="uq_api_keys_id_tenant"),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     user_id: Mapped[str] = mapped_column(Text, ForeignKey("users.id"), nullable=False)
+    # Global on purpose: bearer auth resolves the hash before a tenant is
+    # known, so it cannot be scoped by one.
     key_hash: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
     encrypted_key: Mapped[str] = mapped_column(Text, nullable=False)
     label: Mapped[str] = mapped_column(Text, nullable=False)
@@ -130,11 +203,17 @@ class ApiKey(Base):
 # ── Clients ────────────────────────────────────────────────────────────────────
 
 
-class Client(Base):
+class Client(TenantScoped, Base):
     __tablename__ = "clients"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "matrix_user_id", name="uq_clients_tenant_matrix_user_id"
+        ),
+        UniqueConstraint("id", "tenant_id", name="uq_clients_id_tenant"),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    matrix_user_id: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    matrix_user_id: Mapped[str] = mapped_column(Text, nullable=False)
     display_name: Mapped[str] = mapped_column(Text, nullable=False)
     type: Mapped[str] = mapped_column(Text, nullable=False)
     config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
@@ -143,13 +222,23 @@ class Client(Base):
     )
 
 
-class ClientRoom(Base):
+class ClientRoom(TenantScoped, Base):
     __tablename__ = "client_rooms"
-
-    client_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("clients.id"), primary_key=True
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["tenant_id", "client_id"],
+            ["clients.tenant_id", "clients.id"],
+            name="fk_client_rooms_client",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_client_rooms_room",
+        ),
     )
-    room_id: Mapped[str] = mapped_column(Text, ForeignKey("rooms.id"), primary_key=True)
+
+    client_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    room_id: Mapped[str] = mapped_column(Text, primary_key=True)
     joined_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -158,12 +247,32 @@ class ClientRoom(Base):
 # ── Agents ─────────────────────────────────────────────────────────────────────
 
 
-class Agent(Base):
+class Agent(TenantScoped, Base):
     __tablename__ = "agents"
-    __table_args__ = (Index("ix_agents_parent_agent_id", "parent_agent_id"),)
+    __table_args__ = (
+        Index("ix_agents_parent_agent_id", "parent_agent_id"),
+        UniqueConstraint("tenant_id", "name", name="uq_agents_tenant_name"),
+        UniqueConstraint("id", "tenant_id", name="uq_agents_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "client_id"],
+            ["clients.tenant_id", "clients.id"],
+            name="fk_agents_client",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "api_key_id"],
+            ["api_keys.tenant_id", "api_keys.id"],
+            name="fk_agents_api_key",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "parent_agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_agents_parent_agent",
+            ondelete="SET NULL (parent_agent_id)",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    name: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     # Absolute https URL of the agent's icon (CHOO-2171). Switch stores the
     # link, never image bytes: whatever produces the picture — a generated-
@@ -180,15 +289,11 @@ class Agent(Base):
     agent_type: Mapped[str] = mapped_column(Text, nullable=False)
     connector_type: Mapped[str] = mapped_column(Text, nullable=False)
     integration_profile: Mapped[dict] = mapped_column(JSONB, nullable=False)
-    client_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("clients.id"), unique=True, nullable=False
-    )
+    client_id: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
     # Indexed because bearer-token auth resolves the key row and then looks the
     # agent up by this column on every authenticated request, heartbeats
     # included — without it that is a sequential scan per beat.
-    api_key_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("api_keys.id"), nullable=False, index=True
-    )
+    api_key_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
     owner_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id"), nullable=True
     )
@@ -197,9 +302,7 @@ class Agent(Base):
     # main Claude Code agent. NULL for ordinary top-level agents. ON DELETE
     # SET NULL so deleting a parent orphans its children rather than removing
     # them (they keep their own identity, rooms, and history).
-    parent_agent_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("agents.id", ondelete="SET NULL"), nullable=True
-    )
+    parent_agent_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     oauth_client_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Scoped agent-addressing permissions (CHOO-1585). NULL preserves today's
     # open behaviour (anyone may address the agent); a stored policy is a
@@ -215,13 +318,20 @@ class Agent(Base):
 # ── Tools ──────────────────────────────────────────────────────────────────────
 
 
-class Tool(Base):
+class Tool(TenantScoped, Base):
     __tablename__ = "tools"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["tenant_id", "agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_tools_agent",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
-    agent_id: Mapped[str] = mapped_column(Text, ForeignKey("agents.id"), nullable=False)
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
     args_schema: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     metadata_: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
     created_at: Mapped[str] = mapped_column(
@@ -232,13 +342,20 @@ class Tool(Base):
 # ── Models ─────────────────────────────────────────────────────────────────────
 
 
-class Model(Base):
+class Model(TenantScoped, Base):
     __tablename__ = "models"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["tenant_id", "agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_models_agent",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
-    agent_id: Mapped[str] = mapped_column(Text, ForeignKey("agents.id"), nullable=False)
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
     metadata_: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
     created_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -251,22 +368,45 @@ class Model(Base):
 agent_skills = Table(
     "agent_skills",
     Base.metadata,
-    Column("agent_id", Text, ForeignKey("agents.id"), primary_key=True),
-    Column("skill_id", Text, ForeignKey("skills.id"), primary_key=True),
+    Column(
+        "tenant_id",
+        Text,
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=TENANT_ZERO_ID,
+    ),
+    Column("agent_id", Text, primary_key=True),
+    Column("skill_id", Text, primary_key=True),
+    ForeignKeyConstraint(
+        ["tenant_id", "agent_id"],
+        ["agents.tenant_id", "agents.id"],
+        name="fk_agent_skills_agent",
+    ),
+    ForeignKeyConstraint(
+        ["tenant_id", "skill_id"],
+        ["skills.tenant_id", "skills.id"],
+        name="fk_agent_skills_skill",
+    ),
 )
 
 
-class Skill(Base):
+class Skill(TenantScoped, Base):
     __tablename__ = "skills"
+    __table_args__ = (
+        UniqueConstraint("id", "tenant_id", name="uq_skills_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "owner_agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_skills_owner_agent",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     version: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     visibility: Mapped[str] = mapped_column(Text, nullable=False)
-    owner_agent_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("agents.id"), nullable=True
-    )
+    owner_agent_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id"), nullable=True
     )
@@ -283,8 +423,15 @@ class Skill(Base):
 room_agents = Table(
     "room_agents",
     Base.metadata,
-    Column("room_id", Text, ForeignKey("rooms.id"), primary_key=True),
-    Column("agent_id", Text, ForeignKey("agents.id"), primary_key=True),
+    Column(
+        "tenant_id",
+        Text,
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=TENANT_ZERO_ID,
+    ),
+    Column("room_id", Text, primary_key=True),
+    Column("agent_id", Text, primary_key=True),
     Column("last_connected_at", DateTime(timezone=True), nullable=True),
     Column(
         "receives_join_events",
@@ -295,17 +442,44 @@ room_agents = Table(
     # Room-scoped alias: `@<alias>` addresses this agent in this room exactly
     # like its real name. Null when the agent has no alias here.
     Column("alias", Text, nullable=True),
+    ForeignKeyConstraint(
+        ["tenant_id", "room_id"],
+        ["rooms.tenant_id", "rooms.id"],
+        name="fk_room_agents_room",
+    ),
+    ForeignKeyConstraint(
+        ["tenant_id", "agent_id"],
+        ["agents.tenant_id", "agents.id"],
+        name="fk_room_agents_agent",
+    ),
 )
 
 room_skills = Table(
     "room_skills",
     Base.metadata,
-    Column("room_id", Text, ForeignKey("rooms.id"), primary_key=True),
-    Column("skill_id", Text, ForeignKey("skills.id"), primary_key=True),
+    Column(
+        "tenant_id",
+        Text,
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=TENANT_ZERO_ID,
+    ),
+    Column("room_id", Text, primary_key=True),
+    Column("skill_id", Text, primary_key=True),
+    ForeignKeyConstraint(
+        ["tenant_id", "room_id"],
+        ["rooms.tenant_id", "rooms.id"],
+        name="fk_room_skills_room",
+    ),
+    ForeignKeyConstraint(
+        ["tenant_id", "skill_id"],
+        ["skills.tenant_id", "skills.id"],
+        name="fk_room_skills_skill",
+    ),
 )
 
 
-class Room(Base):
+class Room(TenantScoped, Base):
     __tablename__ = "rooms"
     __table_args__ = (
         # A bridged channel maps to at most one Switch room. Partial so that
@@ -321,15 +495,28 @@ class Room(Base):
         # and the ON DELETE SET NULL when a group is removed both scan the
         # table. Mirrors ix_agents_parent_agent_id.
         Index("ix_rooms_group_id", "group_id"),
+        UniqueConstraint(
+            "tenant_id", "matrix_room_id", name="uq_rooms_tenant_matrix_room_id"
+        ),
+        UniqueConstraint("id", "tenant_id", name="uq_rooms_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "bridge_id"],
+            ["collaboration_bridges.tenant_id", "collaboration_bridges.id"],
+            name="fk_rooms_bridge",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "group_id"],
+            ["room_groups.tenant_id", "room_groups.id"],
+            name="fk_rooms_group",
+            ondelete="SET NULL (group_id)",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    matrix_room_id: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    matrix_room_id: Mapped[str] = mapped_column(Text, nullable=False)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
-    bridge_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("collaboration_bridges.id"), nullable=True
-    )
+    bridge_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     external_channel_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     channel_type: Mapped[str | None] = mapped_column(Text, nullable=True)
     admin_mode: Mapped[bool] = mapped_column(
@@ -341,9 +528,7 @@ class Room(Base):
     created_by: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id"), nullable=True
     )
-    group_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("room_groups.id", ondelete="SET NULL"), nullable=True
-    )
+    group_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     owner_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id"), nullable=True
     )
@@ -369,7 +554,7 @@ class Room(Base):
 # ── Room Groups ─────────────────────────────────────────────────────────────────
 
 
-class RoomGroup(Base):
+class RoomGroup(TenantScoped, Base):
     """A named, optionally-nested organizational group for rooms.
 
     Groups form a tree via the nullable `parent_group_id` self-reference;
@@ -386,15 +571,20 @@ class RoomGroup(Base):
     __tablename__ = "room_groups"
     __table_args__ = (
         CheckConstraint("parent_group_id <> id", name="room_groups_no_self_parent"),
+        UniqueConstraint("id", "tenant_id", name="uq_room_groups_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "parent_group_id"],
+            ["room_groups.tenant_id", "room_groups.id"],
+            name="fk_room_groups_parent_group",
+            ondelete="SET NULL (parent_group_id)",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     color: Mapped[str | None] = mapped_column(Text, nullable=True)
-    parent_group_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("room_groups.id", ondelete="SET NULL"), nullable=True
-    )
+    parent_group_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -403,7 +593,7 @@ class RoomGroup(Base):
 # ── Room Links ────────────────────────────────────────────────────────────────
 
 
-class RoomLink(Base):
+class RoomLink(TenantScoped, Base):
     """Directed pointer from one room to another, with a free-text label.
 
     A row represents a one-way link `source_room_id → target_room_id`. The pair
@@ -414,14 +604,22 @@ class RoomLink(Base):
     __tablename__ = "room_links"
     __table_args__ = (
         CheckConstraint("source_room_id <> target_room_id", name="room_links_no_self"),
+        ForeignKeyConstraint(
+            ["tenant_id", "source_room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_room_links_source_room",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "target_room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_room_links_target_room",
+            ondelete="CASCADE",
+        ),
     )
 
-    source_room_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), primary_key=True
-    )
-    target_room_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), primary_key=True
-    )
+    source_room_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    target_room_id: Mapped[str] = mapped_column(Text, primary_key=True)
     label: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -431,17 +629,32 @@ class RoomLink(Base):
 # ── Tasks ──────────────────────────────────────────────────────────────────────
 
 
-class Task(Base):
+class Task(TenantScoped, Base):
     __tablename__ = "tasks"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_tasks_room",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "requester_agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_tasks_requester_agent",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "performer_agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_tasks_performer_agent",
+            ondelete="CASCADE",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    room_id: Mapped[str] = mapped_column(Text, ForeignKey("rooms.id"), nullable=False)
-    requester_agent_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
-    )
-    performer_agent_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
-    )
+    room_id: Mapped[str] = mapped_column(Text, nullable=False)
+    requester_agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    performer_agent_id: Mapped[str] = mapped_column(Text, nullable=False)
     summary: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(Text, nullable=False)
@@ -464,20 +677,57 @@ class Task(Base):
 room_references = Table(
     "room_references",
     Base.metadata,
-    Column("room_id", Text, ForeignKey("rooms.id"), primary_key=True),
-    Column("reference_id", Text, ForeignKey("references.id"), primary_key=True),
+    Column(
+        "tenant_id",
+        Text,
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=TENANT_ZERO_ID,
+    ),
+    Column("room_id", Text, primary_key=True),
+    Column("reference_id", Text, primary_key=True),
+    ForeignKeyConstraint(
+        ["tenant_id", "room_id"],
+        ["rooms.tenant_id", "rooms.id"],
+        name="fk_room_references_room",
+    ),
+    ForeignKeyConstraint(
+        ["tenant_id", "reference_id"],
+        ["references.tenant_id", "references.id"],
+        name="fk_room_references_reference",
+    ),
 )
 
 room_documents = Table(
     "room_documents",
     Base.metadata,
-    Column("room_id", Text, ForeignKey("rooms.id"), primary_key=True),
-    Column("document_id", Text, ForeignKey("documents.id"), primary_key=True),
+    Column(
+        "tenant_id",
+        Text,
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=TENANT_ZERO_ID,
+    ),
+    Column("room_id", Text, primary_key=True),
+    Column("document_id", Text, primary_key=True),
+    ForeignKeyConstraint(
+        ["tenant_id", "room_id"],
+        ["rooms.tenant_id", "rooms.id"],
+        name="fk_room_documents_room",
+    ),
+    ForeignKeyConstraint(
+        ["tenant_id", "document_id"],
+        ["documents.tenant_id", "documents.id"],
+        name="fk_room_documents_document",
+    ),
 )
 
 
-class Reference(Base):
+class Reference(TenantScoped, Base):
     __tablename__ = "references"
+    __table_args__ = (
+        UniqueConstraint("id", "tenant_id", name="uq_references_id_tenant"),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     owner_id: Mapped[str] = mapped_column(Text, ForeignKey("users.id"), nullable=False)
@@ -493,9 +743,21 @@ class Reference(Base):
     )
 
 
-class ReferenceType(Base):
+class ReferenceType(TenantScoped, Base):
+    """A customer-defined reference type slug.
+
+    No surrogate `id`: the natural key is `(tenant_id, type)`, so `tenant_id`
+    joins the primary key directly here rather than through the `TenantScoped`
+    default alone — a type slug may collide across tenants the way `agents.name`
+    does. Nothing references this table by foreign key, so it is also the one
+    scoped table with no `unique (id, tenant_id)`.
+    """
+
     __tablename__ = "reference_types"
 
+    tenant_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("tenants.id"), primary_key=True, default=TENANT_ZERO_ID
+    )
     type: Mapped[str] = mapped_column(Text, primary_key=True)
     owner_id: Mapped[str] = mapped_column(Text, ForeignKey("users.id"), nullable=False)
     read_visibility: Mapped[str] = mapped_column(Text, nullable=False)
@@ -508,7 +770,7 @@ class ReferenceType(Base):
     )
 
 
-class Document(Base):
+class Document(TenantScoped, Base):
     __tablename__ = "documents"
     __table_args__ = (
         Index(
@@ -518,18 +780,27 @@ class Document(Base):
             unique=True,
             postgresql_where=text("room_id IS NOT NULL"),
         ),
+        UniqueConstraint("id", "tenant_id", name="uq_documents_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_documents_room",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "created_by_agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_documents_created_by_agent",
+            ondelete="SET NULL (created_by_agent_id)",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     owner_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id"), nullable=True
     )
-    room_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), nullable=True
-    )
-    created_by_agent_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("agents.id", ondelete="SET NULL"), nullable=True
-    )
+    room_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by_agent_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     read_visibility: Mapped[str] = mapped_column(Text, nullable=False)
     write_visibility: Mapped[str] = mapped_column(Text, nullable=False)
     name: Mapped[str] = mapped_column(Text, nullable=False)
@@ -547,27 +818,81 @@ class Document(Base):
 room_packages = Table(
     "room_packages",
     Base.metadata,
-    Column("room_id", Text, ForeignKey("rooms.id"), primary_key=True),
-    Column("package_id", Text, ForeignKey("packages.id"), primary_key=True),
+    Column(
+        "tenant_id",
+        Text,
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=TENANT_ZERO_ID,
+    ),
+    Column("room_id", Text, primary_key=True),
+    Column("package_id", Text, primary_key=True),
+    ForeignKeyConstraint(
+        ["tenant_id", "room_id"],
+        ["rooms.tenant_id", "rooms.id"],
+        name="fk_room_packages_room",
+    ),
+    ForeignKeyConstraint(
+        ["tenant_id", "package_id"],
+        ["packages.tenant_id", "packages.id"],
+        name="fk_room_packages_package",
+    ),
 )
 
 package_references = Table(
     "package_references",
     Base.metadata,
-    Column("package_id", Text, ForeignKey("packages.id"), primary_key=True),
-    Column("reference_id", Text, ForeignKey("references.id"), primary_key=True),
+    Column(
+        "tenant_id",
+        Text,
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=TENANT_ZERO_ID,
+    ),
+    Column("package_id", Text, primary_key=True),
+    Column("reference_id", Text, primary_key=True),
+    ForeignKeyConstraint(
+        ["tenant_id", "package_id"],
+        ["packages.tenant_id", "packages.id"],
+        name="fk_package_references_package",
+    ),
+    ForeignKeyConstraint(
+        ["tenant_id", "reference_id"],
+        ["references.tenant_id", "references.id"],
+        name="fk_package_references_reference",
+    ),
 )
 
 package_documents = Table(
     "package_documents",
     Base.metadata,
-    Column("package_id", Text, ForeignKey("packages.id"), primary_key=True),
-    Column("document_id", Text, ForeignKey("documents.id"), primary_key=True),
+    Column(
+        "tenant_id",
+        Text,
+        ForeignKey("tenants.id"),
+        nullable=False,
+        default=TENANT_ZERO_ID,
+    ),
+    Column("package_id", Text, primary_key=True),
+    Column("document_id", Text, primary_key=True),
+    ForeignKeyConstraint(
+        ["tenant_id", "package_id"],
+        ["packages.tenant_id", "packages.id"],
+        name="fk_package_documents_package",
+    ),
+    ForeignKeyConstraint(
+        ["tenant_id", "document_id"],
+        ["documents.tenant_id", "documents.id"],
+        name="fk_package_documents_document",
+    ),
 )
 
 
-class Package(Base):
+class Package(TenantScoped, Base):
     __tablename__ = "packages"
+    __table_args__ = (
+        UniqueConstraint("id", "tenant_id", name="uq_packages_id_tenant"),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     owner_id: Mapped[str] = mapped_column(Text, ForeignKey("users.id"), nullable=False)
@@ -584,16 +909,31 @@ class Package(Base):
 # ── Collaboration Bridges ──────────────────────────────────────────────────────
 
 
-class CollaborationBridge(Base):
+class CollaborationBridge(TenantScoped, Base):
     __tablename__ = "collaboration_bridges"
+    __table_args__ = (
+        # The bridge new rooms land on when no bridge is named. At most one row
+        # per tenant may be true; this partial unique index is what actually
+        # enforces that, so concurrent writers cannot produce two defaults.
+        Index(
+            "ix_collaboration_bridges_single_default",
+            "tenant_id",
+            unique=True,
+            postgresql_where=text("is_default"),
+        ),
+        UniqueConstraint("id", "tenant_id", name="uq_collaboration_bridges_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "client_id"],
+            ["clients.tenant_id", "clients.id"],
+            name="fk_collaboration_bridges_client",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     type: Mapped[str] = mapped_column(Text, nullable=False)
     display_name: Mapped[str] = mapped_column(Text, nullable=False)
     connection_config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    client_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("clients.id"), nullable=False
-    )
+    client_id: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(Text, nullable=False)
     agent_greetings_enabled: Mapped[bool] = mapped_column(
         Boolean, server_default="true", nullable=False
@@ -608,9 +948,6 @@ class CollaborationBridge(Base):
     channel_creation_enabled: Mapped[bool] = mapped_column(
         Boolean, server_default="true", nullable=False
     )
-    # The bridge new rooms land on when no bridge is named. At most one row may
-    # be true; the partial unique index below is what actually enforces that,
-    # so concurrent writers cannot produce two defaults.
     is_default: Mapped[bool] = mapped_column(
         Boolean, server_default="false", nullable=False
     )
@@ -618,29 +955,25 @@ class CollaborationBridge(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
-    __table_args__ = (
-        Index(
-            "ix_collaboration_bridges_single_default",
-            "is_default",
-            unique=True,
-            postgresql_where=text("is_default"),
-        ),
-    )
-
 
 # ── Server-Side Connectors ────────────────────────────────────────────────────
 
 
-class ServerConnector(Base):
+class ServerConnector(TenantScoped, Base):
     __tablename__ = "server_connectors"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["tenant_id", "api_key_id"],
+            ["api_keys.tenant_id", "api_keys.id"],
+            name="fk_server_connectors_api_key",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
     type: Mapped[str] = mapped_column(Text, nullable=False)
     display_name: Mapped[str] = mapped_column(Text, nullable=False)
     connection_config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    api_key_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("api_keys.id"), nullable=False
-    )
+    api_key_id: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -650,25 +983,34 @@ class ServerConnector(Base):
 # ── External Users ─────────────────────────────────────────────────────────────
 
 
-class ExternalUser(Base):
+class ExternalUser(TenantScoped, Base):
     __tablename__ = "external_users"
-    __table_args__ = (UniqueConstraint("bridge_id", "external_user_id"),)
+    __table_args__ = (
+        UniqueConstraint("bridge_id", "external_user_id"),
+        UniqueConstraint("id", "tenant_id", name="uq_external_users_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "bridge_id"],
+            ["collaboration_bridges.tenant_id", "collaboration_bridges.id"],
+            name="fk_external_users_bridge",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "client_id"],
+            ["clients.tenant_id", "clients.id"],
+            name="fk_external_users_client",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    bridge_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("collaboration_bridges.id"), nullable=False
-    )
+    bridge_id: Mapped[str] = mapped_column(Text, nullable=False)
     external_user_id: Mapped[str] = mapped_column(Text, nullable=False)
     external_username: Mapped[str] = mapped_column(Text, nullable=False)
-    client_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("clients.id"), nullable=False
-    )
+    client_id: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
 
-class ExternalUserClaim(Base):
+class ExternalUserClaim(TenantScoped, Base):
     """A Switch user's claim that a platform account is theirs (CHOO-2137).
 
     Deliberately many-to-many rather than a single owner per account: an
@@ -682,13 +1024,17 @@ class ExternalUserClaim(Base):
     """
 
     __tablename__ = "external_user_claims"
-    __table_args__ = (Index("ix_external_user_claims_user_id", "user_id"),)
-
-    external_user_id: Mapped[str] = mapped_column(
-        Text,
-        ForeignKey("external_users.id", ondelete="CASCADE"),
-        primary_key=True,
+    __table_args__ = (
+        Index("ix_external_user_claims_user_id", "user_id"),
+        ForeignKeyConstraint(
+            ["tenant_id", "external_user_id"],
+            ["external_users.tenant_id", "external_users.id"],
+            name="fk_external_user_claims_external_user",
+            ondelete="CASCADE",
+        ),
     )
+
+    external_user_id: Mapped[str] = mapped_column(Text, primary_key=True)
     user_id: Mapped[str] = mapped_column(
         Text,
         ForeignKey("users.id", ondelete="CASCADE"),
@@ -702,7 +1048,7 @@ class ExternalUserClaim(Base):
 # ── Agent Sessions ────────────────────────────────────────────────────────────
 
 
-class AgentSession(Base):
+class AgentSession(TenantScoped, Base):
     """Tracks agent reachability and MCP-session room bindings.
 
     Each row carries two independent pieces of state:
@@ -730,15 +1076,23 @@ class AgentSession(Base):
         ),
         Index("ix_agent_sessions_agent_room", "agent_id", "room_id"),
         Index("ix_agent_sessions_transport_session_id", "transport_session_id"),
+        ForeignKeyConstraint(
+            ["tenant_id", "agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_agent_sessions_agent",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_agent_sessions_room",
+            ondelete="CASCADE",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    agent_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
-    )
-    room_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), nullable=True
-    )
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    room_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     transport_session_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     lifecycle: Mapped[str] = mapped_column(Text, nullable=False)
     last_seen_at: Mapped[str] = mapped_column(
@@ -749,7 +1103,7 @@ class AgentSession(Base):
     )
 
 
-class AgentRuntimeState(Base):
+class AgentRuntimeState(TenantScoped, Base):
     """The runtime/liveness state of an agent's session as seen in one room.
 
     Distinct from `AgentSession` (which tracks *reachability*): this captures
@@ -766,15 +1120,23 @@ class AgentRuntimeState(Base):
         UniqueConstraint(
             "agent_id", "room_id", name="uq_agent_runtime_states_agent_room"
         ),
+        ForeignKeyConstraint(
+            ["tenant_id", "agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_agent_runtime_states_agent",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_agent_runtime_states_room",
+            ondelete="CASCADE",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    agent_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
-    )
-    room_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False
-    )
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    room_id: Mapped[str] = mapped_column(Text, nullable=False)
     state: Mapped[str] = mapped_column(Text, nullable=False)
     # The switchdash://session deeplink the reporting client (Switch Console) last
     # sent for this (agent, room), so `!status` can surface an on-demand link to
@@ -797,7 +1159,7 @@ class AgentRuntimeState(Base):
 # ── Room Roles ────────────────────────────────────────────────────────────────
 
 
-class RoomRole(Base):
+class RoomRole(TenantScoped, Base):
     """A first-class, per-room, assumable instruction bundle.
 
     A role is a named bundle of instructions scoped to a single room, decoupled
@@ -817,12 +1179,17 @@ class RoomRole(Base):
     __tablename__ = "room_roles"
     __table_args__ = (
         UniqueConstraint("room_id", "name", name="uq_room_roles_room_name"),
+        UniqueConstraint("id", "tenant_id", name="uq_room_roles_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_room_roles_room",
+            ondelete="CASCADE",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    room_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False
-    )
+    room_id: Mapped[str] = mapped_column(Text, nullable=False)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     instructions: Mapped[str] = mapped_column(Text, nullable=False)
     exclusive: Mapped[bool] = mapped_column(
@@ -834,7 +1201,7 @@ class RoomRole(Base):
     )
 
 
-class RoleLease(Base):
+class RoleLease(TenantScoped, Base):
     """The current holder of a room-role, with heartbeat-based auto-release.
 
     A lease records that `agent_id` currently holds `role_id` in `room_id`. A
@@ -854,18 +1221,30 @@ class RoleLease(Base):
     __table_args__ = (
         UniqueConstraint("agent_id", name="uq_role_leases_agent"),
         Index("ix_role_leases_role_id", "role_id"),
+        ForeignKeyConstraint(
+            ["tenant_id", "role_id"],
+            ["room_roles.tenant_id", "room_roles.id"],
+            name="fk_role_leases_role",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_role_leases_room",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_role_leases_agent",
+            ondelete="CASCADE",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    role_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("room_roles.id", ondelete="CASCADE"), nullable=False
-    )
-    room_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False
-    )
-    agent_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
-    )
+    role_id: Mapped[str] = mapped_column(Text, nullable=False)
+    room_id: Mapped[str] = mapped_column(Text, nullable=False)
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
     transport_session_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     acquired_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -878,7 +1257,7 @@ class RoleLease(Base):
 # ── Bridge message map ──────────────────────────────────────────────────────────
 
 
-class BridgeMessageMap(Base):
+class BridgeMessageMap(TenantScoped, Base):
     """Durable correlation between a Switch event and its external counterpart.
 
     One row per bridged message, written in both directions. Powers thread
@@ -892,12 +1271,16 @@ class BridgeMessageMap(Base):
     __table_args__ = (
         UniqueConstraint("bridge_id", "transport_event_id"),
         UniqueConstraint("bridge_id", "external_post_id"),
+        ForeignKeyConstraint(
+            ["tenant_id", "bridge_id"],
+            ["collaboration_bridges.tenant_id", "collaboration_bridges.id"],
+            name="fk_bridge_message_map_bridge",
+            ondelete="CASCADE",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    bridge_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("collaboration_bridges.id", ondelete="CASCADE"), nullable=False
-    )
+    bridge_id: Mapped[str] = mapped_column(Text, nullable=False)
     external_channel_id: Mapped[str] = mapped_column(Text, nullable=False)
     transport_event_id: Mapped[str] = mapped_column(Text, nullable=False)
     external_post_id: Mapped[str] = mapped_column(Text, nullable=False)
@@ -932,7 +1315,7 @@ class FeatureFlag(Base):
 # ── Messages ─────────────────────────────────────────────────────────────────
 
 
-class Message(Base):
+class Message(TenantScoped, Base):
     """A message as it was sent into a room.
 
     Written alongside the send to the message bus, which remains the source of
@@ -963,6 +1346,19 @@ class Message(Base):
             "thread_root_event_id",
             postgresql_where=text("thread_root_event_id IS NOT NULL"),
         ),
+        UniqueConstraint("id", "tenant_id", name="uq_messages_id_tenant"),
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_messages_room",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "sender_client_id"],
+            ["clients.tenant_id", "clients.id"],
+            name="fk_messages_sender_client",
+            ondelete="SET NULL (sender_client_id)",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
@@ -973,14 +1369,12 @@ class Message(Base):
     # paging on `seq > n` would step straight over it. See the store for the
     # argument in full.
     seq: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    room_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False
-    )
+    room_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # Global on purpose: a random, globally-unique identifier — scoping it
+    # buys nothing.
     transport_event_id: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
     sender_id: Mapped[str] = mapped_column(Text, nullable=False)
-    sender_client_id: Mapped[str | None] = mapped_column(
-        Text, ForeignKey("clients.id", ondelete="SET NULL"), nullable=True
-    )
+    sender_client_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     sender_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     event_type: Mapped[str] = mapped_column(Text, nullable=False)
     msgtype: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -993,7 +1387,7 @@ class Message(Base):
     )
 
 
-class MessageAttachment(Base):
+class MessageAttachment(TenantScoped, Base):
     """A file carried by a message.
 
     One row per file, so a multi-file send is several rows against one message
@@ -1001,12 +1395,18 @@ class MessageAttachment(Base):
     """
 
     __tablename__ = "message_attachments"
-    __table_args__ = (Index("ix_message_attachments_message", "message_id"),)
+    __table_args__ = (
+        Index("ix_message_attachments_message", "message_id"),
+        ForeignKeyConstraint(
+            ["tenant_id", "message_id"],
+            ["messages.tenant_id", "messages.id"],
+            name="fk_message_attachments_message",
+            ondelete="CASCADE",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    message_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("messages.id", ondelete="CASCADE"), nullable=False
-    )
+    message_id: Mapped[str] = mapped_column(Text, nullable=False)
     position: Mapped[int] = mapped_column(Integer, nullable=False)
     uri: Mapped[str] = mapped_column(Text, nullable=False)
     filename: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -1017,7 +1417,7 @@ class MessageAttachment(Base):
     )
 
 
-class DeliveryCursor(Base):
+class DeliveryCursor(TenantScoped, Base):
     """How far one agent has been delivered in one room.
 
     The cursor it replaces lived in memory in the event buffer, so a restart
@@ -1036,15 +1436,23 @@ class DeliveryCursor(Base):
     __tablename__ = "delivery_cursors"
     __table_args__ = (
         UniqueConstraint("agent_id", "room_id", name="uq_delivery_cursors_agent_room"),
+        ForeignKeyConstraint(
+            ["tenant_id", "agent_id"],
+            ["agents.tenant_id", "agents.id"],
+            name="fk_delivery_cursors_agent",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tenant_id", "room_id"],
+            ["rooms.tenant_id", "rooms.id"],
+            name="fk_delivery_cursors_room",
+            ondelete="CASCADE",
+        ),
     )
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=_uuid)
-    agent_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
-    )
-    room_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("rooms.id", ondelete="CASCADE"), nullable=False
-    )
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    room_id: Mapped[str] = mapped_column(Text, nullable=False)
     last_seq: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
     updated_at: Mapped[str] = mapped_column(
         DateTime(timezone=True),
@@ -1054,7 +1462,7 @@ class DeliveryCursor(Base):
     )
 
 
-class MediaBlob(Base):
+class MediaBlob(TenantScoped, Base):
     """The bytes behind an attachment.
 
     Media used to live in the homeserver's own store, reached by an opaque
@@ -1074,6 +1482,10 @@ class MediaBlob(Base):
     unreferenced and a later sweep can find them by that. Cascading from the
     attachment instead would delete the bytes of a file that two messages
     quote.
+
+    Scoped although nothing references it by foreign key: it holds attachment
+    bytes reached by an opaque URI, and an unguessable identifier is not an
+    isolation boundary.
     """
 
     __tablename__ = "media_blobs"

--- a/core/switch_core/db/models.py
+++ b/core/switch_core/db/models.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column
 
 from switch_core.db.base import Base
 from switch_core.db.notify_ddl import (
@@ -94,11 +94,27 @@ class TenantScoped:
     today — so an ordinary ORM insert needs no change to land in the right
     place. A later PR replaces this default with a value read from the
     request/session context; nothing here reads from a contextvar yet.
+
+    The foreign key is named explicitly (`fk_<table>_tenant`) rather than left
+    for the dialect to default, because `declared_attr` gives each subclass
+    its own column and an unnamed constraint would default to
+    `<table>_tenant_id_fkey` — a different name than the migration gives the
+    same constraint, which would make a schema built by `create_all` disagree
+    with one built by Alembic and break the migration's `downgrade` against
+    the former.
     """
 
-    tenant_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("tenants.id"), nullable=False, default=TENANT_ZERO_ID
-    )
+    @declared_attr
+    def tenant_id(cls) -> Mapped[str]:  # noqa: N805 - SQLAlchemy convention
+        return mapped_column(
+            Text,
+            ForeignKey(
+                "tenants.id",
+                name=f"fk_{cls.__tablename__}_tenant",  # type: ignore[attr-defined]
+            ),
+            nullable=False,
+            default=TENANT_ZERO_ID,
+        )
 
 
 # ── Users ──────────────────────────────────────────────────────────────────────
@@ -371,7 +387,7 @@ agent_skills = Table(
     Column(
         "tenant_id",
         Text,
-        ForeignKey("tenants.id"),
+        ForeignKey("tenants.id", name="fk_agent_skills_tenant"),
         nullable=False,
         default=TENANT_ZERO_ID,
     ),
@@ -426,7 +442,7 @@ room_agents = Table(
     Column(
         "tenant_id",
         Text,
-        ForeignKey("tenants.id"),
+        ForeignKey("tenants.id", name="fk_room_agents_tenant"),
         nullable=False,
         default=TENANT_ZERO_ID,
     ),
@@ -460,7 +476,7 @@ room_skills = Table(
     Column(
         "tenant_id",
         Text,
-        ForeignKey("tenants.id"),
+        ForeignKey("tenants.id", name="fk_room_skills_tenant"),
         nullable=False,
         default=TENANT_ZERO_ID,
     ),
@@ -680,7 +696,7 @@ room_references = Table(
     Column(
         "tenant_id",
         Text,
-        ForeignKey("tenants.id"),
+        ForeignKey("tenants.id", name="fk_room_references_tenant"),
         nullable=False,
         default=TENANT_ZERO_ID,
     ),
@@ -704,7 +720,7 @@ room_documents = Table(
     Column(
         "tenant_id",
         Text,
-        ForeignKey("tenants.id"),
+        ForeignKey("tenants.id", name="fk_room_documents_tenant"),
         nullable=False,
         default=TENANT_ZERO_ID,
     ),
@@ -756,7 +772,10 @@ class ReferenceType(TenantScoped, Base):
     __tablename__ = "reference_types"
 
     tenant_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("tenants.id"), primary_key=True, default=TENANT_ZERO_ID
+        Text,
+        ForeignKey("tenants.id", name="fk_reference_types_tenant"),
+        primary_key=True,
+        default=TENANT_ZERO_ID,
     )
     type: Mapped[str] = mapped_column(Text, primary_key=True)
     owner_id: Mapped[str] = mapped_column(Text, ForeignKey("users.id"), nullable=False)
@@ -821,7 +840,7 @@ room_packages = Table(
     Column(
         "tenant_id",
         Text,
-        ForeignKey("tenants.id"),
+        ForeignKey("tenants.id", name="fk_room_packages_tenant"),
         nullable=False,
         default=TENANT_ZERO_ID,
     ),
@@ -845,7 +864,7 @@ package_references = Table(
     Column(
         "tenant_id",
         Text,
-        ForeignKey("tenants.id"),
+        ForeignKey("tenants.id", name="fk_package_references_tenant"),
         nullable=False,
         default=TENANT_ZERO_ID,
     ),
@@ -869,7 +888,7 @@ package_documents = Table(
     Column(
         "tenant_id",
         Text,
-        ForeignKey("tenants.id"),
+        ForeignKey("tenants.id", name="fk_package_documents_tenant"),
         nullable=False,
         default=TENANT_ZERO_ID,
     ),

--- a/core/switch_core/db/stores/reference_type_store.py
+++ b/core/switch_core/db/stores/reference_type_store.py
@@ -2,7 +2,7 @@ from sqlalchemy import ColumnElement, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from switch_core.db.models import Reference, ReferenceType
+from switch_core.db.models import TENANT_ZERO_ID, Reference, ReferenceType
 
 
 class ReferenceTypeStore:
@@ -28,7 +28,8 @@ class ReferenceTypeStore:
         return reference_type
 
     async def get(self, session: AsyncSession, type_: str) -> ReferenceType | None:
-        return await session.get(ReferenceType, type_)
+        # TODO(next PR): use the request's tenant instead of TENANT_ZERO_ID.
+        return await session.get(ReferenceType, (TENANT_ZERO_ID, type_))
 
     async def get_many(
         self, session: AsyncSession, types: list[str]
@@ -75,7 +76,8 @@ class ReferenceTypeStore:
         read_visibility: str | None = None,
         write_visibility: str | None = None,
     ) -> ReferenceType:
-        rt = await session.get(ReferenceType, type_)
+        # TODO(next PR): use the request's tenant instead of TENANT_ZERO_ID.
+        rt = await session.get(ReferenceType, (TENANT_ZERO_ID, type_))
         if rt is None:
             raise ValueError(f"Reference type not found: {type_}")
         if display_name is not None:
@@ -92,7 +94,8 @@ class ReferenceTypeStore:
         return rt
 
     async def delete(self, session: AsyncSession, type_: str) -> None:
-        rt = await session.get(ReferenceType, type_)
+        # TODO(next PR): use the request's tenant instead of TENANT_ZERO_ID.
+        rt = await session.get(ReferenceType, (TENANT_ZERO_ID, type_))
         if rt is None:
             raise ValueError(f"Reference type not found: {type_}")
         await session.delete(rt)

--- a/core/switch_core/db/stores/reference_type_store.py
+++ b/core/switch_core/db/stores/reference_type_store.py
@@ -15,6 +15,8 @@ class ReferenceTypeStore:
                 session.add(reference_type)
                 await session.flush()
         except IntegrityError as exc:
+            # TODO(next PR): scope to the request's tenant instead of matching
+            # across all of them.
             clash = await session.execute(
                 select(ReferenceType.type).where(
                     ReferenceType.type == reference_type.type
@@ -34,6 +36,8 @@ class ReferenceTypeStore:
     async def get_many(
         self, session: AsyncSession, types: list[str]
     ) -> list[ReferenceType]:
+        # TODO(next PR): scope to the request's tenant instead of matching
+        # across all of them.
         if not types:
             return []
         result = await session.execute(
@@ -50,6 +54,8 @@ class ReferenceTypeStore:
         ``owner_id = NULL`` comparison is never true in SQL, so it is left out
         rather than relied on.
         """
+        # TODO(next PR): scope to the request's tenant instead of matching
+        # across all of them.
         condition: ColumnElement[bool]
         if user_id is None:
             condition = ReferenceType.read_visibility == "public"
@@ -62,6 +68,8 @@ class ReferenceTypeStore:
         return list(result.scalars().all())
 
     async def list_all(self, session: AsyncSession) -> list[ReferenceType]:
+        # TODO(next PR): scope to the request's tenant instead of matching
+        # across all of them.
         result = await session.execute(select(ReferenceType))
         return list(result.scalars().all())
 

--- a/core/switch_core/migrations/versions/8b276792ee30_multi_tenancy_tenants_and_tenant_id.py
+++ b/core/switch_core/migrations/versions/8b276792ee30_multi_tenancy_tenants_and_tenant_id.py
@@ -19,13 +19,12 @@ Order:
    `users.role = 'admin'`, `member` otherwise.
 4. Add `tenant_id` to every scoped table as `NOT NULL DEFAULT '<zero>'`, then
    drop the default. Since Postgres 11, adding a column with a constant
-   default is a metadata-only change — no rewrite, no table lock beyond
-   `ACCESS EXCLUSIVE` for the instant it takes to update the catalog. The
-   alternative sequence (nullable, backfill every row, then `SET NOT NULL`)
-   is what the spike proposed and is not needed here: there is only one
-   tenant to backfill to, the same constant for every row, so a computed
-   backfill buys nothing and would rewrite `messages` and `media_blobs`
-   (20MB rows) under an exclusive lock instead.
+   default is a metadata-only change — no rewrite. The alternative sequence
+   (nullable, backfill every row, then `SET NOT NULL`) is what the spike
+   proposed and is not needed here: there is only one tenant to backfill to,
+   the same constant for every row, so a computed backfill buys nothing and
+   would rewrite `messages` and `media_blobs` (20MB rows) instead of just
+   touching the catalog.
 5. Add the foreign key to `tenants`, and `UNIQUE (id, tenant_id)` on the
    tables actually referenced by a composite key.
 6. Swap the uniqueness constraints that were global singletons and are not
@@ -34,12 +33,27 @@ Order:
    default-bridge partial index.
 7. Rewrite every scoped-to-scoped foreign key as composite: drop the old
    single-column constraint, add the new one `NOT VALID`, then `VALIDATE
-   CONSTRAINT` — so the validation scan takes a lock no stronger than a
-   plain read for the duration of the scan, rather than blocking writes for
-   as long as the scan takes. Five keys use the Postgres 15+ column-list
-   `ON DELETE SET NULL (<col>)` form: a plain multi-column `SET NULL` would
-   null every referencing column including `tenant_id`, which then fails
-   the new NOT NULL constraint on the very delete this is meant to allow.
+   CONSTRAINT`. Five keys use the Postgres 15+ column-list `ON DELETE SET
+   NULL (<col>)` form: a plain multi-column `SET NULL` would null every
+   referencing column including `tenant_id`, which then fails the new NOT
+   NULL constraint on the very delete this is meant to allow.
+
+**On locking: this whole revision runs inside one transaction** —
+`migrations/env.py` wraps every revision in `context.begin_transaction()`,
+and this one adds no `autocommit_block` of its own. Every `ACCESS EXCLUSIVE`
+lock taken by any statement above — including the plain `CREATE UNIQUE INDEX`
+built for each `UNIQUE (id, tenant_id)` and for the uniqueness swaps in step
+6 — is held on its table until the whole migration commits, not just for the
+instant that statement runs. The `NOT VALID` / `VALIDATE CONSTRAINT` split in
+step 7 buys nothing here: a single transaction holds the lock from the first
+statement to the commit regardless of when the validating scan runs, and
+`VALIDATE CONSTRAINT` cannot run in a later, separate transaction unless the
+`NOT VALID` addition already committed. It stays anyway, commented, because
+it becomes useful the day this migration is split so the addition and the
+validation are in different transactions — see the note on `CONCURRENTLY`
+below in the design doc if that split is needed. The longest-held lock here
+is whichever unique index build takes the longest, most likely the ones on
+`messages` and `media_blobs`.
 
 This migration creates no roles, issues no grants, and adds no row-level
 security policy — that is a separate, later change (see the design doc's
@@ -728,7 +742,11 @@ def upgrade() -> None:
         postgresql_where=sa.text("is_default"),
     )
 
-    # 7. Rewrite every scoped-to-scoped FK as composite.
+    # 7. Rewrite every scoped-to-scoped FK as composite. `NOT VALID` then
+    # `VALIDATE CONSTRAINT` buys no lock reduction while the whole revision
+    # runs in one transaction (see the module docstring) — it stays because
+    # it is what makes the pair splittable across two transactions later,
+    # which is the only way this split ever pays for itself.
     for (
         table,
         old_name,

--- a/core/switch_core/migrations/versions/8b276792ee30_multi_tenancy_tenants_and_tenant_id.py
+++ b/core/switch_core/migrations/versions/8b276792ee30_multi_tenancy_tenants_and_tenant_id.py
@@ -1,0 +1,807 @@
+"""multi-tenancy phase 1: tenants, tenant_members, and tenant_id everywhere
+
+Implements the schema half of Phase 1 multi-tenancy (see
+`docs/old/multi-tenancy-phase1-db.md`): every table holding customer data
+gains a non-null `tenant_id`, and every foreign key between two such tables
+gains it too, so a row can no longer reference a parent in another tenant.
+
+Order:
+
+1. Create `tenants` and `tenant_members`.
+2. Insert tenant zero — the one tenant that exists before this migration
+   runs — with a fixed id written literally below rather than imported from
+   `switch_core.db.models.TENANT_ZERO_ID`. A migration is a record of a
+   change that already happened; importing the live constant would let a
+   later edit to it silently change what this migration means, the same
+   reason the notify trigger keeps a frozen copy of its DDL instead of
+   importing `notify_ddl.py`.
+3. Insert a `tenant_members` row for every existing user: `owner` where
+   `users.role = 'admin'`, `member` otherwise.
+4. Add `tenant_id` to every scoped table as `NOT NULL DEFAULT '<zero>'`, then
+   drop the default. Since Postgres 11, adding a column with a constant
+   default is a metadata-only change — no rewrite, no table lock beyond
+   `ACCESS EXCLUSIVE` for the instant it takes to update the catalog. The
+   alternative sequence (nullable, backfill every row, then `SET NOT NULL`)
+   is what the spike proposed and is not needed here: there is only one
+   tenant to backfill to, the same constant for every row, so a computed
+   backfill buys nothing and would rewrite `messages` and `media_blobs`
+   (20MB rows) under an exclusive lock instead.
+5. Add the foreign key to `tenants`, and `UNIQUE (id, tenant_id)` on the
+   tables actually referenced by a composite key.
+6. Swap the uniqueness constraints that were global singletons and are not
+   anymore: `agents.name`, `clients.matrix_user_id`, `rooms.matrix_room_id`,
+   the `reference_types` primary key, and the `collaboration_bridges`
+   default-bridge partial index.
+7. Rewrite every scoped-to-scoped foreign key as composite: drop the old
+   single-column constraint, add the new one `NOT VALID`, then `VALIDATE
+   CONSTRAINT` — so the validation scan takes a lock no stronger than a
+   plain read for the duration of the scan, rather than blocking writes for
+   as long as the scan takes. Five keys use the Postgres 15+ column-list
+   `ON DELETE SET NULL (<col>)` form: a plain multi-column `SET NULL` would
+   null every referencing column including `tenant_id`, which then fails
+   the new NOT NULL constraint on the very delete this is meant to allow.
+
+This migration creates no roles, issues no grants, and adds no row-level
+security policy — that is a separate, later change (see the design doc's
+"runtime role" section).
+
+Only tenant zero exists when this runs, so the usual expand-then-contract
+caution does not apply yet: there is no second tenant's traffic to keep
+running against the old shape while this lands. From the next customer
+onward it does, and any future schema change here must be split into an
+expand migration (deployed, then the application updated to use the new
+shape) and a contract migration (deployed once nothing reads the old shape),
+never both at once.
+
+Revision ID: 8b276792ee30
+Revises: b47e0c39a1f5
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "8b276792ee30"
+down_revision: str | None = "b47e0c39a1f5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# The fixed id of the one tenant that exists before a second is ever
+# onboarded. Matches `switch_core.db.models.TENANT_ZERO_ID`, copied rather
+# than imported — see the module docstring.
+TENANT_ZERO_ID = "00000000-0000-0000-0000-000000000000"
+
+# Every table gaining `tenant_id`. Order doesn't matter for the column add
+# (each statement stands alone), so this is alphabetical rather than
+# dependency order.
+SCOPED_TABLES = [
+    "agent_runtime_states",
+    "agent_sessions",
+    "agent_skills",
+    "agents",
+    "api_keys",
+    "bridge_message_map",
+    "client_rooms",
+    "clients",
+    "collaboration_bridges",
+    "delivery_cursors",
+    "documents",
+    "external_user_claims",
+    "external_users",
+    "media_blobs",
+    "message_attachments",
+    "messages",
+    "models",
+    "package_documents",
+    "package_references",
+    "packages",
+    "reference_types",
+    "references",
+    "role_leases",
+    "room_agents",
+    "room_documents",
+    "room_groups",
+    "room_links",
+    "room_packages",
+    "room_references",
+    "room_roles",
+    "room_skills",
+    "rooms",
+    "server_connectors",
+    "skills",
+    "tasks",
+    "tools",
+]
+
+# The 13 scoped tables referenced by a composite foreign key elsewhere, and so
+# need `UNIQUE (id, tenant_id)` in addition to the plain FK to `tenants`.
+# `reference_types` has no surrogate `id` at all (its natural key already
+# becomes the composite primary key below) so it is not in this list even
+# though it is scoped.
+ID_TENANT_UNIQUE_TABLES = [
+    "agents",
+    "api_keys",
+    "clients",
+    "collaboration_bridges",
+    "documents",
+    "external_users",
+    "messages",
+    "packages",
+    "references",
+    "room_groups",
+    "room_roles",
+    "rooms",
+    "skills",
+]
+
+# Every foreign key from a scoped table to another scoped table, rewritten to
+# carry `tenant_id`. `ondelete` is the *new* (possibly column-list) clause;
+# `downgrade` derives the original single-column clause from it.
+#
+# (table, old_constraint_name, local_column, ref_table, ref_column, new_constraint_name, ondelete)
+FK_REWRITES: list[tuple[str, str, str, str, str, str, str | None]] = [
+    (
+        "client_rooms",
+        "client_rooms_client_id_fkey",
+        "client_id",
+        "clients",
+        "id",
+        "fk_client_rooms_client",
+        None,
+    ),
+    (
+        "client_rooms",
+        "client_rooms_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_client_rooms_room",
+        None,
+    ),
+    (
+        "agents",
+        "agents_client_id_fkey",
+        "client_id",
+        "clients",
+        "id",
+        "fk_agents_client",
+        None,
+    ),
+    (
+        "agents",
+        "fk_agents_api_key_id",
+        "api_key_id",
+        "api_keys",
+        "id",
+        "fk_agents_api_key",
+        None,
+    ),
+    (
+        "agents",
+        "fk_agents_parent_agent_id",
+        "parent_agent_id",
+        "agents",
+        "id",
+        "fk_agents_parent_agent",
+        "SET NULL (parent_agent_id)",
+    ),
+    (
+        "tools",
+        "tools_agent_id_fkey",
+        "agent_id",
+        "agents",
+        "id",
+        "fk_tools_agent",
+        None,
+    ),
+    (
+        "models",
+        "models_agent_id_fkey",
+        "agent_id",
+        "agents",
+        "id",
+        "fk_models_agent",
+        None,
+    ),
+    (
+        "skills",
+        "skills_owner_agent_id_fkey",
+        "owner_agent_id",
+        "agents",
+        "id",
+        "fk_skills_owner_agent",
+        None,
+    ),
+    (
+        "agent_skills",
+        "agent_skills_agent_id_fkey",
+        "agent_id",
+        "agents",
+        "id",
+        "fk_agent_skills_agent",
+        None,
+    ),
+    (
+        "agent_skills",
+        "agent_skills_skill_id_fkey",
+        "skill_id",
+        "skills",
+        "id",
+        "fk_agent_skills_skill",
+        None,
+    ),
+    (
+        "rooms",
+        "rooms_bridge_id_fkey",
+        "bridge_id",
+        "collaboration_bridges",
+        "id",
+        "fk_rooms_bridge",
+        None,
+    ),
+    (
+        "rooms",
+        "rooms_group_id_fkey",
+        "group_id",
+        "room_groups",
+        "id",
+        "fk_rooms_group",
+        "SET NULL (group_id)",
+    ),
+    (
+        "room_agents",
+        "room_agents_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_room_agents_room",
+        None,
+    ),
+    (
+        "room_agents",
+        "room_agents_agent_id_fkey",
+        "agent_id",
+        "agents",
+        "id",
+        "fk_room_agents_agent",
+        None,
+    ),
+    (
+        "room_skills",
+        "room_skills_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_room_skills_room",
+        None,
+    ),
+    (
+        "room_skills",
+        "room_skills_skill_id_fkey",
+        "skill_id",
+        "skills",
+        "id",
+        "fk_room_skills_skill",
+        None,
+    ),
+    (
+        "room_groups",
+        "room_groups_parent_group_id_fkey",
+        "parent_group_id",
+        "room_groups",
+        "id",
+        "fk_room_groups_parent_group",
+        "SET NULL (parent_group_id)",
+    ),
+    (
+        "room_links",
+        "room_links_source_room_id_fkey",
+        "source_room_id",
+        "rooms",
+        "id",
+        "fk_room_links_source_room",
+        "CASCADE",
+    ),
+    (
+        "room_links",
+        "room_links_target_room_id_fkey",
+        "target_room_id",
+        "rooms",
+        "id",
+        "fk_room_links_target_room",
+        "CASCADE",
+    ),
+    (
+        "room_roles",
+        "room_roles_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_room_roles_room",
+        "CASCADE",
+    ),
+    (
+        "role_leases",
+        "role_leases_role_id_fkey",
+        "role_id",
+        "room_roles",
+        "id",
+        "fk_role_leases_role",
+        "CASCADE",
+    ),
+    (
+        "role_leases",
+        "role_leases_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_role_leases_room",
+        "CASCADE",
+    ),
+    (
+        "role_leases",
+        "role_leases_agent_id_fkey",
+        "agent_id",
+        "agents",
+        "id",
+        "fk_role_leases_agent",
+        "CASCADE",
+    ),
+    ("tasks", "tasks_room_id_fkey", "room_id", "rooms", "id", "fk_tasks_room", None),
+    (
+        "tasks",
+        "tasks_requester_agent_id_fkey",
+        "requester_agent_id",
+        "agents",
+        "id",
+        "fk_tasks_requester_agent",
+        "CASCADE",
+    ),
+    (
+        "tasks",
+        "tasks_performer_agent_id_fkey",
+        "performer_agent_id",
+        "agents",
+        "id",
+        "fk_tasks_performer_agent",
+        "CASCADE",
+    ),
+    (
+        "documents",
+        "documents_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_documents_room",
+        "CASCADE",
+    ),
+    (
+        "documents",
+        "documents_created_by_agent_id_fkey",
+        "created_by_agent_id",
+        "agents",
+        "id",
+        "fk_documents_created_by_agent",
+        "SET NULL (created_by_agent_id)",
+    ),
+    (
+        "room_references",
+        "room_references_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_room_references_room",
+        None,
+    ),
+    (
+        "room_references",
+        "room_references_reference_id_fkey",
+        "reference_id",
+        "references",
+        "id",
+        "fk_room_references_reference",
+        None,
+    ),
+    (
+        "room_documents",
+        "room_documents_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_room_documents_room",
+        None,
+    ),
+    (
+        "room_documents",
+        "room_documents_document_id_fkey",
+        "document_id",
+        "documents",
+        "id",
+        "fk_room_documents_document",
+        None,
+    ),
+    (
+        "room_packages",
+        "room_packages_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_room_packages_room",
+        None,
+    ),
+    (
+        "room_packages",
+        "room_packages_package_id_fkey",
+        "package_id",
+        "packages",
+        "id",
+        "fk_room_packages_package",
+        None,
+    ),
+    (
+        "package_references",
+        "package_references_package_id_fkey",
+        "package_id",
+        "packages",
+        "id",
+        "fk_package_references_package",
+        None,
+    ),
+    (
+        "package_references",
+        "package_references_reference_id_fkey",
+        "reference_id",
+        "references",
+        "id",
+        "fk_package_references_reference",
+        None,
+    ),
+    (
+        "package_documents",
+        "package_documents_package_id_fkey",
+        "package_id",
+        "packages",
+        "id",
+        "fk_package_documents_package",
+        None,
+    ),
+    (
+        "package_documents",
+        "package_documents_document_id_fkey",
+        "document_id",
+        "documents",
+        "id",
+        "fk_package_documents_document",
+        None,
+    ),
+    (
+        "collaboration_bridges",
+        "collaboration_bridges_client_id_fkey",
+        "client_id",
+        "clients",
+        "id",
+        "fk_collaboration_bridges_client",
+        None,
+    ),
+    (
+        "server_connectors",
+        "server_connectors_api_key_id_fkey",
+        "api_key_id",
+        "api_keys",
+        "id",
+        "fk_server_connectors_api_key",
+        None,
+    ),
+    (
+        "external_users",
+        "external_users_bridge_id_fkey",
+        "bridge_id",
+        "collaboration_bridges",
+        "id",
+        "fk_external_users_bridge",
+        None,
+    ),
+    (
+        "external_users",
+        "external_users_client_id_fkey",
+        "client_id",
+        "clients",
+        "id",
+        "fk_external_users_client",
+        None,
+    ),
+    (
+        "external_user_claims",
+        "external_user_claims_external_user_id_fkey",
+        "external_user_id",
+        "external_users",
+        "id",
+        "fk_external_user_claims_external_user",
+        "CASCADE",
+    ),
+    (
+        "agent_sessions",
+        "agent_sessions_agent_id_fkey",
+        "agent_id",
+        "agents",
+        "id",
+        "fk_agent_sessions_agent",
+        "CASCADE",
+    ),
+    (
+        "agent_sessions",
+        "agent_sessions_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_agent_sessions_room",
+        "CASCADE",
+    ),
+    (
+        "agent_runtime_states",
+        "agent_runtime_states_agent_id_fkey",
+        "agent_id",
+        "agents",
+        "id",
+        "fk_agent_runtime_states_agent",
+        "CASCADE",
+    ),
+    (
+        "agent_runtime_states",
+        "agent_runtime_states_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_agent_runtime_states_room",
+        "CASCADE",
+    ),
+    (
+        "bridge_message_map",
+        "bridge_message_map_bridge_id_fkey",
+        "bridge_id",
+        "collaboration_bridges",
+        "id",
+        "fk_bridge_message_map_bridge",
+        "CASCADE",
+    ),
+    (
+        "messages",
+        "messages_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_messages_room",
+        "CASCADE",
+    ),
+    (
+        "messages",
+        "messages_sender_client_id_fkey",
+        "sender_client_id",
+        "clients",
+        "id",
+        "fk_messages_sender_client",
+        "SET NULL (sender_client_id)",
+    ),
+    (
+        "message_attachments",
+        "message_attachments_message_id_fkey",
+        "message_id",
+        "messages",
+        "id",
+        "fk_message_attachments_message",
+        "CASCADE",
+    ),
+    (
+        "delivery_cursors",
+        "delivery_cursors_agent_id_fkey",
+        "agent_id",
+        "agents",
+        "id",
+        "fk_delivery_cursors_agent",
+        "CASCADE",
+    ),
+    (
+        "delivery_cursors",
+        "delivery_cursors_room_id_fkey",
+        "room_id",
+        "rooms",
+        "id",
+        "fk_delivery_cursors_room",
+        "CASCADE",
+    ),
+]
+
+
+def _single_column_ondelete(ondelete: str | None) -> str | None:
+    """Strip a column-list `SET NULL (col)` back to plain `SET NULL`."""
+    if ondelete is None:
+        return None
+    return ondelete.split(" (")[0]
+
+
+def upgrade() -> None:
+    # 1. New tables.
+    op.create_table(
+        "tenants",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+    )
+    op.create_table(
+        "tenant_members",
+        sa.Column("tenant_id", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "role IN ('owner', 'admin', 'member')", name="ck_tenant_members_role"
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("tenant_id", "user_id"),
+    )
+
+    # 2. Tenant zero.
+    op.execute(
+        f"""
+        INSERT INTO tenants (id, slug, name)
+        VALUES ('{TENANT_ZERO_ID}', 'default', 'Default')
+        """
+    )
+
+    # 3. A membership row for every existing user.
+    op.execute(
+        f"""
+        INSERT INTO tenant_members (tenant_id, user_id, role)
+        SELECT '{TENANT_ZERO_ID}', id, CASE WHEN role = 'admin' THEN 'owner' ELSE 'member' END
+        FROM users
+        """
+    )
+
+    # 4. `tenant_id` on every scoped table, metadata-only (default then drop
+    # the default, never backfill-then-set-not-null — see the docstring).
+    for table in SCOPED_TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "tenant_id",
+                sa.Text(),
+                nullable=False,
+                server_default=TENANT_ZERO_ID,
+            ),
+        )
+        op.alter_column(table, "tenant_id", server_default=None)
+
+    # 5. FK to tenants, and UNIQUE (id, tenant_id) where referenced.
+    for table in SCOPED_TABLES:
+        op.create_foreign_key(
+            f"fk_{table}_tenant", table, "tenants", ["tenant_id"], ["id"]
+        )
+    for table in ID_TENANT_UNIQUE_TABLES:
+        op.create_unique_constraint(f"uq_{table}_id_tenant", table, ["id", "tenant_id"])
+
+    # 6. Uniqueness swaps.
+    op.drop_constraint("agents_name_key", "agents", type_="unique")
+    op.create_unique_constraint(
+        "uq_agents_tenant_name", "agents", ["tenant_id", "name"]
+    )
+
+    op.drop_constraint("clients_matrix_user_id_key", "clients", type_="unique")
+    op.create_unique_constraint(
+        "uq_clients_tenant_matrix_user_id", "clients", ["tenant_id", "matrix_user_id"]
+    )
+
+    op.drop_constraint("rooms_matrix_room_id_key", "rooms", type_="unique")
+    op.create_unique_constraint(
+        "uq_rooms_tenant_matrix_room_id", "rooms", ["tenant_id", "matrix_room_id"]
+    )
+
+    op.drop_constraint("reference_types_pkey", "reference_types", type_="primary")
+    op.create_primary_key(
+        "reference_types_pkey", "reference_types", ["tenant_id", "type"]
+    )
+
+    op.drop_index(
+        "ix_collaboration_bridges_single_default", table_name="collaboration_bridges"
+    )
+    op.create_index(
+        "ix_collaboration_bridges_single_default",
+        "collaboration_bridges",
+        ["tenant_id"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+    )
+
+    # 7. Rewrite every scoped-to-scoped FK as composite.
+    for (
+        table,
+        old_name,
+        local_col,
+        ref_table,
+        ref_col,
+        new_name,
+        ondelete,
+    ) in FK_REWRITES:
+        op.drop_constraint(old_name, table, type_="foreignkey")
+        op.create_foreign_key(
+            new_name,
+            table,
+            ref_table,
+            ["tenant_id", local_col],
+            ["tenant_id", ref_col],
+            ondelete=ondelete,
+            postgresql_not_valid=True,
+        )
+        op.execute(f'ALTER TABLE "{table}" VALIDATE CONSTRAINT {new_name}')
+
+
+def downgrade() -> None:
+    # 7. Restore single-column FKs.
+    for table, old_name, local_col, ref_table, ref_col, new_name, ondelete in reversed(
+        FK_REWRITES
+    ):
+        op.drop_constraint(new_name, table, type_="foreignkey")
+        op.create_foreign_key(
+            old_name,
+            table,
+            ref_table,
+            [local_col],
+            [ref_col],
+            ondelete=_single_column_ondelete(ondelete),
+        )
+
+    # 6. Restore original uniqueness.
+    op.drop_index(
+        "ix_collaboration_bridges_single_default", table_name="collaboration_bridges"
+    )
+    op.create_index(
+        "ix_collaboration_bridges_single_default",
+        "collaboration_bridges",
+        ["is_default"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+    )
+
+    op.drop_constraint("reference_types_pkey", "reference_types", type_="primary")
+    op.create_primary_key("reference_types_pkey", "reference_types", ["type"])
+
+    op.drop_constraint("uq_rooms_tenant_matrix_room_id", "rooms", type_="unique")
+    op.create_unique_constraint("rooms_matrix_room_id_key", "rooms", ["matrix_room_id"])
+
+    op.drop_constraint("uq_clients_tenant_matrix_user_id", "clients", type_="unique")
+    op.create_unique_constraint(
+        "clients_matrix_user_id_key", "clients", ["matrix_user_id"]
+    )
+
+    op.drop_constraint("uq_agents_tenant_name", "agents", type_="unique")
+    op.create_unique_constraint("agents_name_key", "agents", ["name"])
+
+    # 5. Drop UNIQUE (id, tenant_id) and the FK to tenants.
+    for table in ID_TENANT_UNIQUE_TABLES:
+        op.drop_constraint(f"uq_{table}_id_tenant", table, type_="unique")
+    for table in SCOPED_TABLES:
+        op.drop_constraint(f"fk_{table}_tenant", table, type_="foreignkey")
+
+    # 4. Drop tenant_id from every scoped table.
+    for table in SCOPED_TABLES:
+        op.drop_column(table, "tenant_id")
+
+    # 1. Drop the new tables.
+    op.drop_table("tenant_members")
+    op.drop_table("tenants")

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -4,7 +4,9 @@ from collections.abc import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
@@ -15,6 +17,20 @@ from testcontainers.postgres import PostgresContainer
 # create_all provisions the full schema (rooms, room_groups, FKs, …).
 import switch_core.db.models  # noqa: F401
 from switch_core.db.base import Base
+from switch_core.db.models import TENANT_ZERO_ID, Tenant
+
+
+async def _seed_tenant_zero(conn: AsyncConnection) -> None:
+    """Insert the one tenant every scoped row's `tenant_id` default points at.
+
+    Every scoped table's `tenant_id` FK requires a matching `tenants` row, so
+    this must run right after the schema exists.
+    """
+    await conn.execute(
+        insert(Tenant.__table__).values(
+            id=TENANT_ZERO_ID, slug="default", name="Tenant Zero"
+        )
+    )
 
 
 @pytest.fixture(scope="session")
@@ -41,6 +57,7 @@ async def session_factory(
     engine = create_async_engine(postgres_url)
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await _seed_tenant_zero(conn)
     try:
         yield async_sessionmaker(bind=engine, expire_on_commit=False)
     finally:

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -28,7 +28,7 @@ async def _seed_tenant_zero(conn: AsyncConnection) -> None:
     """
     await conn.execute(
         insert(Tenant.__table__).values(
-            id=TENANT_ZERO_ID, slug="default", name="Tenant Zero"
+            id=TENANT_ZERO_ID, slug="default", name="Default"
         )
     )
 

--- a/core/tests/integration/conftest.py
+++ b/core/tests/integration/conftest.py
@@ -319,7 +319,7 @@ async def _seed_tenant_zero(engine: AsyncEngine) -> None:
     async with engine.begin() as conn:
         await conn.execute(
             insert(Tenant.__table__).values(
-                id=TENANT_ZERO_ID, slug="default", name="Tenant Zero"
+                id=TENANT_ZERO_ID, slug="default", name="Default"
             )
         )
 

--- a/core/tests/integration/conftest.py
+++ b/core/tests/integration/conftest.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 import asyncpg
 import pytest
 import pytest_asyncio
-from sqlalchemy import text
+from sqlalchemy import insert, text
 from sqlalchemy.ext.asyncio import AsyncEngine
 from testcontainers.postgres import PostgresContainer
 
@@ -57,7 +57,7 @@ from switch_core.db.engine import (
     create_session_factory,
     create_unpooled_engine,
 )
-from switch_core.db.models import User
+from switch_core.db.models import TENANT_ZERO_ID, Tenant, User
 from switch_core.db.stores.agent_session_store import AgentSessionStore
 from switch_core.db.stores.agent_store import AgentStore
 from switch_core.db.stores.api_key_store import ApiKeyStore
@@ -309,6 +309,21 @@ async def _admin_dsn(stack: StackInfo) -> str:
     )
 
 
+async def _seed_tenant_zero(engine: AsyncEngine) -> None:
+    """Insert the one tenant every scoped row's `tenant_id` default points at.
+
+    Needed right after schema creation, and again after every truncation:
+    `tenants` is in `Base.metadata.sorted_tables` like everything else, so
+    `_truncate_all` empties it along with the rest.
+    """
+    async with engine.begin() as conn:
+        await conn.execute(
+            insert(Tenant.__table__).values(
+                id=TENANT_ZERO_ID, slug="default", name="Tenant Zero"
+            )
+        )
+
+
 async def _truncate_all(engine: AsyncEngine) -> None:
     """Reset row state between tests by truncating every mapped table at once.
 
@@ -320,6 +335,7 @@ async def _truncate_all(engine: AsyncEngine) -> None:
         return
     async with engine.begin() as conn:
         await conn.execute(text(f"TRUNCATE TABLE {tables} RESTART IDENTITY CASCADE"))
+    await _seed_tenant_zero(engine)
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session")
@@ -343,6 +359,7 @@ async def session_env(switch_stack: StackInfo) -> AsyncIterator[SessionEnv]:
     # separately by `just migrate`, not here.
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    await _seed_tenant_zero(engine)
 
     env = SessionEnv(
         config=config,

--- a/core/tests/switch_core/db/test_multi_tenant_scoping.py
+++ b/core/tests/switch_core/db/test_multi_tenant_scoping.py
@@ -1,0 +1,390 @@
+"""Two-tenant behaviour for the multi-tenancy Phase 1 schema (CHOO-2623).
+
+Every fixture in the rest of the suite runs against a single tenant (tenant
+zero), so none of it can tell a composite foreign key from a single-column
+one, or a per-tenant unique constraint from a global one — the two schemas
+behave identically until a second tenant exists. These tests are the ones
+that actually create one.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.db.models import (
+    Agent,
+    ApiKey,
+    Client,
+    CollaborationBridge,
+    Document,
+    ReferenceType,
+    Room,
+    RoomGroup,
+    Tenant,
+    User,
+)
+
+TENANT_A = "tenant-a"
+TENANT_B = "tenant-b"
+
+
+async def _make_tenant(session: AsyncSession, tenant_id: str) -> Tenant:
+    tenant = Tenant(id=tenant_id, slug=tenant_id, name=tenant_id)
+    session.add(tenant)
+    await session.flush()
+    return tenant
+
+
+async def _make_user(session: AsyncSession, name: str) -> User:
+    user = User(name=name, email=f"{name}@example.invalid", role="user")
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def _make_client(
+    session: AsyncSession, tenant_id: str, matrix_user_id: str
+) -> Client:
+    client = Client(
+        tenant_id=tenant_id,
+        matrix_user_id=matrix_user_id,
+        display_name=matrix_user_id,
+        type="agent",
+    )
+    session.add(client)
+    await session.flush()
+    return client
+
+
+async def _make_api_key(
+    session: AsyncSession, tenant_id: str, user_id: str, label: str
+) -> ApiKey:
+    api_key = ApiKey(
+        tenant_id=tenant_id,
+        user_id=user_id,
+        key_hash=f"hash-{tenant_id}-{label}",
+        encrypted_key="enc",
+        label=label,
+        type="agent",
+    )
+    session.add(api_key)
+    await session.flush()
+    return api_key
+
+
+async def _make_agent(
+    session: AsyncSession,
+    tenant_id: str,
+    name: str,
+    owner_id: str,
+    *,
+    parent_agent_id: str | None = None,
+) -> Agent:
+    client = await _make_client(session, tenant_id, f"@{tenant_id}-{name}:test")
+    api_key = await _make_api_key(session, tenant_id, owner_id, name)
+    agent = Agent(
+        tenant_id=tenant_id,
+        name=name,
+        description=f"{name} desc",
+        agent_type="always_on",
+        connector_type="claude_code",
+        integration_profile={"connection_model": "always_on"},
+        client_id=client.id,
+        api_key_id=api_key.id,
+        owner_id=owner_id,
+        parent_agent_id=parent_agent_id,
+    )
+    session.add(agent)
+    await session.flush()
+    return agent
+
+
+class TestCrossTenantForeignKeyRejected:
+    async def test_child_row_disagreeing_with_parent_tenant_is_rejected(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """An agent in tenant B naming a client that actually belongs to
+        tenant A must fail at the database, via `fk_agents_client` — the
+        composite key is the thing that makes this unrepresentable, not
+        application code that happens to always pass matching ids."""
+        async with session_factory() as session:
+            tenant_a = await _make_tenant(session, TENANT_A)
+            tenant_b = await _make_tenant(session, TENANT_B)
+            owner = await _make_user(session, "cross-tenant-owner")
+            client_in_a = await _make_client(session, tenant_a.id, "@mismatch:test")
+            api_key_in_b = await _make_api_key(
+                session, tenant_b.id, owner.id, "mismatched"
+            )
+            await session.commit()
+
+            mismatched_agent = Agent(
+                tenant_id=tenant_b.id,
+                name="mismatched",
+                description="disagrees with its own client's tenant",
+                agent_type="always_on",
+                connector_type="claude_code",
+                integration_profile={"connection_model": "always_on"},
+                client_id=client_in_a.id,
+                api_key_id=api_key_in_b.id,
+                owner_id=owner.id,
+            )
+            session.add(mismatched_agent)
+            with pytest.raises(IntegrityError):
+                await session.flush()
+
+
+class TestPerTenantUniqueness:
+    async def test_same_agent_name_in_two_tenants(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant_a = await _make_tenant(session, TENANT_A)
+            tenant_b = await _make_tenant(session, TENANT_B)
+            owner = await _make_user(session, "reviewer-owner")
+
+            agent_a = await _make_agent(session, tenant_a.id, "reviewer", owner.id)
+            agent_b = await _make_agent(session, tenant_b.id, "reviewer", owner.id)
+            await session.commit()
+
+            assert agent_a.id != agent_b.id
+            assert agent_a.name == agent_b.name == "reviewer"
+
+    async def test_same_matrix_user_id_in_two_tenants(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant_a = await _make_tenant(session, TENANT_A)
+            tenant_b = await _make_tenant(session, TENANT_B)
+
+            client_a = await _make_client(session, tenant_a.id, "@shared:test")
+            client_b = await _make_client(session, tenant_b.id, "@shared:test")
+            await session.commit()
+
+            assert client_a.id != client_b.id
+            assert client_a.matrix_user_id == client_b.matrix_user_id == "@shared:test"
+
+    async def test_same_matrix_room_id_in_two_tenants(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant_a = await _make_tenant(session, TENANT_A)
+            tenant_b = await _make_tenant(session, TENANT_B)
+
+            room_a = Room(
+                tenant_id=tenant_a.id,
+                matrix_room_id="!shared:test",
+                name="room",
+                description="room desc",
+            )
+            room_b = Room(
+                tenant_id=tenant_b.id,
+                matrix_room_id="!shared:test",
+                name="room",
+                description="room desc",
+            )
+            session.add_all([room_a, room_b])
+            await session.commit()
+
+            assert room_a.id != room_b.id
+            assert room_a.matrix_room_id == room_b.matrix_room_id == "!shared:test"
+
+    async def test_each_tenant_can_have_its_own_default_bridge(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant_a = await _make_tenant(session, TENANT_A)
+            tenant_b = await _make_tenant(session, TENANT_B)
+            client_a = await _make_client(session, tenant_a.id, "@bridge-a:test")
+            client_b = await _make_client(session, tenant_b.id, "@bridge-b:test")
+
+            bridge_a = CollaborationBridge(
+                tenant_id=tenant_a.id,
+                type="slack",
+                display_name="Bridge A",
+                client_id=client_a.id,
+                status="active",
+                is_default=True,
+            )
+            bridge_b = CollaborationBridge(
+                tenant_id=tenant_b.id,
+                type="slack",
+                display_name="Bridge B",
+                client_id=client_b.id,
+                status="active",
+                is_default=True,
+            )
+            session.add_all([bridge_a, bridge_b])
+            await session.commit()
+
+            assert bridge_a.is_default is True
+            assert bridge_b.is_default is True
+
+    async def test_second_default_bridge_in_same_tenant_still_rejected(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The partial unique index is per-tenant now, not gone: two defaults
+        in the *same* tenant must still collide."""
+        async with session_factory() as session:
+            tenant_a = await _make_tenant(session, TENANT_A)
+            client_1 = await _make_client(session, tenant_a.id, "@bridge-1:test")
+            client_2 = await _make_client(session, tenant_a.id, "@bridge-2:test")
+
+            first = CollaborationBridge(
+                tenant_id=tenant_a.id,
+                type="slack",
+                display_name="First",
+                client_id=client_1.id,
+                status="active",
+                is_default=True,
+            )
+            session.add(first)
+            await session.commit()
+
+            second = CollaborationBridge(
+                tenant_id=tenant_a.id,
+                type="slack",
+                display_name="Second",
+                client_id=client_2.id,
+                status="active",
+                is_default=True,
+            )
+            session.add(second)
+            with pytest.raises(IntegrityError):
+                await session.flush()
+
+    async def test_reference_types_accepts_same_slug_in_two_tenants(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant_a = await _make_tenant(session, TENANT_A)
+            tenant_b = await _make_tenant(session, TENANT_B)
+            owner = await _make_user(session, "reftype-owner")
+
+            type_a = ReferenceType(
+                tenant_id=tenant_a.id,
+                type="doc",
+                owner_id=owner.id,
+                read_visibility="private",
+                write_visibility="private",
+                display_name="Doc",
+                instructions="Use doc links.",
+                value_hint="Paste a URL.",
+            )
+            type_b = ReferenceType(
+                tenant_id=tenant_b.id,
+                type="doc",
+                owner_id=owner.id,
+                read_visibility="private",
+                write_visibility="private",
+                display_name="Doc",
+                instructions="Use doc links.",
+                value_hint="Paste a URL.",
+            )
+            session.add_all([type_a, type_b])
+            await session.commit()
+
+            assert type_a.tenant_id != type_b.tenant_id
+            assert type_a.type == type_b.type == "doc"
+
+
+class TestSetNullOnDeleteKeepsTenantIdIntact:
+    """`ON DELETE SET NULL (<col>)` names its column so the delete only nulls
+    that column, never `tenant_id` — a plain multi-column `SET NULL` would
+    null both and then fail the `NOT NULL` constraint on `tenant_id`, which
+    is exactly the bug this form exists to avoid (see the design doc's
+    "Composite foreign keys" section). These three keys have no other test
+    exercising the database's own `ON DELETE` behaviour directly: existing
+    coverage either goes through store methods that reparent explicitly
+    before deleting (room groups) or covers a different key (`rooms.group_id`,
+    `messages.sender_client_id`)."""
+
+    async def test_deleting_parent_agent_nulls_only_parent_agent_id(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant = await _make_tenant(session, TENANT_A)
+            tenant_id = tenant.id
+            owner = await _make_user(session, "set-null-agent-owner")
+            parent = await _make_agent(session, tenant_id, "parent-agent", owner.id)
+            child = await _make_agent(
+                session,
+                tenant_id,
+                "child-agent",
+                owner.id,
+                parent_agent_id=parent.id,
+            )
+            await session.commit()
+            child_id = child.id
+
+            await session.execute(delete(Agent).where(Agent.id == parent.id))
+            await session.commit()
+            session.expire_all()
+
+            refreshed = await session.get(Agent, child_id)
+            assert refreshed is not None
+            assert refreshed.parent_agent_id is None
+            assert refreshed.tenant_id == tenant_id
+
+    async def test_deleting_creator_agent_nulls_only_created_by_agent_id(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        async with session_factory() as session:
+            tenant = await _make_tenant(session, TENANT_A)
+            tenant_id = tenant.id
+            owner = await _make_user(session, "set-null-doc-owner")
+            creator = await _make_agent(session, tenant_id, "creator-agent", owner.id)
+            document = Document(
+                tenant_id=tenant_id,
+                owner_id=owner.id,
+                room_id=None,
+                created_by_agent_id=creator.id,
+                read_visibility="private",
+                write_visibility="private",
+                name="doc",
+                description="doc desc",
+                instructions="doc instructions",
+                content="doc content",
+            )
+            session.add(document)
+            await session.commit()
+            document_id = document.id
+
+            await session.execute(delete(Agent).where(Agent.id == creator.id))
+            await session.commit()
+            session.expire_all()
+
+            refreshed = await session.get(Document, document_id)
+            assert refreshed is not None
+            assert refreshed.created_by_agent_id is None
+            assert refreshed.tenant_id == tenant_id
+
+    async def test_deleting_parent_group_nulls_only_parent_group_id(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Deletes the parent group directly (unlike `RoomGroupStore.delete`,
+        which reparents children first) so the FK's own `SET NULL` is what is
+        under test, not the store's promote-on-delete behaviour."""
+        async with session_factory() as session:
+            tenant = await _make_tenant(session, TENANT_A)
+            tenant_id = tenant.id
+            parent = RoomGroup(tenant_id=tenant_id, name="parent-group")
+            session.add(parent)
+            await session.flush()
+            child = RoomGroup(
+                tenant_id=tenant_id, name="child-group", parent_group_id=parent.id
+            )
+            session.add(child)
+            await session.commit()
+            child_id = child.id
+
+            await session.execute(delete(RoomGroup).where(RoomGroup.id == parent.id))
+            await session.commit()
+            session.expire_all()
+
+            refreshed = await session.get(RoomGroup, child_id)
+            assert refreshed is not None
+            assert refreshed.parent_group_id is None
+            assert refreshed.tenant_id == tenant_id

--- a/core/tests/switch_core/db/test_tenant_schema_catalogue.py
+++ b/core/tests/switch_core/db/test_tenant_schema_catalogue.py
@@ -1,0 +1,147 @@
+"""Catalogue tests for the multi-tenancy Phase 1 schema (CHOO-2623).
+
+These read the built schema back out of the database — `pg_constraint` and
+friends, via SQLAlchemy's reflection `Inspector` — rather than the model
+source, so a table added later without following the tenant-scoping rule
+fails here even if nobody remembers to update these tests by hand. See
+`docs/old/multi-tenancy-phase1-db.md` for the rule itself:
+
+    Every table holding customer data carries a non-null `tenant_id`, and
+    every foreign key between two such tables carries `tenant_id` as well.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession, async_sessionmaker
+
+# Importing models registers every table (including the plain `Table()`
+# junction tables) on `Base.metadata`.
+import switch_core.db.models  # noqa: F401
+from switch_core.db.base import Base
+
+
+def _scoped_tables() -> set[str]:
+    """Every table carrying a `tenant_id` column whose foreign key targets
+    `tenants.id` — the schema's own definition of "scoped".
+
+    Deliberately not the list from the design doc: a table that gains a
+    `tenant_id` later by copying the mixin (or the equivalent inline column,
+    for the plain `Table()` junction tables) is picked up automatically, and
+    one that forgets the foreign key to `tenants` is correctly left out and
+    so exempt from these checks — the accompanying test that every scoped
+    table's FKs carry `tenant_id` only means anything once a table is on this
+    list at all.
+    """
+    scoped = set()
+    for table in Base.metadata.tables.values():
+        tenant_id_col = table.columns.get("tenant_id")
+        if tenant_id_col is None:
+            continue
+        if any(
+            fk.column.table.name == "tenants" and fk.column.name == "id"
+            for fk in tenant_id_col.foreign_keys
+        ):
+            scoped.add(table.name)
+    return scoped
+
+
+def _get_foreign_keys(sync_conn, table_name: str) -> list[dict]:
+    return inspect(sync_conn).get_foreign_keys(table_name)
+
+
+def _get_unique_column_sets(sync_conn, table_name: str) -> list[frozenset[str]]:
+    insp = inspect(sync_conn)
+    sets = [
+        frozenset(uc["column_names"]) for uc in insp.get_unique_constraints(table_name)
+    ]
+    pk = insp.get_pk_constraint(table_name)
+    if pk.get("constrained_columns"):
+        sets.append(frozenset(pk["constrained_columns"]))
+    return sets
+
+
+async def _foreign_keys(conn: AsyncConnection, table_name: str) -> list[dict]:
+    return await conn.run_sync(_get_foreign_keys, table_name)
+
+
+async def _unique_column_sets(
+    conn: AsyncConnection, table_name: str
+) -> list[frozenset[str]]:
+    return await conn.run_sync(_get_unique_column_sets, table_name)
+
+
+class TestScopedTableCatalogue:
+    async def test_scoped_tables_exist_and_are_not_trivial(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Sanity check on the derivation itself: if this list ever collapses
+        to empty or to one table, the two tests below would pass vacuously."""
+        scoped = _scoped_tables()
+        assert len(scoped) >= 30, scoped
+        assert "messages" in scoped
+        assert "agents" in scoped
+        # Global tables must not appear.
+        assert "users" not in scoped
+        assert "oidc_identities" not in scoped
+        assert "feature_flags" not in scoped
+
+    async def test_every_cross_scoped_foreign_key_carries_tenant_id(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """A foreign key from one scoped table to another must be composite
+        on `tenant_id`, so a row can never reference a parent in another
+        tenant. Foreign keys to a *global* table (e.g. `rooms.owner_id ->
+        users.id`) are single-column by design and are not checked here."""
+        scoped = _scoped_tables()
+        violations: list[tuple[str, str, str]] = []
+        async with session_factory() as session:
+            conn = await session.connection()
+            for table_name in scoped:
+                for fk in await _foreign_keys(conn, table_name):
+                    ref_table = fk["referred_table"]
+                    if ref_table not in scoped:
+                        continue
+                    local_cols = set(fk["constrained_columns"])
+                    ref_cols = set(fk["referred_columns"])
+                    if "tenant_id" not in local_cols or "tenant_id" not in ref_cols:
+                        violations.append((table_name, fk["name"] or "?", ref_table))
+        assert violations == [], (
+            "foreign key(s) between scoped tables missing tenant_id "
+            f"(table, constraint, referenced table): {violations}"
+        )
+
+    async def test_every_referenced_scoped_table_has_id_tenant_unique(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Any scoped table that is the target of a composite (`tenant_id`,
+        `id`)-shaped foreign key must itself expose a `UNIQUE (id,
+        tenant_id)` — Postgres requires a unique constraint on the referenced
+        columns for a composite foreign key to exist at all, but this asserts
+        it is exactly the `(id, tenant_id)` shape the design calls for,
+        derived from who actually references whom rather than a hand-kept
+        list of "the ~13 referenced tables"."""
+        scoped = _scoped_tables()
+        async with session_factory() as session:
+            conn = await session.connection()
+            referenced: set[str] = set()
+            for table_name in scoped:
+                for fk in await _foreign_keys(conn, table_name):
+                    ref_table = fk["referred_table"]
+                    if ref_table not in scoped:
+                        continue
+                    local_cols = fk["constrained_columns"]
+                    ref_cols = fk["referred_columns"]
+                    if "tenant_id" in local_cols and "tenant_id" in ref_cols:
+                        referenced.add(ref_table)
+
+            missing: list[str] = []
+            for table_name in referenced:
+                unique_sets = await _unique_column_sets(conn, table_name)
+                if not any({"id", "tenant_id"} <= s for s in unique_sets):
+                    missing.append(table_name)
+        assert referenced, "expected at least one table referenced by a composite key"
+        assert missing == [], (
+            "scoped table(s) referenced by a composite key but missing "
+            f"UNIQUE (id, tenant_id): {missing}"
+        )

--- a/docs/old/multi-tenancy-phase1-db.md
+++ b/docs/old/multi-tenancy-phase1-db.md
@@ -1,11 +1,24 @@
 # Multi-tenancy Phase 1: the database design
 
-Status: design, reviewed once. Implements §2 of `multi-tenancy.md` (spike
-CHOO-2603) for CHOO-2623. Not yet built.
+Status: partially built. Implements §2 of `multi-tenancy.md` (spike CHOO-2603)
+for CHOO-2623.
 
-This document is the schema half of Phase 1: what tables change, what the
-policies look like, how a session learns which tenant it is acting for, and
-what the one migration does.
+This document was written as one design covering the whole schema half of
+Phase 1 — new tables, per-tenant uniqueness, composite foreign keys, the
+row-level-security policies, and the session plumbing that sets the tenant —
+and its reasoning below still describes that whole shape. What actually
+shipped is narrower: **the tenant model, per-tenant uniqueness and the
+composite foreign keys are built**, in the one migration this document
+describes. **Row-level security is not**: `require_tenant_id()`, the policy
+attached to each table, `db/rls_ddl.py`, and the isolation test under "Done
+when" were all split out into a later change, along with everything in
+"Setting the tenant" and "The bootstrap problem" below — the `tenant_session`
+/ `system_session` seam, the 107-call-site and 206-call-site migrations off
+the raw session, and the request-side wiring. None of that exists in the
+codebase yet. Read the sections below as the design those later changes
+implement, not as a description of what is running today; "What Phase 1 does
+not close" has been updated to say which gaps are this migration's and which
+belong to the deferred work.
 
 Postgres 16 everywhere — local Compose, the chart, and the test containers —
 and two things below need at least 15, so that is a floor, not an incidental
@@ -397,20 +410,48 @@ One revision:
 3. Insert a membership for every existing user — `owner` for accounts with the
    global admin role, `member` otherwise.
 4. Per scoped table: `add column tenant_id text not null default '<zero>'`,
-   then drop the default. Since Postgres 11 that is a metadata-only operation;
-   the add-nullable-then-backfill-then-set-not-null sequence the spike
-   describes rewrites the whole table under an exclusive lock, which on
-   `messages` and on `media_blobs` with its 20MB rows is the difference between
-   a blink and an outage.
+   then drop the default. Since Postgres 11 that is a metadata-only operation
+   for *this one statement* — no table rewrite, unlike the
+   add-nullable-then-backfill-then-set-not-null sequence the spike describes,
+   which would rewrite `messages` and `media_blobs` (20MB rows) instead of
+   just touching the catalog.
 5. Add the foreign key to `tenants` and, where the table is referenced, the
    `unique (id, tenant_id)`.
 6. Swap the uniqueness constraints listed above.
 7. Rewrite each scoped-to-scoped foreign key as composite, `not valid` first
-   and `validate constraint` after, so the validation scan does not hold an
-   exclusive lock.
-8. Enable row-level security and create the policy on each table.
+   and `validate constraint` after.
 
 No roles are created and no grants issued — see the role section above.
+Row-level security is not part of this migration either: `require_tenant_id()`,
+the policies and the isolation test described elsewhere in this document are
+deferred to a later change, tracked separately from the schema landed here
+(see "Status" at the top of this document).
+
+**On locking.** Alembic wraps a whole revision in one transaction
+(`migrations/env.py`, `context.begin_transaction()`), and this migration does
+not open an `autocommit_block` to opt out. So every `ACCESS EXCLUSIVE` lock
+taken above — including the plain `CREATE UNIQUE INDEX` behind step 5's
+`unique (id, tenant_id)` and step 6's uniqueness swaps — is held on its table
+for the whole migration, not released until it commits. The `not valid` /
+`validate constraint` split in step 7 does not reduce that: both statements
+run inside the same transaction, so the exclusive lock from the `not valid`
+add is already held by the time `validate constraint` runs its scan, and
+holding it is what a single transaction means. The split is retained anyway,
+commented at the call site, because it is the shape this migration would need
+if it were ever divided into two transactions — seconds without which
+dividing it later means rewriting the FK step, not just moving code. The
+longest single lock is very likely whichever unique index build takes
+longest — plausibly the ones on `messages` and `media_blobs`.
+
+If a rehearsal against a copy of the production database shows this is too
+slow to run as one migration, the fix is to move the index builds to `create
+unique index concurrently` inside an Alembic `autocommit_block`, each in its
+own non-transactional step. That drops the exclusive lock during the (much
+slower) concurrent build down to a share lock, at the cost of the migration
+no longer being atomic — a partial failure leaves indexes to clean up by hand
+rather than a rolled-back transaction. Deliberately not done here: there are
+no measurements yet showing it is needed, and atomicity is worth keeping
+until there are.
 
 Only tenant zero exists when this runs, so the usual expand-then-contract
 caution does not apply yet. From the next customer onward it does, and that
@@ -443,10 +484,12 @@ to prevent:
 
 Named so they are decisions rather than omissions.
 
-- **The policies do not bite in a deployed environment.** The runtime still
-  connects as a superuser, so every policy here is inert outside the test
-  suite until the runtime-role work lands. Deliberate, and safe while one
-  tenant exists — and the hard prerequisite for the second.
+- **No row-level security yet.** The migration that landed adds the tenant
+  model, per-tenant uniqueness and the composite foreign keys, and stops
+  there — `require_tenant_id()`, the policy, and the runtime-role work that
+  would make a policy bite are a later change, not merely inert code sitting
+  next to this one. Deliberate, and safe while one tenant exists — and the
+  hard prerequisite for the second.
 - **Cross-tenant user enumeration.** `users` and `oidc_identities` have no
   policy, so any tenant session can read every account. There is no exposure
   while one tenant exists, and the correct fix needs invitations and a
@@ -460,6 +503,23 @@ Named so they are decisions rather than omissions.
 - **No indexes on `tenant_id`.** With one tenant the column has no selectivity
   and an index is pure write cost. Add them when the second tenant lands, in
   one migration, `concurrently`, with data to measure against.
+- **Two references bypass the composite-key guarantee entirely, by being
+  plain strings rather than foreign keys.** `message_attachments.uri`
+  references `media_blobs.uri`, and `Reference.type` references
+  `reference_types.type`, and neither carries a `tenant_id` or a constraint of
+  any kind — so a row can be made to name another tenant's blob or reference
+  type, and nothing in this schema stops it. Row-level security closes this
+  once a session is tenant-scoped, because the lookup itself becomes
+  tenant-filtered rather than because the reference is checked; it does not
+  need a foreign key to be safe, but it is unsafe until that lands.
+- **Roughly ten read paths call `scalar_one_or_none()` on a column that is
+  now unique per tenant rather than globally**, so they raise
+  `MultipleResultsFound` the moment a second tenant has a row that also
+  matches — `agent_store.get_by_name`, `collaboration_bridge_store.get_default`,
+  `client_store.get_by_matrix_user_id`, and `room_store.get_by_matrix_room_id`
+  are four of them. They are correct today, with one tenant, and wrong the
+  day a second one exists; making the session tenant-scoped, in the next PR,
+  is what makes them correct rather than each needing its own fix.
 - No plan, status or soft-delete on `tenants`; no tenant deletion; no
   per-tenant feature flags; no tenant switching.
 - No per-tenant agent registration credential — Phase 2 owns it as a security

--- a/docs/old/multi-tenancy-phase1-db.md
+++ b/docs/old/multi-tenancy-phase1-db.md
@@ -1,0 +1,457 @@
+# Multi-tenancy Phase 1: the database design
+
+Status: design, reviewed once. Implements §2 of `multi-tenancy.md` (spike
+CHOO-2603) for CHOO-2623. Not yet built.
+
+This document is the schema half of Phase 1: what tables change, what the
+policies look like, how a session learns which tenant it is acting for, and
+what the one migration does.
+
+Postgres 16 everywhere — local Compose, the chart, and the test containers —
+and two things below need at least 15, so that is a floor, not an incidental
+detail.
+
+## The rule
+
+Everything follows from one sentence:
+
+> **Every table holding customer data carries a non-null `tenant_id`, carries
+> the same isolation policy, and every foreign key between two such tables
+> carries `tenant_id` as well.**
+
+Uniformity is the point. A reviewer should be able to open any table and know
+without thinking whether it is scoped and what its policy says, because there
+is only one kind of scoped table and one policy text.
+
+The rule buys two separate guarantees, and they are worth separating:
+
+- **A query that forgets its filter returns nothing** rather than another
+  tenant's rows. That is row-level security.
+- **A row cannot reference a parent in another tenant.** That is the composite
+  foreign key, and row-level security does not give it — referential integrity
+  checks in Postgres deliberately bypass policies, so without it a bug can
+  write a message into tenant A pointing at tenant B's room. The row is
+  unreadable from either side, but it exists, and cleaning that up later is
+  worse than preventing it now.
+
+## New tables
+
+```
+tenants
+  id          text primary key
+  slug        text not null unique
+  name        text not null
+  created_at  timestamptz not null default now()
+
+tenant_members
+  tenant_id   text not null references tenants(id)
+  user_id     text not null references users(id)
+  role        text not null check (role in ('owner','admin','member'))
+  created_at  timestamptz not null default now()
+  primary key (tenant_id, user_id)
+```
+
+Membership is a row, not a column on the user: a person has one login and may
+belong to several tenants. That decision is argued in the spike.
+
+`tenants` deliberately has no `plan`, `status` or `deleted_at`. Phase 3 adds
+plans, Phase 5 adds deletion, and a `deleted_at` that nothing honours is worse
+than no column — it reads as a guarantee the code does not make.
+
+`role` is a checked string rather than an enum type, matching how `users.role`
+is already stored. Phase 2 owns making these roles mean something; Phase 1 only
+records them so the migration loses no information.
+
+## Which tables are scoped
+
+**Scoped — 36 tables, each gains `tenant_id text not null references
+tenants(id)`:**
+
+`api_keys`, `clients`, `client_rooms`, `agents`, `tools`, `models`, `skills`,
+`agent_skills`, `rooms`, `room_agents`, `room_skills`, `room_groups`,
+`room_links`, `room_roles`, `role_leases`, `tasks`, `references`,
+`reference_types`, `documents`, `room_references`, `room_documents`,
+`packages`, `room_packages`, `package_references`, `package_documents`,
+`collaboration_bridges`, `server_connectors`, `external_users`,
+`external_user_claims`, `agent_sessions`, `agent_runtime_states`,
+`bridge_message_map`, `messages`, `message_attachments`, `delivery_cursors`,
+`media_blobs`.
+
+Longer than the spike's thirteen, because the spike named top-level entities
+and the schema has children hanging off them. The test is mechanical: if a row
+would be meaningless to another customer, it is scoped.
+
+Three entries are worth justifying:
+
+- **Junction tables are scoped like everything else.** `room_agents` joins a
+  room to an agent; both parents are scoped, and the pair is exactly where a
+  cross-tenant reference gets introduced. Its own `tenant_id` plus composite
+  keys to both parents makes "an agent from tenant B in a room from tenant A"
+  unrepresentable. Inheriting tenancy through a subquery policy instead is
+  slower and needs per-table reasoning.
+- **`media_blobs` is scoped** although nothing references it by foreign key. It
+  holds attachment bytes reached by an opaque URI, and unguessable identifiers
+  are not an isolation boundary.
+- **`clients` is scoped**, so the admin/system client becomes one row per
+  tenant rather than one per deployment. Today that is a no-op — the single
+  existing row backfills to tenant zero — and it is the right shape later.
+
+**Global — no `tenant_id`, no policy:** `users`, `oidc_identities`,
+`feature_flags`, `alembic_version`.
+
+A user is a person, not a tenant member; the membership row is the per-tenant
+object. `oidc_identities` records how that person proves who they are, equally
+tenant-independent. `feature_flags` is a deployment switch; a flag that needs
+to vary per tenant is a new table, not a nullable column.
+
+Leaving `users` and `oidc_identities` unpoliced has a consequence, and it is
+recorded as an open item rather than buried: see "What Phase 1 does not close".
+
+## Uniqueness changes
+
+Adding a column is the easy half. Constraints are what break silently when a
+second tenant appears, so the whole list was walked.
+
+**Becomes per-tenant:**
+
+- `agents.name` → `unique (tenant_id, name)`. Two customers can both have a
+  `reviewer`. The registration path already treats owner equality as a de facto
+  tenant boundary and calls a mismatch a cross-tenant takeover; this makes it
+  real.
+- `clients.matrix_user_id` → `unique (tenant_id, matrix_user_id)`, required by
+  per-tenant system clients.
+- `rooms.matrix_room_id` → `unique (tenant_id, matrix_room_id)`.
+- `reference_types` primary key → `(tenant_id, type)`. Customer-defined type
+  slugs collide. This table has no `id` column at all, so it is the one scoped
+  table that cannot carry a `unique (id, tenant_id)` — harmless, because
+  nothing references it by foreign key.
+- `collaboration_bridges` default-bridge index → `unique (tenant_id) where
+  is_default`. "One default bridge for the deployment" is exactly the global
+  singleton that breaks on the second tenant.
+
+**Stays global, deliberately:**
+
+- `users.email`. A person is one account across tenants.
+- `api_keys.key_hash`. Bearer authentication resolves the hash *before* it
+  knows a tenant. Load-bearing — see the bootstrap section.
+- `oidc_identities (iss, sub)`. The issuer already namespaces it.
+- `media_blobs.uri`, `messages.transport_event_id`. Random globally-unique
+  identifiers; scoping them buys nothing.
+
+**Already scoped transitively, left alone:** `messages (room_id, seq)`,
+`documents (room_id, name)`, `room_roles (room_id, name)`,
+`delivery_cursors (agent_id, room_id)`, `agent_sessions`,
+`agent_runtime_states`, `external_users (bridge_id, external_user_id)`,
+`bridge_message_map`, `rooms (bridge_id, external_channel_id)`,
+`agents.client_id`. Each is unique within a parent that is itself scoped, and
+the composite foreign key keeps the parent honest.
+
+`role_leases` is unique on `agent_id` alone across all rooms by design — an
+agent has one session and one lease — and an agent implies a tenant, so no
+change.
+
+## Composite foreign keys
+
+Every foreign key from a scoped table to a scoped table gains `tenant_id`:
+
+```sql
+alter table rooms add constraint uq_rooms_id_tenant unique (id, tenant_id);
+
+alter table messages
+  add constraint fk_messages_room
+  foreign key (tenant_id, room_id) references rooms (tenant_id, id);
+```
+
+Only tables that are actually referenced need the extra `unique (id,
+tenant_id)` — about thirteen, not one per scoped table. Foreign keys to
+*global* tables (`rooms.owner_id → users.id` and friends) stay single-column.
+
+Two mechanical details decide whether this works at all:
+
+- **Nullable parents keep Postgres's default `MATCH SIMPLE`**, under which a
+  NULL in any column skips the check entirely. That is what we want: no parent,
+  nothing to verify. `MATCH FULL` would reject a row with a non-null tenant and
+  a null parent, which is a legitimate row.
+- **`ON DELETE SET NULL` must name its column.** A plain multi-column `SET
+  NULL` nulls *every* referencing column, `tenant_id` included, so the delete
+  fails on the not-null constraint. Five scoped-to-scoped keys are affected —
+  `agents.parent_agent_id`, `rooms.group_id`, `room_groups.parent_group_id`,
+  `documents.created_by_agent_id`, `messages.sender_client_id` — and each needs
+  the Postgres 15+ form `on delete set null (parent_agent_id)`. Without it,
+  deleting a room group or a parent agent is broken from day one. This is the
+  single easiest thing to get wrong here.
+
+`ON DELETE CASCADE` needs no such care: it removes the child row entirely.
+
+The cost is every foreign key rewritten and thirteen indexes added. The benefit
+is invisible until something goes wrong. The cheaper variant is composite keys
+on the junction tables and `messages` only, accepting that everything else
+relies on the application writing the right parent id; I recommend against it,
+because an inconsistent rule is harder to hold in your head than a uniform one
+and the tables left out would be the ones nobody thinks about.
+
+## Row-level security
+
+One function, one policy text, applied identically to all 38 scoped tables (the
+36 above plus `tenants` and `tenant_members`).
+
+```sql
+create or replace function require_tenant_id() returns text
+language plpgsql stable as $$
+declare v text := current_setting('app.tenant_id', true);
+begin
+  if v is null or v = '' then
+    raise exception 'app.tenant_id is not set on this session'
+      using errcode = '42501';
+  end if;
+  return v;
+end $$;
+```
+
+Three cases, one behaviour. Never set in this session returns NULL because of
+the `true`; set and then released at commit returns the empty string, not NULL
+— the trap that produced a P1 elsewhere in the company; set returns the value.
+Both empty cases raise. **The function fails closed, and every other safety
+property here rests on that.**
+
+```sql
+alter table <t> enable row level security;
+
+create policy tenant_isolation on <t>
+  for all
+  using       (tenant_id = (select require_tenant_id()))
+  with check  (tenant_id = (select require_tenant_id()));
+```
+
+- **`with check` is not optional.** `using` filters what you can read; without
+  `with check` a write is unconstrained and you can insert a row into another
+  tenant that you cannot then read back. Two of the four prior-art bugs are
+  this.
+- **`(select require_tenant_id())`** rather than a bare call, so the planner
+  evaluates it once per query as an InitPlan rather than once per row. Marking
+  the function `stable` is not sufficient on its own.
+- **No `TO <role>` clause.** An earlier draft named the runtime role; that
+  makes the DDL fail wherever the role does not exist yet, including
+  `create_all` in tests. The owner-bypass model below already defines exactly
+  who is and is not subject to policies, so the clause bought nothing.
+- `tenants` uses `id = (select require_tenant_id())`; every other table uses
+  `tenant_id`.
+
+## One new database role
+
+Today the application connects to Postgres as the superuser in local Compose,
+in the chart and in the test containers. **A superuser ignores row-level
+security unconditionally** — not "unless forced", unconditionally. Shipping
+policies without changing this produces a schema full of decoration and an
+isolation test that passes for the wrong reason. This is the largest piece of
+work in Phase 1 and the only part that touches deployment.
+
+The change is deliberately small: **add one role, transfer nothing.**
+
+- **The existing role keeps owning the schema** and keeps running Alembic.
+  Because it owns the tables it bypasses their policies, and we deliberately do
+  **not** set `force row level security`, so that stays true. No `ALTER TABLE
+  … OWNER TO`, no `REASSIGN OWNED`, nothing to go wrong during a cutover.
+- **`switch_app` is new**: the runtime role, not the owner, not a superuser, no
+  `BYPASSRLS`. Policies apply to it and it is the only role the request path
+  ever uses.
+
+Roles are cluster-level, so the migration does not create them — it grants to a
+role that must already exist and fails loudly if it does not. Creating the role
+belongs to Compose, to the chart, and to the RDS runbook, which already
+recreates roles by hand. `alter default privileges` covers tables added later,
+so a future migration cannot ship a table the runtime cannot read.
+
+**The check that matters runs at startup, not in CI.** CI asserts nothing about
+production, and the failure mode here is silent. On boot the service verifies
+its own connection: not a superuser, no `BYPASSRLS`, not the owner of
+`messages`, and a probe query against a scoped table with no tenant set must
+raise. If any of those is wrong the service refuses to start, because a Switch
+that thinks it is isolating tenants and is not is worse than one that is down.
+
+**Sequencing.** The role is cheapest to add during the RDS cutover
+(CHOO-2622), which already creates an application role by hand, and that
+restore uses `--no-owner --no-privileges` — so who ends up owning the restored
+tables is a decision that has to be made deliberately there, not discovered
+afterwards. Coordinate, do not race.
+
+## Setting the tenant
+
+```sql
+select set_config('app.tenant_id', $1, true)   -- is_local = true
+```
+
+Transaction-scoped, released at commit, so it cannot leak to the next request
+that borrows the pooled connection. Both remaining prior-art bugs are
+session-scoped settings on a pooled connection; this is the fix, and the
+fail-closed function is the backstop when it is missed. Issuing it outside an
+explicit transaction only warns and does nothing — survivable here only because
+a missing tenant raises rather than matching nothing.
+
+**Where the tenant comes from, per principal:**
+
+| Principal | Source |
+| --- | --- |
+| Gateway user (JWT cookie) | the user's membership row |
+| Agent bearer token | `api_keys.tenant_id` |
+| Bridge inbound event | the bridge row's tenant |
+| Per-room background work | the room's tenant |
+
+Never from a request parameter; no endpoint accepts a tenant id as input.
+
+Phase 1 has one tenant, so membership resolution returns the single row and
+raises if there is more than one. Phase 2 adds tenant switching and an
+active-tenant claim; that is a change to one function.
+
+**The request seam has to move.** `get_session` is a FastAPI dependency that
+resolves *before* the one that authenticates the user, so there is no moment
+today where the principal is known and the session is not yet open. Endpoints
+therefore stop depending on `get_session` and depend on a `tenant_session` that
+composes it with the principal and issues the `set_config`. That is a
+mechanical edit at 107 call sites, and it puts the seam in every signature
+where a reader can see it. A test asserts no endpoint uses the raw session.
+
+**Background work is not a short list.** There are roughly 206 places that open
+a session from the factory directly. They fall into three shapes — acting for a
+room, acting for a bridge, acting for the deployment — so they get two named
+helpers, `tenant_session(tenant_id)` and `system_session()`, and a test that
+the raw factory is not called anywhere else.
+
+**Writes fill the column automatically.** `tenant_id` gets a Python-side
+default reading the request's tenant, so ordinary ORM inserts need no change
+across roughly 250 store methods, and `with check` catches anything that
+disagrees. Two caveats, both real: the default yields nothing in a system
+session, so the startup seeding paths must pass tenant zero explicitly; and one
+Core `executemany` in the room store needs checking rather than assuming.
+
+The same context value feeds the logging filter, which has had a `tenant_id`
+field since before tenants existed and which nothing has ever bound
+per-request. That closes half of Phase 0's logging item as a side effect.
+
+## The bootstrap problem, and the two exceptions
+
+Authentication happens before a tenant is known — resolving an API key by hash,
+or a JWT subject to its memberships, is unscoped by definition. So:
+
+> **Authentication and tenant resolution run in a system session. Everything
+> downstream runs in a tenant session as `switch_app`.**
+
+The same escape hatch covers work that is legitimately cross-tenant: Alembic,
+admin and bootstrap seeding at startup, the bridge and connector lifecycle
+loops that start every row at boot, and the runtime-state and connection
+sweeps. A test pins the set of modules allowed to open one, so a new one is a
+deliberate act.
+
+The delivery listener needs no exception: it holds one unpooled connection that
+relays NOTIFY payloads and never reads a scoped table. Its consumers do read
+per room — so **the notify payload gains `tenant_id`** alongside the room, seq
+and id it already carries. Without it a consumer has to make an unscoped read
+just to learn which tenant to scope by, which is a circle.
+
+Two exceptions to the uniform rule, in full:
+
+1. **`api_keys.key_hash` stays globally unique**, because authentication
+   resolves it before a tenant exists.
+2. **System sessions bypass policies by ownership.** This is a fail-open hatch
+   inside a fail-closed design and is named as such: nothing stops a pinned
+   module reading across tenants once a second one exists. Phase 1 accepts
+   that; the pinned list is what keeps it reviewable.
+
+An earlier draft had a third — a membership-based policy on `users` — and it
+was wrong. Its `with check` made creating a user impossible: the membership row
+cannot exist before the user, and the user cannot be inserted before the
+membership. It also would not have held, because `tenant_members` has no
+constraint on *which* user id a tenant may add to itself. Both problems are
+Phase 2's to solve properly, alongside invitations.
+
+## Where the SQL lives
+
+The repository already has the pattern in the delivery trigger: the DDL lives
+in one module, is attached to the tables so `create_all` builds it, and each
+migration carries its own frozen verbatim copy so that editing the module never
+changes what a past migration means. The policies follow it exactly, in
+`db/rls_ddl.py`.
+
+This matters more than it sounds. Tests build their schema from the model
+metadata rather than by running migrations, so a policy that existed only in a
+migration would be invisible to every test — the isolation test would pass
+against a database with no isolation in it.
+
+A `TenantScoped` declarative mixin carries the column, its default and its
+registration in the policy list, so adding a table means inheriting from it and
+writing the foreign keys. Without the mixin a new table needs seven separate
+things remembered; with it, two, and both are checked by tests.
+
+## The migration
+
+One revision:
+
+1. Create `tenants` and `tenant_members`; create `require_tenant_id()`.
+2. Insert tenant zero, slug `default`, with a fixed id constant written into
+   the migration. Not read from the environment: `TENANT_ID` is config today
+   and a later edit to it must not silently desync from the row.
+3. Insert a membership for every existing user — `owner` for accounts with the
+   global admin role, `member` otherwise.
+4. Per scoped table: `add column tenant_id text not null default '<zero>'`,
+   then drop the default. Since Postgres 11 that is a metadata-only operation;
+   the add-nullable-then-backfill-then-set-not-null sequence the spike
+   describes rewrites the whole table under an exclusive lock, which on
+   `messages` and on `media_blobs` with its 20MB rows is the difference between
+   a blink and an outage.
+5. Add the foreign key to `tenants` and, where the table is referenced, the
+   `unique (id, tenant_id)`.
+6. Swap the uniqueness constraints listed above.
+7. Rewrite each scoped-to-scoped foreign key as composite, `not valid` first
+   and `validate constraint` after, so the validation scan does not hold an
+   exclusive lock.
+8. Enable row-level security and create the policy on each table.
+9. Grant to `switch_app` and set default privileges.
+
+Only tenant zero exists when this runs, so the usual expand-then-contract
+caution does not apply yet. From the next customer onward it does, and that
+note belongs in the migration's docstring.
+
+## Done when
+
+An integration test proves tenant A cannot read tenant B's rows through the
+ordinary application paths — connected as the runtime role, through the store
+layer, not by hand-written SQL. That needs test infrastructure that does not
+exist yet: the fixtures create `switch_app`, grant to it, connect as it, and
+seed tenant zero, because the truncation between tests now empties `tenants`
+too.
+
+Alongside it, three cheap tests that catch the regressions this design exists
+to prevent:
+
+- Every scoped table has row-level security enabled and a policy, asserted by
+  querying `pg_policies` and `pg_tables` rather than by reading the code.
+- Every foreign key between two scoped tables includes `tenant_id`, asserted
+  the same way from the catalogue. Without this a new table passes every other
+  check while quietly falling back to a single-column key.
+- A query issued with no tenant set raises rather than returning nothing.
+
+## What Phase 1 does not close
+
+Named so they are decisions rather than omissions.
+
+- **Cross-tenant user enumeration.** `users` and `oidc_identities` have no
+  policy, so any tenant session can read every account. There is no exposure
+  while one tenant exists, and the correct fix needs invitations and a
+  per-tenant user list, which is Phase 2's scope. It must not ship without it.
+- **`tenant_members` self-service.** A tenant session can insert a membership
+  row naming any user id. Same owner, same phase.
+- **`users.email` is globally unique**, so signing up with an address that
+  exists in another tenant fails on the index rather than being handled — an
+  existence oracle and a bad error. Phase 2.
+- **System sessions can read across tenants** by design, as above.
+- **No indexes on `tenant_id`.** With one tenant the column has no selectivity
+  and an index is pure write cost. Add them when the second tenant lands, in
+  one migration, `concurrently`, with data to measure against.
+- No plan, status or soft-delete on `tenants`; no tenant deletion; no
+  per-tenant feature flags; no tenant switching.
+- No per-tenant agent registration credential — Phase 2 owns it as a security
+  item, not a refactor.
+- No renaming of the residual `matrix_*` columns. Worth doing while these
+  tables are open, but not in the migration that changes isolation.
+- The room advisory lock hashes only the room id, so it is a cluster-global
+  namespace shared across tenants. Harmless at today's scale, worth a note.

--- a/docs/old/multi-tenancy-phase1-db.md
+++ b/docs/old/multi-tenancy-phase1-db.md
@@ -237,43 +237,47 @@ create policy tenant_isolation on <t>
 - `tenants` uses `id = (select require_tenant_id())`; every other table uses
   `tenant_id`.
 
-## One new database role
+## The runtime role, and why it is not in this phase
 
 Today the application connects to Postgres as the superuser in local Compose,
 in the chart and in the test containers. **A superuser ignores row-level
-security unconditionally** — not "unless forced", unconditionally. Shipping
-policies without changing this produces a schema full of decoration and an
-isolation test that passes for the wrong reason. This is the largest piece of
-work in Phase 1 and the only part that touches deployment.
+security unconditionally** — not "unless forced", unconditionally. Until the
+runtime connects as a role that policies apply to, everything in the section
+above is inert in a deployed environment.
 
-The change is deliberately small: **add one role, transfer nothing.**
+That work — creating a `switch_app` role in Compose, the chart and the RDS
+runbook, granting it, pointing the service at it, and a startup self-check that
+refuses to boot if the connection is a superuser or the table owner — **is
+tracked separately and is not part of Phase 1.** The shape it should take, so
+that whoever picks it up does not have to rediscover it:
 
-- **The existing role keeps owning the schema** and keeps running Alembic.
-  Because it owns the tables it bypasses their policies, and we deliberately do
-  **not** set `force row level security`, so that stays true. No `ALTER TABLE
-  … OWNER TO`, no `REASSIGN OWNED`, nothing to go wrong during a cutover.
-- **`switch_app` is new**: the runtime role, not the owner, not a superuser, no
-  `BYPASSRLS`. Policies apply to it and it is the only role the request path
-  ever uses.
+- **Add one role, transfer nothing.** The existing role keeps owning the schema
+  and keeps running Alembic. Because it owns the tables it bypasses their
+  policies, and we deliberately do **not** set `force row level security`, so
+  that stays true. No `ALTER TABLE … OWNER TO`, no `REASSIGN OWNED`, nothing to
+  go wrong during a cutover.
+- **`switch_app` is the runtime role**: not the owner, not a superuser, no
+  `BYPASSRLS`, with `alter default privileges` so a later migration cannot ship
+  a table it cannot read.
+- **The check that matters runs at startup, not in CI.** CI asserts nothing
+  about production and this failure mode is silent. A Switch that believes it
+  is isolating tenants and is not is worse than one that is down.
+- **Cheapest during the RDS cutover** (CHOO-2622), which already creates an
+  application role by hand and restores with `--no-owner --no-privileges` — so
+  who owns the restored tables is a decision made there either way.
 
-Roles are cluster-level, so the migration does not create them — it grants to a
-role that must already exist and fails loudly if it does not. Creating the role
-belongs to Compose, to the chart, and to the RDS runbook, which already
-recreates roles by hand. `alter default privileges` covers tables added later,
-so a future migration cannot ship a table the runtime cannot read.
+Splitting it is a reasonable call while the deployment has one tenant, because
+there is nothing to leak. It is not a follow-up nicety: **it is a prerequisite
+for onboarding a second tenant**, and Phase 1 shipping without it means the
+policies exist and do not yet bite.
 
-**The check that matters runs at startup, not in CI.** CI asserts nothing about
-production, and the failure mode here is silent. On boot the service verifies
-its own connection: not a superuser, no `BYPASSRLS`, not the owner of
-`messages`, and a probe query against a scoped table with no tenant set must
-raise. If any of those is wrong the service refuses to start, because a Switch
-that thinks it is isolating tenants and is not is worse than one that is down.
+Phase 1 does keep a restricted role **inside the test fixtures**, which is
+contained to the test harness and touches no environment. Without it nothing
+verifies a single policy, and 38 of them would ship unexercised.
 
-**Sequencing.** The role is cheapest to add during the RDS cutover
-(CHOO-2622), which already creates an application role by hand, and that
-restore uses `--no-owner --no-privileges` — so who ends up owning the restored
-tables is a decision that has to be made deliberately there, not discovered
-afterwards. Coordinate, do not race.
+Consequently this design's migration creates no roles and issues no grants.
+Both belong to the role work, in one place, rather than half here behind a
+conditional that silently does nothing.
 
 ## Setting the tenant
 
@@ -334,7 +338,7 @@ Authentication happens before a tenant is known — resolving an API key by hash
 or a JWT subject to its memberships, is unscoped by definition. So:
 
 > **Authentication and tenant resolution run in a system session. Everything
-> downstream runs in a tenant session as `switch_app`.**
+> downstream runs in a tenant session, as the restricted runtime role.**
 
 The same escape hatch covers work that is legitimately cross-tenant: Alembic,
 admin and bootstrap seeding at startup, the bridge and connector lifecycle
@@ -405,7 +409,8 @@ One revision:
    and `validate constraint` after, so the validation scan does not hold an
    exclusive lock.
 8. Enable row-level security and create the policy on each table.
-9. Grant to `switch_app` and set default privileges.
+
+No roles are created and no grants issued — see the role section above.
 
 Only tenant zero exists when this runs, so the usual expand-then-contract
 caution does not apply yet. From the next customer onward it does, and that
@@ -414,11 +419,15 @@ note belongs in the migration's docstring.
 ## Done when
 
 An integration test proves tenant A cannot read tenant B's rows through the
-ordinary application paths — connected as the runtime role, through the store
+ordinary application paths — connected as a restricted role, through the store
 layer, not by hand-written SQL. That needs test infrastructure that does not
-exist yet: the fixtures create `switch_app`, grant to it, connect as it, and
-seed tenant zero, because the truncation between tests now empties `tenants`
-too.
+exist yet: the fixtures create the role, grant to it, connect as it, and seed
+tenant zero, because the truncation between tests now empties `tenants` too.
+
+Note what this does and does not prove. It proves the **policies** are correct,
+which is the part Phase 1 owns. It does not prove the **deployment** is subject
+to them — that is the role work, and until it lands the same test against a
+real environment would pass for the wrong reason.
 
 Alongside it, three cheap tests that catch the regressions this design exists
 to prevent:
@@ -434,6 +443,10 @@ to prevent:
 
 Named so they are decisions rather than omissions.
 
+- **The policies do not bite in a deployed environment.** The runtime still
+  connects as a superuser, so every policy here is inert outside the test
+  suite until the runtime-role work lands. Deliberate, and safe while one
+  tenant exists — and the hard prerequisite for the second.
 - **Cross-tenant user enumeration.** `users` and `oidc_identities` have no
   policy, so any tenant session can read every account. There is no exposure
   while one tenant exists, and the correct fix needs invitations and a


### PR DESCRIPTION
Phase 1 of multi-tenancy, schema only. The existing deployment becomes tenant
zero and nothing changes for anyone using it.

The design, with the reasoning behind each choice and an honest list of what
this phase deliberately does not close, is committed alongside the code:
`docs/old/multi-tenancy-phase1-db.md`. It is worth reading before the diff —
the diff is large and mechanical, the design is where the decisions are.

## What is here

- `tenants` and `tenant_members`. Membership is a row, not a column on the
  user, because a person may belong to more than one tenant.
- `tenant_id` on the 36 tables holding customer data. Four tables stay global:
  `users`, `oidc_identities`, `feature_flags`, `alembic_version`.
- Per-tenant uniqueness where a global constraint would break on the second
  customer — agent names most obviously.
- Composite foreign keys between scoped tables.
- One migration turning the existing deployment into tenant zero.

## What is not here

- **Row-level security policies** — the next change.
- **Session plumbing**, resolving the tenant from the caller — the change after
  that.
- **The runtime database role** — split out as its own ticket. Until it lands
  the service still connects as a superuser, and a superuser ignores row-level
  security outright, so the policies that arrive next will not bite in a
  deployed environment. Safe while one tenant exists; a hard prerequisite for
  the second.

## Two things reviewers should look at hardest

**Composite foreign keys are the expensive half of this.** Referential
integrity checks in Postgres deliberately bypass row-level security, so a
policy cannot stop a row referencing another tenant's parent — only the key
can. The cost is 53 keys rewritten and 13 extra unique indexes. If that trade
looks wrong, that is the thing to argue with.

**The five keys that null on delete name their column explicitly**
(`ON DELETE SET NULL (group_id)` and friends, Postgres 15+). A plain
multi-column SET NULL nulls `tenant_id` as well, and the delete then fails on
the not-null constraint. This was caught in review rather than in production;
one of the five is covered by an explicit check described below.

## Locking: measured against production-sized data

**Verdict: a blink, not an incident. No change needed.**

Measured by restoring a copy of the pilot database into a throwaway container
and running the migration against it with lock logging on:

- **Total migration time: 0.92s.** Downgrade 0.69s, data intact — row counts
  identical before and after.
- **Longest any table is unwritable: ~0.6s.** The whole revision runs in one
  transaction, so every `ACCESS EXCLUSIVE` lock is held to commit; the
  transaction span is ~620ms and that is the real answer, not the per-statement
  times.
- Slowest single statement is the unique index on `messages` at 44ms. That is
  the one that scales with data, so it is the one to watch.
- Disk cost of the new columns and indexes: ~8.4MB on a 291MB database.

Adding the tenant column is metadata-only and does not rewrite the table, which
is what keeps this cheap. The thirteen unique index builds are the part that
grows with data.

**When to revisit — now measured, not extrapolated.** The 100x figure above
was a guess from one data point. Since then we generated synthetic databases
at 1x, 5x and 20x the pilot's row counts
(`core/tests/synthetic/generate_synthetic_db.py --scale-factor`) and reran
the same lock-logged migration against each in a throwaway container:

| scale | messages | transaction span | slowest statement (unique index on `messages`) | total wall time | disk growth |
|-------|----------|-------------------|--------------------------------------------------|------------------|-------------|
| 1x    | 63k      | 1.0s               | 53ms                                             | 1.6s             | +5.6MB      |
| 5x    | 314k     | 1.6s               | 270ms                                            | 2.7s             | +25MB       |
| 20x   | 1.26M    | 3.4s               | 892ms                                            | 3.8s             | +97MB       |

The slowest statement — the `messages` unique index build — scales almost
exactly linearly with row count, as expected for a btree build. But the
*transaction span* grows much slower than the row count: 20x the messages
only triples the lock time, because roughly 900ms of every run is fixed
cost — the other ~35 scoped tables each get a handful of small,
constant-cost `ALTER TABLE` / `CREATE POLICY` statements, independent of how
many rows they hold.

That is a straight line, not a knee: there is no point where this suddenly
stops being a blink. Extrapolating the measured per-row cost to 100x the
pilot's size (~6.3M messages) predicts roughly 13 seconds of exclusive lock
on `messages` — a real cost, and a predictable multiple of what we measured,
but not the cliff the original claim implied. The more useful takeaway is
that a 20x deployment, not an extreme one, already spends 3-4 seconds unable
to write, which is worth planning around well before 100x. **Revised
guidance:** keep this as one transaction for now; revisit `CREATE INDEX
CONCURRENTLY` once total message volume heads into the low millions (roughly
30-50x today's pilot size), where the lock span starts running several
seconds rather than one.

The `NOT VALID` / `VALIDATE CONSTRAINT` split on the foreign keys buys nothing
inside a single transaction. It is kept because it is the shape a future
two-phase split would need, and commented as such.

## How it was verified

Not against an empty database, which proves little. The migration was run over
a pre-change schema holding real rows, then reversed, then re-applied:

- Row counts preserved; every scoped table carries tenant zero afterwards.
- `tenant_members` backfilled from existing accounts, admins as owners.
- All rewritten keys validated; no constraint left `NOT VALID`.
- Deleting a client nulls only the sender column and leaves the tenant intact
  — the exact failure the column-list form exists to prevent.
- `downgrade` returns constraints and indexes byte-for-byte to the baseline.
- Full suite green: 2691 passed, 6 skipped.

One pre-existing failure in the integration suite
(`test_agent_greeting_e2e.py::test_no_greeting_when_the_bridge_has_them_disabled`)
was reproduced on `main` with none of these changes present, so it is unrelated
and left alone.


