### PR TITLE
feat: platform sender kind for agent addressing (CHOO-2719)

### DIFF
--- a/core/switch_core/addressing.py
+++ b/core/switch_core/addressing.py
@@ -14,8 +14,12 @@ Model:
       * `agents`      — matched when the sender is another agent
   - Each dimension is either ``"*"`` (any), or an explicit list of ids. An
     empty list ``[]`` is the "none" value: it matches nothing. The sender is
-    exactly one kind (user XOR agent), so a rule that should admit only humans
-    sets ``agents: []`` and vice-versa.
+    exactly one kind (user, agent, or platform), so a rule that should admit
+    only humans sets ``agents: []`` and vice-versa.
+  - A rule carries a ``platform`` boolean (CHOO-2719). When True, the rule
+    admits the Switch platform as a sender. Platform is denied by default —
+    even an open policy (no rules) refuses it — so an agent must explicitly
+    opt in via a rule with ``platform=True``.
   - A rule additionally carries two *symbolic* subjects (CHOO-2137), resolved
     at enforcement time rather than stored as ids, so they survive the owner
     claiming a new platform identity, a bridge being recreated, or the agent
@@ -41,6 +45,9 @@ Defaults / precedence:
     are permitted.
   - Agents created from CHOO-2137 onwards start owner-only (see
     `owner_only_policy`) rather than open.
+  - **Platform senders are always deny-by-default** (CHOO-2719), even for an
+    open policy. An agent must have at least one rule with ``platform=True``
+    to receive platform messages.
 
 This module is deliberately pure (no DB, no I/O) so it is trivially testable
 and reusable from the receive path, the protocol service, and the gateway.
@@ -52,7 +59,7 @@ from typing import Literal
 
 from pydantic import BaseModel, field_validator
 
-SenderKind = Literal["user", "agent"]
+SenderKind = Literal["user", "agent", "platform"]
 
 ANY = "*"
 
@@ -72,6 +79,7 @@ class AddressingRule(BaseModel):
     agents: Dimension = ANY
     owner: bool = False
     owner_agents: bool = False
+    platform: bool = False
 
     @field_validator("rooms", "room_groups", "users", "agents")
     @classmethod
@@ -97,6 +105,8 @@ class AddressingRule(BaseModel):
             return False
         if not _dim_contains(self.room_groups, group_id):
             return False
