### PR TITLE
Scope the per-tenant lookups (CHOO-2623)

### DIFF
--- a/core/switch_core/db/stores/agent_store.py
+++ b/core/switch_core/db/stores/agent_store.py
@@ -1,7 +1,14 @@
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from switch_core.db.models import Agent, ClientRoom, Model, Tool, room_agents
+from switch_core.db.models import (
+    Agent,
+    ClientRoom,
+    Model,
+    Tool,
+    require_tenant_id,
+    room_agents,
+)
 
 
 class AgentStore:
@@ -15,19 +22,36 @@ class AgentStore:
         return await session.get(Agent, agent_id)
 
     async def get_by_name(self, session: AsyncSession, name: str) -> Agent | None:
-        result = await session.execute(select(Agent).where(Agent.name == name))
+        """Resolve an agent by name within the bound tenant.
+
+        Scoped explicitly rather than left to row-level security: `name` is
+        unique per tenant (`uq_agents_tenant_name`), not globally, so the
+        moment a second tenant has an agent of the same name, an unfiltered
+        read here matches both rows and raises `MultipleResultsFound` out of
+        every caller that resolves an agent by name — mention routing,
+        registration, and the gateway's agent lookup among them.
+        """
+        result = await session.execute(
+            select(Agent).where(
+                Agent.tenant_id == require_tenant_id(), Agent.name == name
+            )
+        )
         return result.scalar_one_or_none()
 
     async def get_by_name_insensitive(
         self, session: AsyncSession, name: str
     ) -> Agent | None:
-        """Resolve an agent by name, case-insensitively.
+        """Resolve an agent by name, case-insensitively, within the bound tenant.
 
         Mirrors how `@name` mentions are matched (case-insensitive), so a tagged
