### PR TITLE
fix(helm): point Mattermost at the schema owner in existing mode (CHOO-2623)

### DIFF
--- a/deploy/remote/helm/switch/templates/_helpers.tpl
+++ b/deploy/remote/helm/switch/templates/_helpers.tpl
@@ -94,11 +94,15 @@ two modes stay in lockstep.
 {{/*
 The bootstrapped Postgres superuser: "postgres" in managed mode (the account
 POSTGRES_USER creates on the StatefulSet below), or postgresql.external.username
-in existing mode. This is the identity Mattermost connects as — it owns its
-own "mattermost" database and runs no row-level security, so it has nothing to
-be restricted from there — and the identity the managed StatefulSet and its
-initdb scripts bootstrap and administer with. Distinct from switch.postgresUser
-below, which is DB_USER: the restricted role the RLS policies apply to.
+in existing mode. The identity the managed StatefulSet, its initdb scripts and
+the create-runtime-role Job bootstrap and administer with. Distinct from
+switch.postgresUser below, which is DB_USER: the restricted role the RLS
+policies apply to.
+
+In managed mode those two are genuinely different accounts. In existing mode
+they are the same value, because the chart does not manage that database and
+has only the one username to go on — so this helper is *not* what Mattermost
+should connect as there; see switch.mattermostDbUser.
 */}}
 {{- define "switch.postgresSuperUser" -}}
 {{- if eq .Values.postgresql.mode "existing" -}}
@@ -208,6 +212,66 @@ callers must fall back to those directly rather than through this helper.
 
 {{- define "switch.postgresOwnerSecretKey" -}}
 {{- .Values.postgresql.owner.existingSecretKey | default "DB_OWNER_PASSWORD" -}}
+{{- end }}
+
+{{/*
+The credentials Mattermost connects to its own "mattermost" database with,
+and the reason they are not switch.postgresUser's.
+
+Mattermost creates and migrates its own schema, so it needs an account with
+rights in that database. The runtime role has none: it is granted CRUD on the
+tables switch-core's own migration created, in switch-core's own database, and
+nothing anywhere else. There is no isolation argument for restricting
+Mattermost either — its schema carries no row-level security and no tenant
+column — so the administrative account is simply the right one.
+
+In managed mode that is the bootstrapped superuser, unchanged: initdb creates
+the "mattermost" database as "postgres" and postgresql.owner.username does not
+move it, so this deliberately does not follow that value there.
+
+Existing mode is the case this exists for. switch.postgresSuperUser and
+switch.postgresUser both resolve to postgresql.external.username there, so the
+moment an operator repoints external.username at a restricted role — which is
+exactly what docs/old/rds-migration.md asks them to do — Mattermost would
+follow it onto a role with no rights in its database and fail to start. When an
+owner is configured, use it; when one is not, this is a deployment that has not
+split its roles yet and external.username is still the administrative account,
+which is the behaviour it has always had.
+
+The three helpers below share one condition, so it is written once and the
+other two ask it. It answers with a non-empty string or nothing, which is what
+`if` reads — deliberately not "true"/"false", since an `include` returning the
+string "false" is still truthy and inviting a reader to compare against it
+would be inviting a bug.
+*/}}
+{{- define "switch.mattermostUsesOwner" -}}
+{{- if and (eq .Values.postgresql.mode "existing") .Values.postgresql.owner.username -}}
+owner
+{{- end -}}
+{{- end }}
+
+{{- define "switch.mattermostDbUser" -}}
+{{- if include "switch.mattermostUsesOwner" . -}}
+{{- .Values.postgresql.owner.username -}}
+{{- else -}}
+{{- include "switch.postgresSuperUser" . -}}
+{{- end -}}
+{{- end }}
+
+{{- define "switch.mattermostDbSecretName" -}}
+{{- if include "switch.mattermostUsesOwner" . -}}
+{{- include "switch.postgresOwnerSecretName" . -}}
+{{- else -}}
+{{- include "switch.postgresSecretName" . -}}
+{{- end -}}
+{{- end }}
+
+{{- define "switch.mattermostDbSecretKey" -}}
+{{- if include "switch.mattermostUsesOwner" . -}}
+{{- include "switch.postgresOwnerSecretKey" . -}}
+{{- else -}}
+{{- include "switch.postgresSecretKey" . -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/deploy/remote/helm/switch/templates/mattermost/deployment.yaml
+++ b/deploy/remote/helm/switch/templates/mattermost/deployment.yaml
@@ -39,10 +39,10 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "switch.postgresSecretName" . }}
-                  key: {{ include "switch.postgresSecretKey" . }}
+                  name: {{ include "switch.mattermostDbSecretName" . }}
+                  key: {{ include "switch.mattermostDbSecretKey" . }}
             - name: MM_SQLSETTINGS_DATASOURCE