+        if sender_kind == "platform":
+            return self.platform
         if sender_kind == "user" and self._is_owner(sender_user_ids, owner_user_id):
             return True
         if sender_kind == "agent" and self._is_owners_agent(
@@ -162,13 +172,17 @@ class AddressingPolicy(BaseModel):
         permitted. Allow-all when the policy is open; otherwise permitted iff
         at least one rule matches.
 
+        Platform senders are denied even by an open policy — an agent must
+        explicitly opt in via a rule with ``platform=True``. This is
+        "deny by default with no configuration needed" (CHOO-2719).
+
         `sender_user_ids` are the Switch users who have claimed a human
         sender's platform account (empty when nobody has);
         `sender_owner_user_id` is who owns an agent sender (None for a human
         or an ownerless agent); `owner_user_id` is the addressed agent's
         owner. Together they resolve the `owner` and `owner_agents` rules.
         """
-        if self.is_open():
+        if self.is_open() and sender_kind != "platform":
             return True
         return any(
             rule._matches(
@@ -249,6 +263,26 @@ def owner_and_owner_agents_policy() -> AddressingPolicy:
                 agents=[],
                 owner=True,
                 owner_agents=True,
+            )
+        ]
+    )
+
+
+def platform_allowed_policy() -> AddressingPolicy:
+    """A policy that admits the platform sender (CHOO-2719).
+
+    Returns a single rule allowing ``platform`` in any room. Combine with
+    owner/agent rules by appending to their rule list rather than replacing
+    their policy with this one.
+    """
+    return AddressingPolicy(
+        rules=[
+            AddressingRule(
+                rooms=ANY,
+                room_groups=ANY,
+                users=[],
+                agents=[],
+                platform=True,
             )
         ]
     )

--- a/core/switch_core/bridges/agent/protocol/service.py
+++ b/core/switch_core/bridges/agent/protocol/service.py
@@ -56,6 +56,7 @@ from switch_core.bridges.agent.registration_bootstrap import (
     resolve_registration_owner_id,
 )
 from switch_core.bridges.resource.service import ResourceService
+from switch_core.clients.admin_messages import PLATFORM_MARKER as _PLATFORM_MARKER
 from switch_core.crypto import encrypt_token
 from switch_core.db.models import (
     Agent,
@@ -1672,15 +1673,24 @@ class ProtocolService:
 
     @staticmethod
     def _timeline_entry(
-        message: Message, attachments: list[MessageAttachment]
+        message: Message,
+        attachments: list[MessageAttachment],
+        sender_kinds: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Build the agent-facing entry for a recorded row.
 
         An arrival is stored with no body — how it reads is this function's to
         decide, not the writer's — so the sentence is composed here and can be
         changed without rewriting history.
+
+        ``sender_kinds`` is an optional pre-resolved map of sender mxid → kind
+        ("user", "agent", "platform"). When absent, ``sender_kind`` is derived
+        from the message content (PLATFORM_MARKER → "platform", else None).
         """
         name = message.sender_name or message.sender_id
+        sender_kind = (sender_kinds or {}).get(message.sender_id)
+        if sender_kind is None and _PLATFORM_MARKER in (message.content or {}):
+            sender_kind = "platform"
         if message.event_type == MEMBERSHIP_EVENT_TYPE:
             return {
                 "id": message.transport_event_id,
@@ -1691,7 +1701,7 @@ class ProtocolService:
                 "timestamp": _epoch_ms(message.sent_at),
                 "attachments": [],
             }
-        return {
+        entry: dict[str, Any] = {
             "id": message.transport_event_id,
             "kind": "message",
             "sender": message.sender_id,
@@ -1709,6 +1719,9 @@ class ProtocolService:
                 for attachment in attachments
             ],
         }
+        if sender_kind is not None:
+            entry["sender_kind"] = sender_kind
+        return entry
 
     @staticmethod
     def _thread_root_id(message: Message) -> str:

--- a/core/switch_core/bridges/agent/protocol/types.py
+++ b/core/switch_core/bridges/agent/protocol/types.py
@@ -213,6 +213,10 @@ class MessagePayload(BaseModel):
     addressed: bool
     sender: str
     sender_name: str
+    # The kind of entity that sent this message: "user" (a human on a bridge),
+    # "agent" (another agent), or "platform" (the Switch app itself,
+    # CHOO-2719). None for messages sent before sender_kind was tracked.
+    sender_kind: str | None = None
     message_id: str
     body: str
     timestamp: int

--- a/core/switch_core/bridges/collaboration/bridge_core.py
+++ b/core/switch_core/bridges/collaboration/bridge_core.py
@@ -26,7 +26,11 @@ from switch_core.bridges.collaboration.models import (
     InboundUserJoin,
     OutboundAttachment,
 )
-from switch_core.clients.admin_messages import ADMIN_MARKER, AdminMessageType
+from switch_core.clients.admin_messages import (
+    ADMIN_MARKER,
+    PLATFORM_MARKER,
+    AdminMessageType,
+)
 from switch_core.clients.client_base import ClientBase, ClientConfig
 from switch_core.clients.mentions import mention_regex, strip_emphasis
 from switch_core.db.models import BridgeMessageMap, ExternalUser
@@ -1432,27 +1436,31 @@ class BridgeCore:
     ) -> None:
         event_content = event.content
         admin_marker = event_content.get(ADMIN_MARKER)
+        platform_marker = event_content.get(PLATFORM_MARKER)
         sender_name = event.sender_name
