### PR TITLE
Route the test fixture's tenant binding through the safe helper (CHOO-2698)

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import uuid
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
@@ -24,7 +25,7 @@ from switch_core.db.base import Base
 from switch_core.db.engine import create_session_factory
 from switch_core.db.models import TENANT_ZERO_ID, Tenant
 from switch_core.db.runtime_role import grant_runtime_role
-from switch_core.tenant_context import bind_tenant_id, unbind_tenant_id
+from switch_core.tenant_context import tenant_scope
 
 
 async def _seed_tenant_zero(conn: AsyncConnection) -> None:
@@ -85,19 +86,18 @@ async def session_factory(
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
         await _seed_tenant_zero(conn)
-    token = (
-        None
+    ambient_tenant = (
+        contextlib.nullcontext()
         if request.node.get_closest_marker("no_ambient_tenant")
-        else bind_tenant_id(TENANT_ZERO_ID)
+        else tenant_scope(TENANT_ZERO_ID)
     )
     try:
-        # Goes through the same factory constructor production wiring uses,
-        # so this fixture — which backs most of the store test suite — differs
-        # from production in as little as possible.
-        yield create_session_factory(engine)
+        with ambient_tenant:
+            # Goes through the same factory constructor production wiring
+            # uses, so this fixture — which backs most of the store test
+            # suite — differs from production in as little as possible.
+            yield create_session_factory(engine)
     finally:
-        if token is not None:
-            unbind_tenant_id(token)
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()

--- a/core/tests/test_conftest_tenant_binding.py
+++ b/core/tests/test_conftest_tenant_binding.py
@@ -1,0 +1,65 @@
+"""Regression coverage for CHOO-2698: `conftest.session_factory` binds
+tenant zero and restores it in a `finally`, and pytest-asyncio can finalise a
+fixture's async generator by having the garbage collector close a suspended,
+dropped one rather than resuming it. That `finally` then runs in whatever
+context the collector happens to be in, not the one the token was created in.
+
+`Token.reset` refuses to cross contexts, so a raw `bind_tenant_id` /
+`unbind_tenant_id` pair here raises `ValueError` instead of tearing down —
+exactly the shape that made this the fourth instance of the pattern. The
+fixture is pinned to `tenant_context.tenant_scope` instead, whose own guard
+(`_held`) is covered by
+`test_tenant_context.TestFinalisationInAnotherContext`; this test is not
+about that mechanism, it is about the fixture actually using it, which
+nothing else would notice if undone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from tests.conftest import session_factory as _session_factory_fixture
+
+# The bare async generator function pytest_asyncio.fixture wraps, so it can
+# be driven directly instead of through pytest's fixture machinery. Fetched
+# via getattr rather than `.__wrapped__` directly since the fixture wrapper's
+# declared type doesn't carry that attribute.
+_session_factory: Any = getattr(_session_factory_fixture, "__wrapped__")
+
+
+class _NoMarkerRequest:
+    """Stands in for `pytest.FixtureRequest` with no markers on the node --
+    enough for the fixture's `no_ambient_tenant` check to take the ambient
+    tenant-scope branch."""
+
+    class _Node:
+        def get_closest_marker(self, name: str) -> None:
+            return None
+
+    node = _Node()
+
+
+async def test_survives_being_finalised_from_another_context(
+    postgres_url: str,
+) -> None:
+    agen: AsyncGenerator[Any, None] = _session_factory(postgres_url, _NoMarkerRequest())
+    loop = asyncio.get_running_loop()
+    # Advance to the fixture's `yield` inside its own, isolated context -- the
+    # same isolation a pytest-asyncio task gives it going in.
+    drive_ctx = contextvars.copy_context()
+    await loop.create_task(agen.asend(None), context=drive_ctx)
+    try:
+        # Finalise it the way the collector does to a dropped, suspended
+        # async generator: close it from whatever context is current here,
+        # which is deliberately not `drive_ctx`.
+        await agen.aclose()
+    except ValueError as exc:
+        raise AssertionError(
+            "session_factory's tenant bind was restored in a context other "
+            "than the one that created it -- it must route through "
+            "tenant_scope rather than a raw bind_tenant_id/unbind_tenant_id "
+            "pair"
+        ) from exc


### PR DESCRIPTION
Folds into #425. Small, and the fourth instance of one pattern.

## The bug

The unit suite's database fixture bound a context token and restored it in a
cleanup path. When a frame is *finalised* by the garbage collector — the
collector closing a suspended, dropped async generator — rather than resumed,
the cleanup runs in a different context and the restore raises.

Routed through the guard that already exists rather than writing a third copy
of it.

## Why bother with a latent one

Because the first instance of this pattern was latent too. It sat harmless for
months, then unrelated work changed allocation timing enough to move garbage
collection inside the test window, and it became a 100%-reproducible failure
that read as flakiness and cost hours to diagnose. "Cannot happen today" is a
statement about today's allocation behaviour, not about the code.

This is the fourth site found. The reason there was a fourth is that each
earlier fix left the next one unguarded.

## The test is the point

Reproduced before fixing: drives the fixture's own generator to its yield
inside an isolated context, then closes it from a different one, which is what
the collector does. Against the old code that raises
`ValueError: <Token ...> was created in a different Context` — the exact
production symptom.

A first pass fixed the fixture with only a throwaway reproduction, which would
have left nothing to notice if someone reinstated the raw pattern. This tests
the real fixture object rather than asserting on its source text, so it stays
honest as the fixture changes and would catch a *different* unsafe pair added
later, which a static check would not.

Verified both directions: reverted the fix, watched it fail with that error,
restored, watched it pass.

## Verified

2901 passing, up from 2900. `check` and `typecheck` clean.