-              value: "postgres://{{ include "switch.postgresSuperUser" . }}:$(POSTGRES_PASSWORD)@{{ include "switch.postgresHost" . }}:{{ include "switch.postgresPort" . }}/mattermost?sslmode={{ .Values.postgresql.sslMode }}{{ if include "switch.dbCaBundleConfigMap" . }}&sslrootcert={{ include "switch.dbCaBundlePath" . }}{{ end }}"
+              value: "postgres://{{ include "switch.mattermostDbUser" . }}:$(POSTGRES_PASSWORD)@{{ include "switch.postgresHost" . }}:{{ include "switch.postgresPort" . }}/mattermost?sslmode={{ .Values.postgresql.sslMode }}{{ if include "switch.dbCaBundleConfigMap" . }}&sslrootcert={{ include "switch.dbCaBundlePath" . }}{{ end }}"
             - name: MM_SERVICESETTINGS_SITEURL
               value: {{ .Values.mattermost.siteUrl | default "" | quote }}
             - name: MM_SERVICESETTINGS_ENABLELOCALMODE

--- a/deploy/remote/helm/switch/values.yaml
+++ b/deploy/remote/helm/switch/values.yaml
@@ -430,11 +430,25 @@ postgresql:
   # owner.username stays genuinely empty there until you set it. That does NOT
   # mean boot skips migrations: alembic upgrade head still runs, over whatever
   # DB_USER resolves to (see migrations/env.py's fallback), and for a
-  # restricted runtime role that fails loudly with a permissions error rather
-  # than quietly doing nothing. That failure is deliberate — it is boot
-  # telling you this deployment moved to a restricted role without saying who
-  # owns the schema, rather than starting up unable to apply its own
-  # migrations and only finding out later.
+  # restricted runtime role any migration it actually has to apply fails with a
+  # permissions error.
+  #
+  # Note what that does not cover, because it is the trap here. A boot with
+  # nothing pending never issues a statement the restricted role lacks rights
+  # for, so it succeeds — and so does the isolation self-check, which asks
+  # about the connection rather than about who can migrate. An existing-mode
+  # deployment with a restricted DB_USER and no owner therefore comes up
+  # perfectly on the release that moved it there, and fails at boot on the
+  # next release that carries a migration. Set owner.username at the same time
+  # you repoint external.username, not afterwards.
+  #
+  # Setting it also decides what Mattermost connects as. In existing mode the
+  # chart has one username value for both roles, so Mattermost follows
+  # external.username unless an owner is configured — onto the restricted role,
+  # which has no rights in the "mattermost" database and cannot create or
+  # migrate its schema. With owner.username set, Mattermost uses the owner and
+  # switch-core alone uses the restricted role. See switch.mattermostDbUser in
+  # templates/_helpers.tpl.
   #
   # mode: managed can create the runtime role itself (see
   # postgresql.managed.runtimeUsername, templates/postgresql/configmap-init.yaml