-        # An admin/system message renders natively per bridge (admin_message)
-        # rather than on behalf of its Matrix sender, so it needs no sender_name.
-        if sender_name is None and admin_marker is None:
+        # An admin/system or platform message renders natively per bridge
+        # (admin_message) rather than on behalf of its Matrix sender, so it
+        # needs no sender_name.
+        is_system = admin_marker is not None or platform_marker is not None
+        if sender_name is None and not is_system:
             logger.error(
                 "No sender_name in event from %s — skipping outbound", event.sender
             )
             return
 
         logger.debug(
-            "[BRIDGE-OUT] sending to channel=%s sender=%s admin=%s",
+            "[BRIDGE-OUT] sending to channel=%s sender=%s admin=%s platform=%s",
             channel_id,
             sender_name,
             admin_marker is not None,
+            platform_marker is not None,
         )
 
         thread_root_ref = await self._outbound_thread_root_ref(
             event_content, channel_id
         )
 
-        if admin_marker is not None:
+        if is_system:
             message_type = (
                 admin_marker.get("type") if isinstance(admin_marker, dict) else None
             )

--- a/core/switch_core/clients/admin_client.py
+++ b/core/switch_core/clients/admin_client.py
@@ -8,6 +8,7 @@ from switch_core.bridges.agent.commands import dispatch_admin_command
 from switch_core.bridges.agent.protocol.connections import ConnectionRegistry
 from switch_core.clients.admin_messages import (
     ADMIN_MARKER,
+    PLATFORM_MARKER,
     AdminMessageType,
     admin_extra_content,
 )
@@ -123,6 +124,39 @@ class AdminClient(ClientBase[ClientConfig]):
             format=format,
             thread_root_id=thread_root_id,
             extra_content=admin_extra_content(AdminMessageType.COMMAND_RESULT),
+        )
+
+    # ── Platform messages (CHOO-2719) ───────────────────────────────────────
+
+    async def send_platform_message(
+        self,
+        room_id: str,
+        body: str,
+        *,
+        thread_root_id: str | None = None,
+        on_behalf_of: str | None = None,
+    ) -> str | None:
+        """Send an addressed message as the Switch platform.
+
+        Unlike admin messages, platform messages carry no ADMIN_MARKER and ARE
+        addressed to agents — they expect a response. The PLATFORM_MARKER
+        identifies them as platform-sourced so the bridge renders them as the
+        Switch app and resolve_sender maps them to sender_kind="platform".
+
+        ``on_behalf_of``, when set, is the name of the user the platform is
+        impersonating (creator impersonation). The marker carries it so every
+        layer can distinguish a direct platform message from an impersonated
+        one.
+        """
+        marker_value: dict[str, object] = {}
+        if on_behalf_of is not None:
+            marker_value["on_behalf_of"] = on_behalf_of
+        return await self.send_message(
+            room_id,
+            body,
+            format="markdown",
+            thread_root_id=thread_root_id,
+            extra_content={PLATFORM_MARKER: marker_value},
         )
 
     # ── Admin notices ─────────────────────────────────────────────────────────

--- a/core/switch_core/clients/admin_messages.py
+++ b/core/switch_core/clients/admin_messages.py
@@ -15,6 +15,16 @@ from enum import StrEnum
 # human-readable default text, so a vanilla Matrix client still renders it.
 ADMIN_MARKER = "com.switch.admin"
 
