### PR TITLE
docs(gateway): correct what OIDC does with an existing account (CHOO-2726)

### DIFF
--- a/docs/old/GATEWAY_OIDC_SETUP.md
+++ b/docs/old/GATEWAY_OIDC_SETUP.md
@@ -117,18 +117,26 @@ to the mutable email address. This is the behavior on `main` today
 (`core/switch_core/db/stores/user_store.py`); it may change as the identity
 model evolves, so check that file if this page has drifted.
 
-Two things worth knowing before your first login:
+Three things worth knowing before your first login:
 
-- **It is deliberately not linked to an existing local account with the same
-  email.** If a password-authenticated account already owns that email
-  address, the OIDC login is refused with a conflict rather than silently
-  taking over the account — auto-linking by email is an account-takeover
-  vector (a token asserting someone else's email would otherwise inherit
-  their account, including a seeded admin's). There is currently no
-  self-service linking flow; a conflicting account has to be resolved by an
-  admin.
-- **Every OIDC-provisioned user gets the `user` role**, never `admin`.
-  Promote it by hand afterwards if it needs elevated access.
+- **An existing local account with the same email is linked, not refused —
+  provided the IdP says the address is verified.** The identity is attached to
+  that account and the person signs in as it, keeping its role, its rooms and
+  its password. An *unverified* address is refused with a conflict instead,
+  because auto-linking on an unverified claim is an account-takeover vector: a
+  token asserting someone else's address would otherwise inherit their
+  account. The whole guard is therefore the `email_verified` claim, which is
+  why the setting above is not cosmetic — turning it off removes the only
+  thing standing between a claimed address and the account that owns it.
+- **That is also the supported way to have an administrator who signs in
+  through the IdP.** The seeded administrator is an ordinary account on
+  `GATEWAY_ADMIN_EMAIL`; set that to an address you control at the identity
+  provider before first boot, and signing in through the IdP lands you in it
+  with its `admin` role. Point it at an address nobody can claim and there is
+  no such route.
+- **Anyone provisioned fresh gets the `user` role**, never `admin` — that
+  applies to a new account, not to one linked as above. Promote it by hand
+  afterwards if it needs elevated access.
 
 ## Setting up WorkOS as the provider
 


### PR DESCRIPTION
## Summary

`docs/old/GATEWAY_OIDC_SETUP.md` states that an OIDC login is **refused** when a local account already owns the same email, and that auto-linking by email does not happen. That was true when the page was written. It is not true on `main`:

- `UserStore.get_or_create_oidc_user` refuses only when the token's email is **unverified**. A **verified** address is linked to the existing account, and the person signs in as that account — keeping its role, its rooms and its password login.

Two reasons this is worth correcting rather than leaving to drift:

- **It is the account-takeover guard.** The page presents the refusal as the protection. The actual protection is the `email_verified` claim, which means `GATEWAY_OIDC_REQUIRE_EMAIL_VERIFIED=false` removes the only thing between a claimed address and the account that owns it. A reader working from the old text will misprice that setting.
- **It denies something the product supports.** "How does an administrator sign in through the identity provider?" currently has no answer on this page, because the page says linking cannot happen. It can: the seeded administrator is an ordinary account on `GATEWAY_ADMIN_EMAIL`, so pointing that at an address the operator controls at the IdP makes SSO sign-in land in the admin account. Relevant to CHOO-2726.

The page already warns the reader to check the code if it has drifted. It had.

## Test plan

- [x] Documentation only; no code touched.
- [x] Verified against `main` at 362bd6a7: the unverified-only refusal and the linking branch in `core/switch_core/db/stores/user_store.py`, the seeded administrator's email and role in `core/switch_core/main.py`, and the `email_verified` gate in `core/switch_core/gateway/oidc_routes.py`.
- [x] No credentials, internal hostnames or personal data.