--- a/docs/old/rds-migration.md
+++ b/docs/old/rds-migration.md
@@ -191,13 +191,47 @@ so there is nothing to reset behind a replicated cutover.
      NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;
    ```
 
-   That is the only manual step. Nothing here grants `switch_app` anything on
-   `switch` or `mattermost` — switch-core does that itself at boot, from the
-   owner connection (the RDS master user, over `DB_OWNER_USER` /
-   `DB_OWNER_PASSWORD`), immediately after running Alembic. The master user
-   stays the schema owner throughout; it is configured as the owner
-   connection, never as `DB_USER`, so it is never the connection every
+   That is the only manual step in the database. Nothing here grants
+   `switch_app` anything on `switch` or `mattermost` — switch-core does that
+   itself at boot, from the owner connection (the RDS master user, over
+   `DB_OWNER_USER` / `DB_OWNER_PASSWORD`), immediately after running Alembic.
+   The master user stays the schema owner throughout; it is configured as the
+   owner connection, never as `DB_USER`, so it is never the connection every
    request is served over.
+
+   Both halves go into the chart values together:
+
+   ```yaml
+   postgresql:
+     mode: existing
+     external:
+       username: switch_app        # DB_USER — the restricted runtime role
+     owner:
+       username: <the master user> # DB_OWNER_USER — migrations and grants
+   secrets:
+     postgresPassword: <switch_app's password>
+     dbOwnerPassword: <the master password>
+   ```
+
+   Note `secrets.postgresPassword` is the *runtime* role's password here, not
+   the master's: in existing mode it is whatever `external.username`
+   authenticates with. Setting one half without the other renders fine and
+   will not necessarily fail on the deploy that introduces it —
+
+   - **`external.username` moved, `owner.username` left empty.** switch-core
+     has no owner to migrate as, so it migrates as the restricted role. With
+     nothing pending that is a no-op and the deployment comes up clean; the
+     next release carrying a migration dies at boot. Mattermost breaks
+     immediately, though, because in existing mode it follows
+     `external.username` unless an owner is configured, and the restricted
+     role has no rights in the `mattermost` database.
+   - **`owner.username` set, `external.username` left at the master user.**
+     switch-core refuses to serve: the runtime connection owns the tables its
+     own policies protect, so the policies are inert against it and tenants
+     are not isolated.
+
+   An instance that is already on RDS needs the same two values and the same
+   `CREATE ROLE`; only the dump and restore below are specific to the move.
 
 3. Download the CA bundle and put it in `postgresql.caBundle` — as
    `existingConfigMap` if it is synced in from elsewhere, otherwise inline.


### PR DESCRIPTION
## The bug

`switch.postgresSuperUser` and `switch.postgresUser` both resolve to `postgresql.external.username` in `mode: existing`. The two-role split introduced by the row-level-security work only produces two distinct accounts in **managed** mode.

So an operator who follows `docs/old/rds-migration.md` and repoints `external.username` at the restricted runtime role takes Mattermost with them — onto a role that owns nothing in the `mattermost` database and was granted nothing there. switch-core grants only inside its own database, and only on the tables its own migration created. Mattermost cannot create or migrate its schema as that role, so it does not come back up.

This blocks the upgrade for every `mode: existing` deployment.

## The fix

Mattermost asks for the administrative identity by name (`switch.mattermostDbUser` and its secret pair) rather than borrowing the superuser helper:

- **managed** — the bootstrapped superuser, unchanged. It deliberately does *not* follow `owner.username`: initdb creates the `mattermost` database as `postgres` and no values change moves it.
- **existing, owner configured** — the owner, with the owner's secret.
- **existing, no owner** — `external.username`, unchanged. That is a deployment that has not split its roles yet.

## Verification

`helm template` across all four combinations; rendered manifests diffed against `main`:

| values | Mattermost datasource | vs `main` |
|---|---|---|
| managed, default | `postgres` | byte-identical |
| managed + `owner.username` set | `postgres` | byte-identical |
| existing, no owner | `external.username` | byte-identical |
| existing + owner | **owner**, owner secret key | the only diff, and the intended one |

`helm lint` clean in both modes.

## Also in here

Two things the docs got wrong, found while confirming the above:

- The `postgresql.owner` values comment claimed that migrating as the restricted role "fails loudly with a permissions error". It does not when there is nothing pending — no statement is issued that the role lacks rights for. Reproduced: an existing-mode deployment with a restricted `DB_USER` and no owner comes up perfectly clean on the release that moves it there, then dies at boot on the next release that carries a migration. The comment now says so.
- The RDS runbook told you to create the role but never which chart values to set. It now shows both halves together, and what each one does on its own if you set only one.

No chart version change — the version is stamped at package time by the release workflow. Deployments pinned to a released chart need a release cut before they can take this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)