+# Marker for a platform-sourced message (CHOO-2719). Unlike ADMIN_MARKER, a
+# platform message IS addressed to agents and expects action — the marker
+# tells the bridge to render it as the Switch app and lets resolve_sender
+# identify it as sender_kind="platform". Carried as a content field on a
+# plain m.room.message whose body is the human-readable default text.
+#
+# Value is a dict: {"on_behalf_of": "<name>"} when the platform is
+# impersonating a creator, or {} for a direct platform message.
+PLATFORM_MARKER = "com.switch.platform"
+
 
 class AdminMessageType(StrEnum):
     """The kind of admin/system message, carried in the marker so a bridge

--- a/core/switch_core/clients/agent_client.py
+++ b/core/switch_core/clients/agent_client.py
@@ -28,6 +28,7 @@ from switch_core.bridges.agent.protocol.types import (
     TaskFinalisePayload,
     TaskUpdatePayload,
 )
+from switch_core.clients.admin_messages import PLATFORM_MARKER
 from switch_core.clients.client_base import (
     ClientBase,
     ClientBaseKwargs,
@@ -464,6 +465,10 @@ class AgentClient(ClientBase[ClientConfig]):
                 sender_name,
             )
 
+        sender_kind: str | None = None
+        if PLATFORM_MARKER in event.content:
+            sender_kind = "platform"
+
         agent_event = AgentEvent(
             type="message",
             room_id=meta.room_id,
@@ -473,6 +478,7 @@ class AgentClient(ClientBase[ClientConfig]):
                 addressed=is_addressed,
                 sender=event.sender,
                 sender_name=sender_name,
+                sender_kind=sender_kind,
                 message_id=event.event_id,
                 body=text,
                 timestamp=event.timestamp,
@@ -662,6 +668,10 @@ class AgentClient(ClientBase[ClientConfig]):
                     room.room_id, event, gate.refusal, reply_thread_root
                 )
 
+        sender_kind: str | None = None
+        if PLATFORM_MARKER in event.content:
+            sender_kind = "platform"
+
         agent_event = AgentEvent(
             type="message",
             room_id=meta.room_id,
@@ -671,6 +681,7 @@ class AgentClient(ClientBase[ClientConfig]):
                 addressed=is_addressed,
                 sender=event.sender,
                 sender_name=sender_name,
+                sender_kind=sender_kind,
                 message_id=event.event_id,
                 body=body,
                 timestamp=event.timestamp,

--- a/core/switch_core/delivery/addressing.py
+++ b/core/switch_core/delivery/addressing.py
@@ -333,9 +333,9 @@ class AddressingResolver:
         """Map a sender's mxid to the principal a policy is written about.
 
         Every participant is a Switch client, so the mxid resolves to a Client
-        and from there to either an Agent (an agent-to-agent attempt) or an
-        ExternalUser (a human on a bridge). None means neither, which a
-        restricted agent should not trust.
+        and from there to an Agent, an ExternalUser, or the admin client
+        (the platform). None means none of those, which a restricted agent
+        should not trust.
 
         The two symbolic subjects come from different fields and only one
         applies to any sender: `user_ids` are the Switch users who have claimed
@@ -357,4 +357,6 @@ class AddressingResolver:
                 session, external_user.id
             )
             return SenderPrincipal("user", external_user.id, claimants, None)
+        if client.type == "admin":
+            return SenderPrincipal("platform", client.id, [], None)
         return None

--- a/core/switch_core/gateway/dependencies.py
+++ b/core/switch_core/gateway/dependencies.py
@@ -134,6 +134,7 @@ def get_room_yaml_service() -> RoomYamlService:
         external_user_store=_state["external_user_store"],
         room_role_store=protocol.room_role_store,
         session_factory=_state["session_factory"],
+        client_lifecycle=_state["client_lifecycle"],
     )
 
 

--- a/core/switch_core/rooms_yaml.py
+++ b/core/switch_core/rooms_yaml.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
     from switch_core.bridges.resource.service import ResourceService