-        token resolves to the same agent the router would address.
+        token resolves to the same agent the router would address. Scoped for
+        the same reason as `get_by_name`.
         """
         result = await session.execute(
-            select(Agent).where(func.lower(Agent.name) == name.lower())
+            select(Agent).where(
+                Agent.tenant_id == require_tenant_id(),
+                func.lower(Agent.name) == name.lower(),
+            )
         )
         return result.scalar_one_or_none()
 

--- a/core/switch_core/db/stores/client_store.py
+++ b/core/switch_core/db/stores/client_store.py
@@ -1,7 +1,7 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from switch_core.db.models import Client
+from switch_core.db.models import Client, require_tenant_id
 
 
 class ClientStore:
@@ -15,8 +15,21 @@ class ClientStore:
     async def get_by_matrix_user_id(
         self, session: AsyncSession, matrix_user_id: str
     ) -> Client | None:
+        """Resolve a client by its Matrix user id within the bound tenant.
+
+        Scoped explicitly rather than left to row-level security:
+        `matrix_user_id` is unique per tenant
+        (`uq_clients_tenant_matrix_user_id`), not globally, so the moment a
+        second tenant has a client with the same puppet id, an unfiltered read
+        here matches both rows and raises `MultipleResultsFound` out of
+        message routing and provisioning, which resolve the sending client
+        from an inbound event this way.
+        """
         result = await session.execute(
-            select(Client).where(Client.matrix_user_id == matrix_user_id)
+            select(Client).where(
+                Client.tenant_id == require_tenant_id(),
+                Client.matrix_user_id == matrix_user_id,
+            )
         )
         return result.scalar_one_or_none()
 

--- a/core/switch_core/db/stores/room_store.py
+++ b/core/switch_core/db/stores/room_store.py
@@ -13,6 +13,7 @@ from switch_core.db.models import (
     RoomGroup,
     room_agents,
 )
+from switch_core.tenant_context import current_tenant_id
 
 
 class RoomStore:
@@ -51,9 +52,27 @@ class RoomStore:
     async def get_by_matrix_room_id(
         self, session: AsyncSession, matrix_room_id: str
     ) -> Room | None:
-        result = await session.execute(
-            select(Room).where(Room.matrix_room_id == matrix_room_id)
-        )
+        """Resolve a room by its Matrix room id, scoped to the bound tenant
+        when one is bound.
+
+        `matrix_room_id` is unique per tenant
+        (`uq_rooms_tenant_matrix_room_id`), not globally, so a caller that
+        already knows its tenant must not match another tenant's room of the
+        same transport id — that read is filtered explicitly here rather than
+        left to row-level security, which is inert against the owner
+        connection every environment uses today.
+
+        A caller with nothing bound gets the unfiltered search instead of an
+        error: `_resolve_room_and_tenant` (`transport/postgres.py`) is exactly
+        this lookup used to discover *which* tenant a transport-side id
+        belongs to, deliberately with no tenant bound yet, and forcing one
+        would make that bootstrap impossible.
+        """
+        conditions = [Room.matrix_room_id == matrix_room_id]
+        tenant_id = current_tenant_id()
+        if tenant_id is not None:
+            conditions.append(Room.tenant_id == tenant_id)
+        result = await session.execute(select(Room).where(*conditions))
         return result.scalar_one_or_none()
 
     async def get_all(

--- a/core/tests/switch_core/db/stores/test_agent_store.py
+++ b/core/tests/switch_core/db/stores/test_agent_store.py
@@ -1,26 +1,35 @@
 from __future__ import annotations
 
+import uuid
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from switch_core.db.models import Agent, ApiKey, Client, Room, Task, User
+from switch_core.db.models import Agent, ApiKey, Client, Room, Task, Tenant, User
 from switch_core.db.stores.agent_store import AgentStore
+from switch_core.tenant_context import tenant_scope
 
 
-async def _make_agent(session: AsyncSession, name: str) -> Agent:
-    """Minimal User → ApiKey → Client → Agent chain."""
-    user = User(name=name, email=f"{name}@test", role="user", password_hash="x")
+async def _make_agent(session: AsyncSession, name: str, *, unique: str = "") -> Agent:
+    """Minimal User → ApiKey → Client → Agent chain.
+
+    `unique` disambiguates the user email / api-key hash / client matrix id —
+    each globally unique columns — when two agents share `name` across
+    tenants, since `name` itself is only unique per tenant.
+    """
+    slug = f"{name}-{unique}" if unique else name
+    user = User(name=name, email=f"{slug}@test", role="user", password_hash="x")
     session.add(user)
     await session.flush()
     api_key = ApiKey(
         user_id=user.id,
-        key_hash=f"hash-{name}",
+        key_hash=f"hash-{slug}",
         encrypted_key="enc",
         label=name,
         type="agent",
     )
     client = Client(
-        matrix_user_id=f"@{name}:test",
+        matrix_user_id=f"@{slug}:test",
         display_name=name,
         type="agent",
     )
@@ -38,6 +47,18 @@ async def _make_agent(session: AsyncSession, name: str) -> Agent:
     session.add(agent)
     await session.flush()
     return agent
+
+
+async def _make_agent_for_tenant(
+    session: AsyncSession, tenant_id: str, name: str
+) -> Agent:
+    """An agent named `name`, filed under `tenant_id` rather than the ambient
+    tenant. The underlying user/api-key/client identifiers stay globally
+    unique (suffixed with a fresh uuid) regardless of tenant — only `name`
+    is meant to collide with another tenant's agent here."""
+    unique = uuid.uuid4().hex[:8]
+    with tenant_scope(tenant_id):
+        return await _make_agent(session, name, unique=unique)
 
 
 async def _make_room(session: AsyncSession, name: str) -> Room:
@@ -111,3 +132,61 @@ class TestDeleteAgentWithTasks:
             )
             assert remaining.scalars().first() is None
             assert await verify.get(Agent, performer_id) is not None
