### PR TITLE
fix(logging): never restore a log context token in a context that did not make it

### DIFF
--- a/core/switch_core/bridges/agent/api/operations.py
+++ b/core/switch_core/bridges/agent/api/operations.py
@@ -26,11 +26,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 from switch_core.bridges.agent.auth import get_agent_from_scope
 from switch_core.bridges.agent.dependencies import get_protocol
 from switch_core.bridges.agent.operations import all_operations, get_operation
-from switch_core.bridges.agent.operations.callctx import (
-    CallContext,
-    reset_call_context,
-    set_call_context,
-)
+from switch_core.bridges.agent.operations.callctx import CallContext, call_context
 from switch_core.bridges.agent.protocol.connections import UnknownConnectionError
 from switch_core.bridges.agent.protocol.service import ProtocolService
 from switch_core.db.models import Agent
@@ -103,14 +99,11 @@ async def call_operation(
     if missing:
         raise BadArgumentsError(f"{operation} requires: {', '.join(missing)}")
 
-    token = set_call_context(CallContext(agent_id=agent_id, session_key=connection_id))
-    try:
+    with call_context(CallContext(agent_id=agent_id, session_key=connection_id)):
         result = fn(**call_args)
         if inspect.isawaitable(result):
             result = await result
         return result
-    finally:
-        reset_call_context(token)
 
 
 # ── HTTP router ──────────────────────────────────────────────────────────────

--- a/core/switch_core/bridges/agent/auth.py
+++ b/core/switch_core/bridges/agent/auth.py
@@ -20,7 +20,7 @@ from switch_core.db.tenant_lookup import (
     tenant_of_agent_oauth_client,
     tenant_of_api_key,
 )
-from switch_core.logging_context import bind_log_context, unbind_log_context
+from switch_core.logging_context import log_context
 from switch_core.tenant_context import tenant_scope
 
 logger = logging.getLogger(__name__)
@@ -162,12 +162,10 @@ class BearerAuthMiddleware:
             # path resolves straight to an Agent with no ApiKey row, so it
             # falls back to the agent's own tenant.
             tenant_id = api_key.tenant_id if api_key is not None else agent.tenant_id
-            with tenant_scope(tenant_id):
-                log_token = bind_log_context(agent_id=agent.id, tenant_id=tenant_id)
-                try:
-                    await self.app(scope, receive, send)
-                finally:
-                    unbind_log_context(log_token)
+            with tenant_scope(tenant_id), log_context(
+                agent_id=agent.id, tenant_id=tenant_id
+            ):
+                await self.app(scope, receive, send)
             return
 
         # Registration token: pass through (handler validates again). MCP rejects.
@@ -184,12 +182,10 @@ class BearerAuthMiddleware:
             # tenant zero by fallback and make that wrong answer permanent and
             # self-confirming — so bind the token's own tenant here, exactly
             # as an agent key does.
-            with tenant_scope(api_key.tenant_id):
-                log_token = bind_log_context(tenant_id=api_key.tenant_id)
-                try:
-                    await self.app(scope, receive, send)
-                finally:
-                    unbind_log_context(log_token)
+            with tenant_scope(api_key.tenant_id), log_context(
+                tenant_id=api_key.tenant_id
+            ):
+                await self.app(scope, receive, send)
             return
 
         response = Response("Invalid credentials", status_code=401)

--- a/core/switch_core/bridges/agent/auth.py
+++ b/core/switch_core/bridges/agent/auth.py
@@ -162,8 +162,9 @@ class BearerAuthMiddleware:
             # path resolves straight to an Agent with no ApiKey row, so it
             # falls back to the agent's own tenant.
             tenant_id = api_key.tenant_id if api_key is not None else agent.tenant_id
-            with tenant_scope(tenant_id), log_context(
-                agent_id=agent.id, tenant_id=tenant_id
+            with (
+                tenant_scope(tenant_id),
+                log_context(agent_id=agent.id, tenant_id=tenant_id),
             ):
                 await self.app(scope, receive, send)
             return
@@ -182,8 +183,9 @@ class BearerAuthMiddleware:
             # tenant zero by fallback and make that wrong answer permanent and
             # self-confirming — so bind the token's own tenant here, exactly
             # as an agent key does.
-            with tenant_scope(api_key.tenant_id), log_context(
-                tenant_id=api_key.tenant_id
+            with (
+                tenant_scope(api_key.tenant_id),
+                log_context(tenant_id=api_key.tenant_id),
             ):
                 await self.app(scope, receive, send)
             return

--- a/core/switch_core/bridges/agent/mcp/server.py
+++ b/core/switch_core/bridges/agent/mcp/server.py
@@ -23,11 +23,7 @@ from starlette.types import ASGIApp
 
 from switch_core.bridges.agent.auth import BearerAuthMiddleware, OIDCTokenValidator
 from switch_core.bridges.agent.operations import all_operations
-from switch_core.bridges.agent.operations.callctx import (
-    CallContext,
-    reset_call_context,
-    set_call_context,
-)
+from switch_core.bridges.agent.operations.callctx import CallContext, call_context
 from switch_core.bridges.agent.operations.context import init_operations_protocol
 
 if TYPE_CHECKING:
@@ -64,18 +60,15 @@ class CallContextMiddleware(Middleware):
             raise ValueError("No agent_id in request — authentication failed")
 
         fastmcp_context = context.fastmcp_context
-        token = set_call_context(
+        with call_context(
             CallContext(
                 agent_id=agent_id,
                 session_key=(
                     fastmcp_context.session_id if fastmcp_context is not None else None
                 ),
             )
-        )
-        try:
+        ):
             return await call_next(context)
-        finally:
-            reset_call_context(token)
 
 
 mcp = FastMCP("Switch")

--- a/core/switch_core/bridges/agent/operations/callctx.py
+++ b/core/switch_core/bridges/agent/operations/callctx.py
@@ -13,12 +13,15 @@ room binding", and operations only ever compare them for equality.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 
 from switch_core.logging_context import (
     LogContext,
     bind_log_context,
+    restore_unless_finalising,
     unbind_log_context,
 )
 
@@ -62,3 +65,19 @@ def reset_call_context(token: _CallContextToken) -> None:
 
 def current_call_context() -> CallContext | None:
     return _current.get()
+
+
+@contextmanager
+def call_context(context: CallContext) -> Iterator[None]:
+    """Bind `context` for the block and restore both tokens on the way out.
+
+    The one caller-facing way to use `set_call_context`/`reset_call_context`:
+    a front door binds the caller for an operation call that it does not
+    control the internals of, so the call may suspend and never resume — the
+    caller's coroutine dropped and finalised by the garbage collector rather
+    than completed. `restore_unless_finalising` skips the reset pair in that
+    case instead of raising trying to reset a token from the wrong context.
+    """
+    token = set_call_context(context)
+    with restore_unless_finalising(lambda: reset_call_context(token)):
+        yield

--- a/core/switch_core/gateway/auth.py
+++ b/core/switch_core/gateway/auth.py
@@ -22,7 +22,7 @@ from switch_core.gateway.dependencies import (
     get_session_factory,
     get_user_store,
 )
-from switch_core.logging_context import bind_log_context, unbind_log_context
+from switch_core.logging_context import log_context
 from switch_core.tenant_context import tenant_scope
 
 logger = logging.getLogger(__name__)
@@ -223,16 +223,12 @@ async def get_current_user(
 
     tenant_id = await _resolve_tenant_id(session_factory, user_store, user_id)
 
-    with tenant_scope(tenant_id):
-        log_token = bind_log_context(user_id=user_id, tenant_id=tenant_id)
-        try:
-            user = await user_store.get(session, user_id)
-            if user is None:
-                # Deleted between the two reads; rare, and still not a 500.
-                raise HTTPException(status_code=401, detail="User not found")
-            yield user
-        finally:
-            unbind_log_context(log_token)
+    with tenant_scope(tenant_id), log_context(user_id=user_id, tenant_id=tenant_id):
+        user = await user_store.get(session, user_id)
+        if user is None:
+            # Deleted between the two reads; rare, and still not a 500.
+            raise HTTPException(status_code=401, detail="User not found")
+        yield user
 
 
 async def require_admin(

--- a/core/switch_core/logging_context.py
+++ b/core/switch_core/logging_context.py
@@ -30,7 +30,7 @@ row the way the two bindings could.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, replace
@@ -80,17 +80,24 @@ def unbind_log_context(token: Token[LogContext]) -> None:
 
 
 @contextmanager
-def _held(token: Token[LogContext]) -> Iterator[None]:
-    """Hold `token` for the block and restore what it replaced on the way out.
+def restore_unless_finalising(restore: Callable[[], None]) -> Iterator[None]:
+    """Run `restore` on the way out of the block, except when it is unwound by
+    `GeneratorExit`.
 
-    Not restored when the block is unwound by `GeneratorExit`. That is a frame
-    being *finalised* rather than resumed — a coroutine dropped while
-    suspended and later closed by the garbage collector — and the collector
-    runs it in whatever context it happens to be in, not the one the token
-    belongs to. `Token.reset` refuses to cross contexts, correctly: restoring
-    there would stamp this scope's fields onto an unrelated one. There is also
-    nothing left to restore, since the context the token belongs to is
-    unreachable, which is why the frame is being finalised at all.
+    `GeneratorExit` here means the frame is being *finalised* rather than
+    resumed — a coroutine dropped while suspended and later closed by the
+    garbage collector — and the collector runs that close in whatever context
+    it happens to be in, not the one that entered the block. A `restore` built
+    on a `contextvars.Token.reset` refuses to cross contexts, correctly:
+    running it there would stamp this scope's state onto an unrelated one.
+    There is also nothing left to restore, since the context the token
+    belongs to is unreachable, which is why the frame is being finalised at
+    all.
+
+    Shared by every scope built on a context-variable token — `log_context`
+    below, and the call context in `bridges/agent/operations/callctx.py`,
+    which restores both a call token and a log token together — so the
+    finalisation check is written once rather than duplicated per token type.
     """
     finalising = False
     try:
@@ -100,12 +107,13 @@ def _held(token: Token[LogContext]) -> Iterator[None]:
         raise
     finally:
         if not finalising:
-            unbind_log_context(token)
+            restore()
 
 
 @contextmanager
 def log_context(**fields: str | None) -> Iterator[None]:
-    with _held(bind_log_context(**fields)):
+    token = bind_log_context(**fields)
+    with restore_unless_finalising(lambda: unbind_log_context(token)):
         yield
 
 

--- a/core/switch_core/logging_context.py
+++ b/core/switch_core/logging_context.py
@@ -80,12 +80,33 @@ def unbind_log_context(token: Token[LogContext]) -> None:
 
 
 @contextmanager
-def log_context(**fields: str | None) -> Iterator[None]:
-    token = bind_log_context(**fields)
+def _held(token: Token[LogContext]) -> Iterator[None]:
+    """Hold `token` for the block and restore what it replaced on the way out.
+
+    Not restored when the block is unwound by `GeneratorExit`. That is a frame
+    being *finalised* rather than resumed — a coroutine dropped while
+    suspended and later closed by the garbage collector — and the collector
+    runs it in whatever context it happens to be in, not the one the token
+    belongs to. `Token.reset` refuses to cross contexts, correctly: restoring
+    there would stamp this scope's fields onto an unrelated one. There is also
+    nothing left to restore, since the context the token belongs to is
+    unreachable, which is why the frame is being finalised at all.
+    """
+    finalising = False
     try:
         yield
+    except GeneratorExit:
+        finalising = True
+        raise
     finally:
-        unbind_log_context(token)
+        if not finalising:
+            unbind_log_context(token)
+
+
+@contextmanager
+def log_context(**fields: str | None) -> Iterator[None]:
+    with _held(bind_log_context(**fields)):
+        yield
 
 
 class LogContextFilter(logging.Filter):

--- a/core/switch_core/request_context.py
+++ b/core/switch_core/request_context.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from switch_core.logging_context import bind_log_context, unbind_log_context
+from switch_core.logging_context import log_context
 
 _REQUEST_ID_HEADER = b"x-request-id"
 # An id from a caller is untrusted input that ends up in every log line for the
@@ -34,11 +34,8 @@ class RequestContextMiddleware:
             await self.app(scope, receive, send)
             return
 
-        token = bind_log_context(request_id=_request_id(scope))
-        try:
+        with log_context(request_id=_request_id(scope)):
             await self.app(scope, receive, send)
-        finally:
-            unbind_log_context(token)
 
 
 def _request_id(scope: Scope) -> str:

--- a/core/tests/switch_core/bridges/agent/api/test_operations.py
+++ b/core/tests/switch_core/bridges/agent/api/test_operations.py
@@ -7,6 +7,10 @@ adds an operation and these fail, that is the point.
 
 from __future__ import annotations
 
+import contextvars
+from collections.abc import Coroutine, Generator
+from typing import Any
+
 import pytest
 
 from switch_core.bridges.agent.api.operations import (
@@ -24,6 +28,7 @@ from switch_core.bridges.agent.operations.callctx import (
     reset_call_context,
     set_call_context,
 )
+from switch_core.logging_context import current_log_context
 
 AGENT = "agent-1"
 
@@ -161,6 +166,63 @@ def test_session_key_is_none_when_bound_to_nothing() -> None:
     # Neither an HTTP call context nor an MCP session: operations that need a
     # room report "not connected" rather than guessing one.
     assert op_context.session_key() is None
+
+
+class _Suspend:
+    """An await that suspends once, so a coroutine can be left mid-scope with
+    no event loop in sight."""
+
+    def __await__(self) -> Generator[None, None, None]:
+        yield
+
+
+def _drive_then_finalise_elsewhere(coro: Coroutine[Any, Any, None]) -> None:
+    """Enter the scope inside its own context, then close from this one —
+    what the garbage collector does to a coroutine dropped while suspended."""
+    contextvars.copy_context().run(coro.send, None)
+    coro.close()
+
+
+async def test_the_call_context_survives_a_dropped_operation_call() -> None:
+    """A caller that suspends inside an operation and is then dropped — the
+    coroutine finalised by the garbage collector rather than resumed — must
+    not raise trying to restore a token from the wrong context.
+    """
+
+    async def hanging_op(room_id: str) -> str:
+        await _Suspend()
+        return "unreached"
+
+    from switch_core.bridges.agent.operations import registry
+
+    registry._REGISTRY["hanging_op"] = registry.Operation(
+        name="hanging_op",
+        fn=hanging_op,
+        description="hanging",
+        input_schema=registry._input_schema(hanging_op),
+    )
+    try:
+
+        async def body() -> None:
+            await call_operation(
+                operation="hanging_op",
+                arguments={"room_id": "room-1"},
+                agent_id=AGENT,
+                connection_id="conn-9",
+            )
+
+        assert current_call_context() is None
+        _drive_then_finalise_elsewhere(body())
+        assert current_call_context() is None, (
+            "finalising a dropped operation call leaked its call context "
+            "into the collector's context"
+        )
+        assert current_log_context().agent_id is None, (
+            "finalising a dropped operation call leaked its log context "
+            "into the collector's context"
+        )
+    finally:
+        registry._REGISTRY.pop("hanging_op", None)
 
 
 def test_the_registry_refuses_duplicate_operation_names() -> None:

--- a/core/tests/switch_core/bridges/agent/mcp/test_call_context_middleware.py
+++ b/core/tests/switch_core/bridges/agent/mcp/test_call_context_middleware.py
@@ -1,0 +1,67 @@
+"""CallContextMiddleware's call-context restore.
+
+Same finalisation edge as `test_callctx.py`, exercised through the actual
+front door: an MCP tool call that suspends and is then dropped and finalised
+by the garbage collector, rather than resumed, must not raise trying to reset
+a token from the wrong context.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Coroutine, Generator
+from typing import Any
+
+from fastmcp.server.middleware import MiddlewareContext
+
+from switch_core.bridges.agent.mcp import server as mcp_server
+from switch_core.bridges.agent.operations.callctx import current_call_context
+from switch_core.logging_context import current_log_context
+
+AGENT = "agent-1"
+
+
+class _Suspend:
+    """An await that suspends once, so a coroutine can be left mid-scope with
+    no event loop in sight."""
+
+    def __await__(self) -> Generator[None, None, None]:
+        yield
+
+
+def _drive_then_finalise_elsewhere(coro: Coroutine[Any, Any, None]) -> None:
+    """Enter the scope inside its own context, then close from this one —
+    what the garbage collector does to a coroutine dropped while suspended."""
+    contextvars.copy_context().run(coro.send, None)
+    coro.close()
+
+
+class _FakeRequest:
+    def __init__(self, agent_id: str) -> None:
+        self.scope = {"agent_id": agent_id}
+
+
+def test_the_call_context_survives_being_closed_from_another_context(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(mcp_server, "get_http_request", lambda: _FakeRequest(AGENT))
+
+    middleware = mcp_server.CallContextMiddleware()
+    context: MiddlewareContext = MiddlewareContext(message=None, fastmcp_context=None)
+
+    async def call_next(_context: MiddlewareContext) -> None:
+        await _Suspend()
+
+    async def body() -> None:
+        await middleware.on_call_tool(context, call_next)
+
+    assert current_call_context() is None
+    _drive_then_finalise_elsewhere(body())
+    assert current_call_context() is None, (
+        "finalising a dropped tool call leaked its call context into the "
+        "collector's context"
+    )
+    assert current_log_context().agent_id is None, (
+        "finalising a dropped tool call leaked its log context into the "
+        "collector's context"
+    )

--- a/core/tests/switch_core/bridges/agent/operations/test_callctx.py
+++ b/core/tests/switch_core/bridges/agent/operations/test_callctx.py
@@ -1,0 +1,55 @@
+"""switch_core.bridges.agent.operations.callctx: the finalisation edge of
+`call_context`.
+
+Mirrors `test_logging_context.py`'s case for `log_context`, but for the call
+context: it restores a call token *and* a log token together, so both must be
+skipped consistently when the block is unwound by `GeneratorExit` rather than
+resumed.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Coroutine, Generator
+from typing import Any
+
+from switch_core.bridges.agent.operations.callctx import (
+    CallContext,
+    call_context,
+    current_call_context,
+)
+from switch_core.logging_context import current_log_context
+
+AGENT = "agent-1"
+
+
+class _Suspend:
+    """An await that suspends once, so a coroutine can be left mid-scope with
+    no event loop in sight."""
+
+    def __await__(self) -> Generator[None, None, None]:
+        yield
+
+
+def _drive_then_finalise_elsewhere(coro: Coroutine[Any, Any, None]) -> None:
+    """Enter the scope inside its own context, then close from this one —
+    what the garbage collector does to a coroutine dropped while suspended."""
+    contextvars.copy_context().run(coro.send, None)
+    coro.close()
+
+
+def test_call_context_survives_being_closed_from_another_context() -> None:
+    async def body() -> None:
+        with call_context(CallContext(agent_id=AGENT, session_key="c1")):
+            await _Suspend()
+
+    assert current_call_context() is None
+    _drive_then_finalise_elsewhere(body())
+    assert current_call_context() is None, (
+        "finalising a dropped coroutine leaked its call context into the "
+        "collector's context"
+    )
+    assert current_log_context().agent_id is None, (
+        "finalising a dropped coroutine leaked its log context into the "
+        "collector's context"
+    )

--- a/core/tests/switch_core/bridges/agent/test_bearer_auth_log_context.py
+++ b/core/tests/switch_core/bridges/agent/test_bearer_auth_log_context.py
@@ -1,0 +1,115 @@
+"""BearerAuthMiddleware's log-context restore on the agent-authenticated path.
+
+Mirrors `test_logging_context.py`'s finalisation case for the raw
+`bind_log_context`/`unbind_log_context` pair the middleware used to carry in a
+`try`/`finally`: a downstream app coroutine dropped while suspended and
+finalised by the garbage collector runs its `finally` in whatever context the
+collector happens to be in, not the one the token was bound in.
+
+The agent token is resolved from the in-memory `ApiKeyCache` rather than a
+database lookup, so the only suspension point left in the middleware's
+coroutine is the downstream app — the one this test needs to control.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import hashlib
+from collections.abc import Coroutine, Generator
+from typing import Any
+
+from switch_core.bridges.agent.api_key_cache import ApiKeyCache
+from switch_core.bridges.agent.auth import BearerAuthMiddleware
+from switch_core.db.models import Agent, ApiKey
+from switch_core.db.stores.agent_store import AgentStore
+from switch_core.db.stores.api_key_store import ApiKeyStore
+from switch_core.logging_context import current_log_context, log_context
+
+TOKEN = "agent-token"
+AGENT_ID = "agent-1"
+
+
+class _Suspend:
+    """An await that suspends once, so a coroutine can be left mid-scope with
+    no event loop in sight."""
+
+    def __await__(self) -> Generator[None, None, None]:
+        yield
+
+
+def _drive_then_finalise_elsewhere(coro: Coroutine[Any, Any, None]) -> None:
+    """Enter the scope inside its own context, then close from this one —
+    what the garbage collector does to a coroutine dropped while suspended."""
+    contextvars.copy_context().run(coro.send, None)
+    coro.close()
+
+
+def _middleware() -> tuple[BearerAuthMiddleware, dict]:
+    called: dict[str, Any] = {}
+
+    async def _app(scope: Any, receive: Any, send: Any) -> None:
+        called["scope"] = scope
+        await _Suspend()
+
+    cache = ApiKeyCache(ttl_seconds=5, max_entries=8)
+    cache.put(
+        hashlib.sha256(TOKEN.encode()).hexdigest(),
+        ApiKey(
+            id="key-1",
+            user_id="user-1",
+            key_hash="unused",
+            encrypted_key="enc",
+            label="k",
+            type="agent",
+        ),
+        Agent(
+            id=AGENT_ID,
+            name="agent",
+            description="",
+            agent_type="always_on",
+            connector_type="claude_code",
+            integration_profile={},
+            client_id="client-1",
+            api_key_id="key-1",
+        ),
+    )
+
+    async def _never(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("the cache hit should have made a DB lookup unnecessary")
+
+    mw = BearerAuthMiddleware(
+        _app,
+        agent_store=AgentStore(),
+        api_key_store=ApiKeyStore(),
+        api_key_cache=cache,
+        session_factory=_never,  # type: ignore[arg-type]
+    )
+    return mw, called
+
+
+async def test_the_agent_log_context_survives_being_closed_from_another_context() -> (
+    None
+):
+    mw, called = _middleware()
+
+    async def receive() -> dict:
+        return {"type": "http.request"}
+
+    async def send(message: dict) -> None:
+        return None
+
+    scope = {
+        "type": "http",
+        "path": "/agents",
+        "headers": [(b"authorization", f"Bearer {TOKEN}".encode())],
+    }
+
+    with log_context(request_id="caller"):
+        _drive_then_finalise_elsewhere(mw(scope, receive, send))
+        assert called["scope"]["agent_id"] == AGENT_ID, (
+            "middleware never reached the app"
+        )
+        assert current_log_context().request_id == "caller", (
+            "finalising a dropped downstream coroutine leaked the agent's log "
+            "context into the collector's context"
+        )

--- a/core/tests/switch_core/test_logging_context.py
+++ b/core/tests/switch_core/test_logging_context.py
@@ -1,0 +1,42 @@
+"""switch_core.logging_context: the finalisation edge of `log_context`.
+
+Covers the case `test_logging_config.py` cannot: what happens when the block
+is never resumed to completion, but the coroutine holding it is dropped and
+later closed by the garbage collector instead.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Coroutine, Generator
+from typing import Any
+
+from switch_core.logging_context import current_log_context, log_context
+
+
+class _Suspend:
+    """An await that suspends once, so a coroutine can be left mid-scope with
+    no event loop in sight."""
+
+    def __await__(self) -> Generator[None, None, None]:
+        yield
+
+
+def _drive_then_finalise_elsewhere(coro: Coroutine[Any, Any, None]) -> None:
+    """Enter the scope inside its own context, then close from this one —
+    what the garbage collector does to a coroutine dropped while suspended."""
+    contextvars.copy_context().run(coro.send, None)
+    coro.close()
+
+
+def test_log_context_survives_being_closed_from_another_context() -> None:
+    async def body() -> None:
+        with log_context(request_id="req-1"):
+            await _Suspend()
+
+    with log_context(request_id="caller"):
+        _drive_then_finalise_elsewhere(body())
+        assert current_log_context().request_id == "caller", (
+            "finalising a dropped coroutine leaked its log context into the "
+            "collector's context"
+        )

--- a/core/tests/switch_core/test_request_context.py
+++ b/core/tests/switch_core/test_request_context.py
@@ -1,7 +1,11 @@
+import contextvars
+from collections.abc import Coroutine, Generator
+from typing import Any
+
 import pytest
 from starlette.types import Receive, Scope, Send
 
-from switch_core.logging_context import LogContext, current_log_context
+from switch_core.logging_context import LogContext, current_log_context, log_context
 from switch_core.request_context import RequestContextMiddleware
 
 
@@ -88,6 +92,40 @@ async def test_the_context_is_unbound_when_the_app_raises() -> None:
         await RequestContextMiddleware(_Failing())(_scope([]), _receive, _send)
 
     assert current_log_context().request_id is None
+
+
+class _Suspend:
+    """An await that suspends once, so a coroutine can be left mid-scope with
+    no event loop in sight."""
+
+    def __await__(self) -> Generator[None, None, None]:
+        yield
+
+
+def _drive_then_finalise_elsewhere(coro: Coroutine[Any, Any, None]) -> None:
+    """Enter the scope inside its own context, then close from this one —
+    what the garbage collector does to a coroutine dropped while suspended."""
+    contextvars.copy_context().run(coro.send, None)
+    coro.close()
+
+
+async def test_the_context_survives_being_closed_from_another_context() -> None:
+    """A downstream app dropped while suspended and finalised by the garbage
+    collector must not raise trying to restore the request-id token from the
+    wrong context."""
+
+    class _Hanging:
+        async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+            await _Suspend()
+
+    mw = RequestContextMiddleware(_Hanging())
+
+    with log_context(request_id="caller"):
+        _drive_then_finalise_elsewhere(mw(_scope([]), _receive, _send))
+        assert current_log_context().request_id == "caller", (
+            "finalising a dropped downstream coroutine leaked its log "
+            "context into the collector's context"
+        )
 
 
 async def test_lifespan_traffic_is_passed_through_untouched() -> None:


### PR DESCRIPTION
## Summary

`unbind_log_context` calls `Token.reset`, which refuses to cross contexts. `log_context`'s cleanup runs that reset from a plain `finally`, which assumes the block is always *resumed* to its exit. It isn't always: a coroutine suspended inside `log_context` can instead be dropped and later *finalised* by the garbage collector closing it, and the collector runs that `finally` in whatever context it happens to be in — not the one that created the token. `Token.reset` then raises `ValueError: ... was created in a different Context`.

This is latent rather than live today: it needs a frame that is finalised by the collector instead of resumed normally, and nothing currently drops a coroutine mid-`log_context` block in a way that reaches that path. That's a statement about current allocation behavior, not about the code — it was found while chasing a related bug elsewhere where the identical pattern turned an occasional test flake into a 100% reproducible failure once unrelated changes shifted allocation timing enough to move a GC pass inside the test window. Leaving it means the next such shift turns this one live too, at a time with no connection to whatever change actually triggers it.

Fix: skip the restore when the block is unwound by `GeneratorExit` instead of resumed. There's nothing to restore into anyway — the context the token belongs to is unreachable, which is why the frame is being finalised at all.

This now covers all instances of the bug, not just the context-manager form. The five raw `bind_log_context`/`unbind_log_context` call sites noted below as outstanding are done: `request_context.py` and `bridges/agent/auth.py` now use the `log_context` context manager directly; `operations/callctx.py` gained its own `call_context` context manager (it restores a call-context token alongside the log token, so it needed the same protection under one name), and `mcp/server.py` and `api/operations.py` — the two callers that held `set_call_context`/`reset_call_context` in a `try`/`finally` — now use it. The shared finalisation check moved into a reusable `restore_unless_finalising` helper in `logging_context.py` so it is written once rather than duplicated per token type.

`bind_log_context`/`unbind_log_context` stay public: `gateway/auth.py` binds one deliberately with no matching unbind (left for the outer request middleware to discard), and `callctx.py` composes a log token with its own call token, so both still have a legitimate caller outside the module.

Refs CHOO-2698.

## Test plan
- [x] Added a regression test that drives a coroutine into a suspended `log_context` block in one context and closes it from another, reproducing the `ValueError` on the old code and passing on the new one.
- [x] Added the same regression coverage for each of the five call sites (`request_context.py`, `bridges/agent/auth.py`, `operations/callctx.py`'s `call_context`, `mcp/server.py`'s `CallContextMiddleware`, and `api/operations.py`'s `call_operation`), including one exercised through the real HTTP operations front door rather than the helper alone.
- [x] `just test`
- [x] `just check`
- [x] `just typecheck`