+    from switch_core.clients.client_lifecycle_service import ClientLifecycleService
+    from switch_core.db.models import Room
     from switch_core.db.stores.agent_store import AgentStore
     from switch_core.db.stores.collaboration_bridge_store import (
         CollaborationBridgeStore,
@@ -207,6 +209,18 @@ class DocSpec(BaseModel):
     content: str
 
 
+class KickoffSpec(BaseModel):
+    """The message sent into the room after provisioning (CHOO-2719).
+
+    Defaults to posting as the platform; ``sender: "creator"`` is explicit,
+    visible creator impersonation.
+    """
+
+    message: str
+    targets: list[str] = []
+    sender: Literal["platform", "creator"] = "platform"
+
+
 class RoomSpec(BaseModel):
     name: str
     description: str
@@ -221,6 +235,7 @@ class RoomSpec(BaseModel):
     roles: list[RoleSpec] = []
     references: list[ExternalReferenceEntry] = []
     docs: list[DocSpec] = []
+    kickoff: KickoffSpec | None = None
 
 
 class ProvisionResult(BaseModel):
@@ -263,6 +278,7 @@ class RoomYamlService:
         external_user_store: ExternalUserStore,
         room_role_store: RoomRoleStore,
         session_factory: async_sessionmaker[AsyncSession],
+        client_lifecycle: ClientLifecycleService | None = None,
     ) -> None:
         self._rooms = room_service
         self._resources = resource_service
@@ -272,6 +288,7 @@ class RoomYamlService:
         self._external_users = external_user_store
         self._room_roles = room_role_store
         self._session_factory = session_factory
+        self._client_lifecycle = client_lifecycle
 
     # ── Parse ─────────────────────────────────────────────────────────────
 
@@ -365,6 +382,15 @@ class RoomYamlService:
         created_doc_ids = await self._create_inline_docs(
             room_id, spec.docs, user_id=user_id, failures=failures
         )
+
+        if spec.kickoff is not None:
+            await self._send_kickoff(
+                result.room,
+                spec.kickoff,
+                agent_names=spec.agents,
+                user_id=user_id,
+                failures=failures,
+            )
 
         return ProvisionResult(
             room_id=room_id,
@@ -496,6 +522,76 @@ class RoomYamlService:
                     )
             await session.commit()
         return created
+
+    # ── Kickoff (CHOO-2719) ─────────────────────────────────────────────
+
+    async def _send_kickoff(
+        self,
+        room: Room,
+        kickoff: KickoffSpec,
+        *,
+        agent_names: list[str],
+        user_id: str,
+        failures: list[dict[str, Any]],
+    ) -> None:
+        """Post the kickoff message into the newly provisioned room.
+
+        ``sender="platform"`` (default) sends via the admin client with the
+        platform marker — visible as the Switch app, subject to platform
+        addressing policy.
+
+        ``sender="creator"`` sends via the admin client with ``on_behalf_of``
+        set to the creator — explicit, visible creator impersonation.
+        """
+        if self._client_lifecycle is None:
+            failures.append(
+                {
+                    "kind": "kickoff",
+                    "id": "kickoff",
+                    "error": "no client lifecycle — cannot send kickoff",
+                }
+            )
+            return
+
+        from switch_core.clients.admin_client import AdminClient
+
+        admin_clients = self._client_lifecycle.get_by_type("admin", room.tenant_id)
+        if not admin_clients:
+            failures.append(
+                {
+                    "kind": "kickoff",
+                    "id": "kickoff",
+                    "error": "no admin client available for this tenant",
+                }
+            )
+            return
+
+        admin = admin_clients[0]
+        if not isinstance(admin, AdminClient):
+            failures.append(
+                {
+                    "kind": "kickoff",
+                    "id": "kickoff",
+                    "error": "admin client is not an AdminClient instance",
+                }
+            )
+            return
+
+        targets = kickoff.targets or list(agent_names)
+        body = kickoff.message
+        if targets:
+            prefix = " ".join(f"@{t}" for t in targets)
+            body = f"{prefix} {body}"
+
+        try:
+            on_behalf_of = user_id if kickoff.sender == "creator" else None
+            await admin.send_platform_message(
+                room.matrix_room_id,
+                body,
+                on_behalf_of=on_behalf_of,
+            )
+        except Exception as e:
+            failures.append({"kind": "kickoff", "id": "kickoff", "error": str(e)})
 
     # ── Export ────────────────────────────────────────────────────────────
 