+
+
+class TestGetByNameMultiTenant:
+    """`Agent.name` is unique per tenant (`uq_agents_tenant_name`), not
+    globally — two tenants may each have an agent of the same name. Before
+    scoping the read, an unfiltered `get_by_name`/`get_by_name_insensitive`
+    matched both rows and raised `MultipleResultsFound` out of every caller
+    that resolves an agent by name (mention routing, registration, the
+    gateway).
+    """
+
+    async def test_get_by_name_returns_the_bound_tenants_agent(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        store = AgentStore()
+        other_tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+
+        async with session_factory() as session:
+            session.add(Tenant(id=other_tenant, slug=other_tenant, name=other_tenant))
+            await session.flush()
+            own = await _make_agent(session, "shared-name")
+            other = await _make_agent_for_tenant(session, other_tenant, "shared-name")
+            await session.commit()
+
+        async with session_factory() as verify:
+            result = await store.get_by_name(verify, "shared-name")
+        assert result is not None
+        assert result.id == own.id
+
+        async with session_factory() as verify:
+            with tenant_scope(other_tenant):
+                result = await store.get_by_name(verify, "shared-name")
+        assert result is not None
+        assert result.id == other.id
+
+    async def test_get_by_name_insensitive_returns_the_bound_tenants_agent(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        store = AgentStore()
+        other_tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+
+        async with session_factory() as session:
+            session.add(Tenant(id=other_tenant, slug=other_tenant, name=other_tenant))
+            await session.flush()
+            own = await _make_agent(session, "SharedName")
+            other = await _make_agent_for_tenant(session, other_tenant, "sharedname")
+            await session.commit()
+
+        async with session_factory() as verify:
+            result = await store.get_by_name_insensitive(verify, "sharedname")
+        assert result is not None
+        assert result.id == own.id
+
+        async with session_factory() as verify:
+            with tenant_scope(other_tenant):
+                result = await store.get_by_name_insensitive(verify, "sharedname")
+        assert result is not None
+        assert result.id == other.id

--- a/core/tests/switch_core/db/stores/test_client_store.py
+++ b/core/tests/switch_core/db/stores/test_client_store.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.db.models import Client, Tenant
+from switch_core.db.stores.client_store import ClientStore
+from switch_core.tenant_context import tenant_scope
+
+
+async def _make_client(session: AsyncSession, matrix_user_id: str) -> Client:
+    client = Client(
+        matrix_user_id=matrix_user_id,
+        display_name=matrix_user_id,
+        type="agent",
+    )
+    session.add(client)
+    await session.flush()
+    return client
+
+
+async def _make_client_for_tenant(
+    session: AsyncSession, tenant_id: str, matrix_user_id: str
+) -> Client:
+    """A client filed under `tenant_id` rather than the ambient tenant."""
+    with tenant_scope(tenant_id):
+        return await _make_client(session, matrix_user_id)
+
+
+class TestGetByMatrixUserIdMultiTenant:
+    """`Client.matrix_user_id` is unique per tenant
+    (`uq_clients_tenant_matrix_user_id`), not globally — two tenants may each
+    puppet the same Matrix user id. Before scoping the read, an unfiltered
+    `get_by_matrix_user_id` matched both rows and raised
+    `MultipleResultsFound` out of message routing and provisioning, which
+    resolve the sending client from an inbound event this way.
+    """
+
+    async def test_returns_the_bound_tenants_client(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        store = ClientStore()
+        other_tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+        shared_matrix_user_id = "@shared:switch.local"
+
+        async with session_factory() as session:
+            session.add(Tenant(id=other_tenant, slug=other_tenant, name=other_tenant))
+            await session.flush()
+            own = await _make_client(session, shared_matrix_user_id)
+            other = await _make_client_for_tenant(
+                session, other_tenant, shared_matrix_user_id
+            )
+            await session.commit()
+
+        async with session_factory() as verify:
+            result = await store.get_by_matrix_user_id(verify, shared_matrix_user_id)
+        assert result is not None
+        assert result.id == own.id
+
+        async with session_factory() as verify:
+            with tenant_scope(other_tenant):
+                result = await store.get_by_matrix_user_id(
+                    verify, shared_matrix_user_id
+                )
+        assert result is not None
+        assert result.id == other.id

--- a/core/tests/switch_core/db/stores/test_room_store.py
+++ b/core/tests/switch_core/db/stores/test_room_store.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from switch_core.db.models import Room, Tenant
+from switch_core.db.stores.room_store import RoomStore
+from switch_core.tenant_context import tenant_scope
+
+
+async def _make_room(session: AsyncSession, matrix_room_id: str) -> Room:
+    room = Room(
+        matrix_room_id=matrix_room_id,
+        name=matrix_room_id,
+        description="test room",
+    )
+    session.add(room)
+    await session.flush()
+    return room
+
+
+async def _make_room_for_tenant(
+    session: AsyncSession, tenant_id: str, matrix_room_id: str
+) -> Room:
+    """A room filed under `tenant_id` rather than the ambient tenant."""
+    with tenant_scope(tenant_id):
+        return await _make_room(session, matrix_room_id)
+
+
+class TestGetByMatrixRoomIdMultiTenant:
+    """`Room.matrix_room_id` is unique per tenant
+    (`uq_rooms_tenant_matrix_room_id`), not globally — two tenants may each
+    have a room bound to the same transport room id. Before scoping the read,
+    an unfiltered `get_by_matrix_room_id` matched both rows and raised
+    `MultipleResultsFound` out of every inbound-event path that resolves the
+    room this way (provisioning, the Postgres transport, admin commands).
+    """
+
+    async def test_returns_the_bound_tenants_room(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        store = RoomStore()
+        other_tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+        shared_matrix_room_id = "!shared:switch.local"
+
+        async with session_factory() as session:
+            session.add(Tenant(id=other_tenant, slug=other_tenant, name=other_tenant))
+            await session.flush()
+            own = await _make_room(session, shared_matrix_room_id)
+            other = await _make_room_for_tenant(
+                session, other_tenant, shared_matrix_room_id
+            )
+            await session.commit()
+
+        async with session_factory() as verify:
+            result = await store.get_by_matrix_room_id(verify, shared_matrix_room_id)
+        assert result is not None
+        assert result.id == own.id
+
+        async with session_factory() as verify:
+            with tenant_scope(other_tenant):
+                result = await store.get_by_matrix_room_id(
+                    verify, shared_matrix_room_id
+                )
+        assert result is not None
+        assert result.id == other.id


### PR DESCRIPTION
Folds into #425. Opened against the top of the stack rather than main, because
these bugs only exist *with* the tenant schema — on main those columns really
are globally unique and the code is correct there.

## What

Multi-tenancy made several columns unique per tenant that used to be unique
globally. Reads that key on them still assumed one row existed in the whole
table and ended in a single-result fetch, so with two tenants they either raise
or return the other tenant's row.

Fixed: agent name lookup and its case-insensitive variant, the client lookup by
platform id, and the room lookup by platform id. All 37 single-result reads in
the store layer were walked; these are the ones that were actually wrong.

## Two things worth reading

**One suspect turned out to be fine.** Room role names key on the room, and
that constraint was never widened to include the tenant — they were correctly
scoped all along. They were on the list of things to fix, and checking each
against the migration diff rather than trusting the list is what caught it.

**The room lookup could not simply demand a tenant.** One caller uses it with
no tenant bound on purpose: it is the lookup that *discovers* which tenant a
room belongs to. Requiring one broke twenty-two transport tests. It now scopes
when a tenant is bound and does not when there is none.

That is a distinct category from the rest — a read whose purpose is to resolve
an identifier to its tenant cannot itself be tenant-scoped — and it is safe
today only because the service connects as the table owner. Under the
restricted role an unbound read raises rather than returning everything, so
that path needs the exemption model being built in #425, not this conditional.
Flagged there.

## Verified

2879 passing, up from 2875. Each of the four fixes has a test arranging two
tenants with a colliding name or id, and each was checked by reintroducing the
defect and confirming the failure. Single-tenant tests cannot see any of this,
which is why thousands of them passed while all four were broken.