### PR TITLE
fix(db): rejoin the two migration heads so the service can boot

### DIFF
--- a/core/switch_core/migrations/versions/b47e0c39a1f5_merge_oidc_identities_and_group_id_index_heads.py
+++ b/core/switch_core/migrations/versions/b47e0c39a1f5_merge_oidc_identities_and_group_id_index_heads.py
@@ -1,0 +1,29 @@
+"""merge the oidc identities and rooms.group_id index heads
+
+Two migrations landed in parallel off the same parent, leaving the chain with
+two heads. `alembic upgrade head` is ambiguous with more than one, and the
+service runs exactly that at startup, so a deployment not already sitting on
+one of the two refuses to boot. Neither head carries schema of its own that the
+other needs; this only rejoins them.
+
+Revision ID: b47e0c39a1f5
+Revises: 04f27f37e474, a1c7e2f9b430
+Create Date: 2026-09-10
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "b47e0c39a1f5"
+down_revision: str | Sequence[str] | None = ("04f27f37e474", "a1c7e2f9b430")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## The problem

`main` has two Alembic heads:

```
04f27f37e474  (oidc identities table)
a1c7e2f9b430  (index rooms.group_id)
```

Both branch off `c8e4a10b7f36`. Startup runs `alembic upgrade head`
(`core/switch_core/main.py:729`), which is ambiguous with more than one head, so
a deployment whose database is not already sitting on one of the two refuses to
boot:

```
CommandError: Multiple head revisions are present for given argument 'head';
please specify a specific target revision, '<branchname>@head' to narrow to a
specific head, or 'heads' for all heads
```

The next migration to land is blocked on the same thing.

## Why nothing caught it

`test_single_head` in `core/tests/switch_core/test_migration_chain.py` asserts
exactly this, and it has been failing on `main` since the second migration
merged:

```
AssertionError: expected exactly one migration head, got ['04f27f37e474', 'a1c7e2f9b430']
```

Each pull request was green against its own branch, where there was one head.
Nothing re-ran the suite against the merge result. Worth a look separately —
this is the second time the chain has forked (`c81f4a06d2b7` was the first).

## The change

One empty merge revision, following `c81f4a06d2b7`. Neither head carries schema
the other needs, so there is nothing to reconcile.

## Verified

- `test_migration_chain.py` — 4 passed (was 1 failed, 3 passed on `main`).
- `test_migration_parity.py::test_migrations_match_the_models` — passes; it
  replays the whole chain against a real Postgres and diffs the result against
  the models, so it exercises the merge rather than just the graph.
- `alembic heads` now returns one revision and `head` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)