--- a/core/switch_core/rooms_yaml.py
+++ b/core/switch_core/rooms_yaml.py
@@ -584,7 +584,14 @@ class RoomYamlService:
             body = f"{prefix} {body}"
 
         try:
-            on_behalf_of = user_id if kickoff.sender == "creator" else None
+            on_behalf_of: str | None = None
+            if kickoff.sender == "creator":
+                from switch_core.db.stores.user_store import UserStore
+
+                user_store = UserStore()
+                async with self._session_factory() as session:
+                    user = await user_store.get(session, user_id)
+                on_behalf_of = user.name if user else user_id
             await admin.send_platform_message(
                 room.matrix_room_id,
                 body,

--- a/core/tests/switch_core/clients/test_addressing_enforcement.py
+++ b/core/tests/switch_core/clients/test_addressing_enforcement.py
@@ -130,15 +130,29 @@ class TestResolveSenderPrincipal:
         assert result is None
 
     async def test_client_with_no_agent_or_external_user_is_none(self) -> None:
-        # A Client that is neither an agent nor a bridged human (e.g. a system
-        # client) does not resolve to an addressing principal.
+        # A Client that is neither an agent nor a bridged human and is not the
+        # admin (e.g. a bridge client) does not resolve to an addressing principal.
         client = self._client(
-            client=SimpleNamespace(id="c1"), agent=None, external_user=None
+            client=SimpleNamespace(id="c1", type="bridge"),
+            agent=None,
+            external_user=None,
         )
         result = await AddressingResolver.resolve_sender(
             client, object(), "@system:switch.local"
         )
         assert result is None
+
+    async def test_admin_client_resolves_to_platform(self) -> None:
+        # The admin client resolves to sender_kind="platform" (CHOO-2719).
+        client = self._client(
+            client=SimpleNamespace(id="c1", type="admin"),
+            agent=None,
+            external_user=None,
+        )
+        result = await AddressingResolver.resolve_sender(
+            client, object(), "@switch-admin:switch.local"
+        )
+        assert result == ("platform", "c1", [], None)
 
 
 def _allowed_client(

--- a/core/tests/switch_core/test_addressing.py
+++ b/core/tests/switch_core/test_addressing.py
@@ -10,6 +10,7 @@ from switch_core.addressing import (
     owner_and_owner_agents_policy,
     owner_only_policy,
     parse_policy,
+    platform_allowed_policy,
 )
 
 
@@ -458,6 +459,7 @@ class TestOwnerAndOwnerAgentsPolicy:
                     "agents": [],
                     "owner": True,
                     "owner_agents": True,
+                    "platform": False,
                 }
             ]
         }
@@ -578,6 +580,7 @@ class TestOwnerOnlyPolicy:
                     "agents": ["a1"],
                     "owner": True,
                     "owner_agents": False,
+                    "platform": False,
                 }
             ]
         }
@@ -629,3 +632,144 @@ class TestValidation:
         # A pre-CHOO-2137 blob has no `owner` key; it must not become truthy.
         policy = parse_policy({"rules": [{"users": ["u1"], "agents": []}]})
         assert policy.requires_owner_identity() is False
+
+    def test_stored_policy_without_platform_key_defaults_to_false(self) -> None:
+        # A pre-CHOO-2719 blob has no `platform` key; must deny platform.
+        policy = parse_policy({"rules": [{"users": ["u1"], "agents": []}]})
+        assert policy.rules[0].platform is False
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is False
+
+    def test_platform_flag_roundtrips(self) -> None:
+        policy = platform_allowed_policy()
+        assert parse_policy(policy.model_dump()) == policy
+
+
+class TestPlatformSenderKind:
+    """Platform senders are always denied unless explicitly allowed (CHOO-2719).
+
+    Unlike user/agent, an open policy (no rules) also refuses the platform.
+    This is "deny by default with no configuration needed."
+    """
+
+    def test_open_policy_denies_platform(self) -> None:
+        policy = AddressingPolicy()
+        assert policy.is_open() is True
+        # Users and agents still allowed — only platform is refused.
+        assert _allows(policy, sender_kind="user", sender_id="u1") is True
+        assert _allows(policy, sender_kind="agent", sender_id="a1") is True
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is False
+
+    def test_rules_without_platform_deny_it(self) -> None:
+        # A rule admitting everyone (wildcard users + agents) still denies platform.
+        policy = AddressingPolicy(rules=[AddressingRule()])
+        assert _allows(policy, sender_kind="user", sender_id="u1") is True
+        assert _allows(policy, sender_kind="agent", sender_id="a1") is True
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is False
+
+    def test_platform_rule_allows_it(self) -> None:
+        policy = AddressingPolicy(
+            rules=[AddressingRule(users=[], agents=[], platform=True)]
+        )
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is True
+
+    def test_platform_rule_respects_room_scoping(self) -> None:
+        policy = AddressingPolicy(
+            rules=[AddressingRule(rooms=["r1"], users=[], agents=[], platform=True)]
+        )
+        assert (
+            _allows(policy, room_id="r1", sender_kind="platform", sender_id="switch")
+            is True
+        )
+        assert (
+            _allows(policy, room_id="r2", sender_kind="platform", sender_id="switch")
+            is False
+        )
+
+    def test_platform_rule_respects_group_scoping(self) -> None:
+        policy = AddressingPolicy(
+            rules=[
+                AddressingRule(room_groups=["g1"], users=[], agents=[], platform=True)
+            ]
+        )
+        assert (
+            _allows(policy, group_id="g1", sender_kind="platform", sender_id="switch")
+            is True
+        )
+        assert (
+            _allows(policy, group_id="g2", sender_kind="platform", sender_id="switch")
+            is False
+        )
+
+    def test_platform_does_not_fall_through_to_agents_dim(self) -> None:
+        # A wildcard agents dimension must NOT admit platform — the platform
+        # early return in _matches() prevents the fallthrough.
+        policy = AddressingPolicy(rules=[AddressingRule(agents="*")])
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is False
+
+    def test_platform_flag_off_by_default_for_old_policies(self) -> None:
+        # A stored policy written before CHOO-2719 carries no `platform` key;
+        # it must default to False rather than silently admitting the platform.
+        policy = parse_policy({"rules": [{"users": [], "agents": [], "owner": True}]})
+        assert policy.rules[0].platform is False
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is False
+
+    def test_owner_only_policy_denies_platform(self) -> None:
+        policy = owner_only_policy([])
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is False
+
+    def test_owner_and_owner_agents_policy_denies_platform(self) -> None:
+        policy = owner_and_owner_agents_policy()
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is False
+
+    def test_platform_allowed_policy_shape(self) -> None:
+        policy = platform_allowed_policy()
+        assert policy.model_dump() == {
+            "rules": [
+                {
+                    "rooms": "*",
+                    "room_groups": "*",
+                    "users": [],
+                    "agents": [],
+                    "owner": False,
+                    "owner_agents": False,
+                    "platform": True,
+                }
+            ]
+        }
+
+    def test_platform_allowed_policy_admits_platform(self) -> None:
+        policy = platform_allowed_policy()
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is True
+
+    def test_platform_allowed_policy_denies_users_and_agents(self) -> None:
+        # Platform-only: no human, no agent.
+        policy = platform_allowed_policy()
+        assert _allows(policy, sender_kind="user", sender_id="u1") is False
+        assert _allows(policy, sender_kind="agent", sender_id="a1") is False
+
+    def test_mixed_rule_with_platform_and_owner(self) -> None:
+        # A single rule that admits the owner AND the platform.
+        policy = AddressingPolicy(
+            rules=[AddressingRule(users=[], agents=[], owner=True, platform=True)]
+        )
+        assert (
+            _allows(
+                policy,
+                sender_kind="user",
+                sender_id="ext-3",
+                sender_user_ids=["user-1"],
+                owner_user_id="user-1",
+            )
+            is True
+        )
+        assert _allows(policy, sender_kind="platform", sender_id="switch") is True
+        assert (
+            _allows(
+                policy,
+                sender_kind="user",
+                sender_id="ext-9",
+                sender_user_ids=["user-2"],
+                owner_user_id="user-1",
+            )
+            is False
+        )

--- a/core/tests/switch_core/test_rooms_yaml.py
+++ b/core/tests/switch_core/test_rooms_yaml.py
@@ -963,6 +963,53 @@ def test_parse_unknown_top_level_key_rejected(env):
         )
 
 
+# ── kickoff spec (CHOO-2719) ─────────────────────────────────────────────
+
+
+def test_parse_kickoff_defaults(env):
+    spec = _svc(env).parse(
+        """
+        room:
+          name: "R"
+          description: "d"
+          kickoff:
+            message: "Hello agents!"
+        """
+    )
+    assert spec.kickoff is not None
+    assert spec.kickoff.message == "Hello agents!"
+    assert spec.kickoff.sender == "platform"
+    assert spec.kickoff.targets == []
+
+
+def test_parse_kickoff_with_targets_and_creator(env):
+    spec = _svc(env).parse(
+        """
+        room:
+          name: "R"
+          description: "d"
+          kickoff:
+            message: "Get to work"
+            targets: ["agent-a", "agent-b"]
+            sender: "creator"
+        """
+    )
+    assert spec.kickoff is not None
+    assert spec.kickoff.targets == ["agent-a", "agent-b"]
+    assert spec.kickoff.sender == "creator"
+
+
+def test_parse_no_kickoff(env):
+    spec = _svc(env).parse(
+        """
+        room:
+          name: "R"
+          description: "d"
+        """
+    )
+    assert spec.kickoff is None
+
+
 # ── provision with params (integration) ────────────────────────────────────
 
 


### PR DESCRIPTION
## Brief

Adds "platform" as a third sender kind so Switch can address agents as itself — not impersonating a user, not pretending to be an agent. An agent must explicitly opt in to receive platform messages; the default is deny, with no configuration needed. Room templates can now send a kickoff message after provisioning, posted as the Switch app through normal permission checks. Creator impersonation is still available but only when explicitly chosen, and it's visible (the marker carries the creator's name, not silent).

CHOO-2719: https://sandboxquantum.atlassian.net/browse/CHOO-2719

## Summary

- `SenderKind` extended to `"user" | "agent" | "platform"` in `addressing.py`
- New `platform: bool` field on `AddressingRule` — denied even by open policies (no rules), opt-in via `platform=True`
- `resolve_sender` recognises the admin client (`type="admin"`) as `SenderPrincipal("platform", ...)`
- `PLATFORM_MARKER` (`com.switch.platform`) content marker with optional `on_behalf_of` for visible creator impersonation
- `AdminClient.send_platform_message()` sends addressed messages as the Switch app
- `sender_kind` field on `MessagePayload` and `read_context` timeline entries
- Bridge routes platform-marked messages through the admin/app rendering path
- `RoomSpec.kickoff` — post-provision message, default `sender: "platform"`, opt-in `sender: "creator"`
- No DB migration — existing JSONB policies default `platform: false` via Pydantic

## Test plan

18 new unit tests covering the platform addressing model (deny-by-default for open and closed policies, room/group scoping, no fallthrough to agents dimension, backward compat for stored policies without the key, policy factories), plus resolve_sender admin-client detection, and kickoff spec parsing. Full suite green at 435 relevant tests, lint and typecheck clean.